### PR TITLE
build(ts): add vite-env.d.ts for TS 6.0 side-effect-import strictness

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

- TypeScript 6.0 tightened the rules around side-effect imports — `import "./styles.css"` now errors with `TS2882: Cannot find module or type declarations for side-effect import` unless a matching module declaration exists.
- Adds a one-line `src/vite-env.d.ts` that pulls in `vite/client` types, which ship `declare module '*.css' {}` (and friends for scss/less/etc.). Standard Vite template pattern.
- Unblocks the `typescript@6` Dependabot bump in #4 — once this lands, dependabot will rebase #4 onto `dev` and its build matrix should go green.

## Why a separate PR?

`.github/dependabot.yml` says majors land separately so they "get real review." This shim is the forward-compat work that *enables* TS 6 to land cleanly; keeping it distinct from the bump itself makes both diffs reviewable on their own and gives us a clean revert lever if we ever back the TS major out.

## Test plan

- [x] `npx tsc --noEmit` clean on TS 6.0.3 (was failing with TS2882 before)
- [x] `npm run build` succeeds on TS 6.0.3
- [ ] CI build matrix on this PR (no TS bump yet — sanity check that the shim is harmless on TS 5.9 too)
- [ ] After merge, dependabot rebases #4 and that PR's build matrix goes green

https://claude.ai/code/session_016pgZdgEbJbciwr23tqVr2B

---
_Generated by [Claude Code](https://claude.ai/code/session_016pgZdgEbJbciwr23tqVr2B)_