### PR TITLE
feat(ui): default project picker to ~ + clarify lint is heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Claude Code reads settings from JSON files at several scopes. Moving a permissio
 - **Diff preview modal** — shows before/after for both sides of a move with a proper diff, Esc/Enter/Tab-trap keyboard handling, focus restored to the triggering button on close
 - **Rule search / filter** — press `/` anywhere to focus, case-insensitive substring, `m/n` match counts per group
 - **Auto-reload** — `notify`-based file watcher picks up external edits (hand-edited JSON, another editor, etc.) and refreshes the UI without losing state
-- **Shape-level lint** — subtle ⚠ badge on rules that don't match a recognized shape (`Bash(...)`, `WebFetch(domain:...)`, `mcp__server__tool`, etc.), with tooltips explaining why
+- **Heuristic shape lint** — subtle ⚠ badge on rules that don't match the shapes this UI knows (`Bash(...)`, `WebFetch(domain:...)`, `mcp__server__tool`, etc.). Best-effort only: Claude Code's full rule grammar isn't publicly documented, so flagged rules may still work — the popover names the specific heuristic that tripped and disclaims its scope.
 
 ### Safety model
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "default permissions",
   "windows": ["main"],
-  "permissions": ["core:default", "dialog:default"]
+  "permissions": ["core:default", "core:path:default", "dialog:default"]
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { homeDir } from "@tauri-apps/api/path";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import "./styles.css";
 import type {
@@ -72,7 +73,14 @@ let moveInFlight = false;
 
 async function pickProject(): Promise<void> {
   if (moveInFlight) return;
-  const picked = await openDialog({ directory: true, multiple: false });
+  // Default to ~ so the picker doesn't open in whatever deep subdir the OS
+  // last remembered (often Documents/ on Windows). homeDir() is a Tauri
+  // path API that resolves to the platform-correct home dir.
+  const picked = await openDialog({
+    directory: true,
+    multiple: false,
+    defaultPath: await homeDir(),
+  });
   if (typeof picked === "string") {
     // Reset the filter when the user explicitly picks a different project —
     // a query that matched rules in the old project would silently hide the

--- a/src/styles.css
+++ b/src/styles.css
@@ -708,6 +708,23 @@ button:disabled {
     visibility 120ms ease;
 }
 
+/* Reason on top, then a muted heuristic disclaimer separated by a hairline.
+   The yellow ⚠ reads as authoritative on its own, so the popover spells out
+   that it's a best-effort shape check rather than a verdict from Claude
+   Code itself. */
+.lint-warn-popover-reason {
+  display: block;
+}
+.lint-warn-popover-note {
+  display: block;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
+  font-style: italic;
+}
+
 /* Small caret pointing at the badge so the popover's anchor is obvious. */
 .lint-warn-popover::before {
   content: "";

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -278,7 +278,7 @@ function lintBadge(rule: string): HTMLElement | null {
   btn.type = "button";
   btn.className = "lint-warn";
   btn.textContent = "⚠";
-  btn.setAttribute("aria-label", "Rule warning");
+  btn.setAttribute("aria-label", "Rule shape check");
   // `aria-describedby` is the canonical tooltip relationship. Keep the
   // detailed reason here only — `aria-label` is intentionally short so
   // screen readers don't announce the full message twice (once as the
@@ -292,7 +292,18 @@ function lintBadge(rule: string): HTMLElement | null {
   pop.id = popoverId;
   pop.className = "lint-warn-popover";
   pop.setAttribute("role", "tooltip");
-  pop.textContent = reason;
+  // Two-part body: reason on top, then a muted disclaimer that this is a
+  // best-effort shape check rather than a verdict from Claude Code itself.
+  // The popover is a known authority cue (yellow ⚠), so without the
+  // disclaimer users can read it as canonical validation.
+  const reasonLine = document.createElement("span");
+  reasonLine.className = "lint-warn-popover-reason";
+  reasonLine.textContent = reason;
+  const note = document.createElement("span");
+  note.className = "lint-warn-popover-note";
+  note.textContent = "Best-effort shape check — Claude Code may still accept this rule.";
+  pop.appendChild(reasonLine);
+  pop.appendChild(note);
 
   btn.addEventListener("click", (e) => {
     e.stopPropagation();


### PR DESCRIPTION
Closes #48. Closes #36.

## Summary

Two small UX nits, naturally grouped — both touch the front end, plus one capability-config follow-on for the new Tauri API call.

### #48 — Project picker defaults to `~`

`pickProject()` in `src/main.ts:73-84` was calling `openDialog({ directory: true, multiple: false })` with no `defaultPath`. The OS decides where to start, which on Windows often lands deep in `Documents\` and on macOS varies by build. Now passes `defaultPath: await homeDir()` (from `@tauri-apps/api/path`) so the picker consistently opens at the user's home dir on all three platforms.

> **Capability change:** in Tauri v2 the path API is gated by capabilities. `homeDir()` calls `plugin:path|resolve_directory`, which the previous capability set (`core:default`, `dialog:default`) doesn't permit — the runtime would deny it and the picker would fail to open. `src-tauri/capabilities/default.json` now also grants **`core:path:default`**, the curated bundle of safe path operations (`homeDir`, `join`, `dirname`, `normalize`, etc.). No filesystem access is granted.

### #36 — Lint reads as heuristic, not authoritative

The yellow ⚠ chip was reading as canonical validation even though `lintRule()` is explicitly best-effort (Claude Code's full rule grammar isn't publicly documented).

- **Popover** is now two-part: reason on top, then a muted italic hairline-separated note saying *"Best-effort shape check — Claude Code may still accept this rule."* No change to `lintRule()` logic; the reason is the existing string.
- **Aria-label** `Rule warning` → `Rule shape check`, so screen-reader users hear the same scope-limited framing.
- **README Features bullet** retitled *Heuristic shape lint* with a sentence explaining flagged rules may still work.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `pre-commit run --files …` clean (incl. `check json` on the capability file)
- [ ] CI build matrix
- [ ] Manual smoke (per `docs/SMOKE_TEST.md`):
  - Click **Open project…** → picker opens at `~` (was: wherever the OS last remembered).
  - Trigger a lint chip (e.g. `Bash()`) → popover shows the reason on top, hairline, then italic disclaimer below.
  - Existing chips still appear with the same `aria-describedby` wiring.

https://claude.ai/code/session_016pgZdgEbJbciwr23tqVr2B