### PR TITLE
ci: weekly stale-link detection via lychee

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -48,6 +48,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # Persist `.lycheecache` across runs so the weekly schedule doesn't
+      # rehit every endpoint each Monday. Cache key is unique per run
+      # (always saves), restore-keys does prefix-match against the most
+      # recent prior cache. Combined with `max_cache_age = "7d"` in
+      # .lycheerc, that's roughly: known-good URLs from the last week
+      # don't get re-fetched; everything older or unseen does.
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .lycheecache
+          key: lychee-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            lychee-${{ runner.os }}-
+
       # `fail: false` keeps lychee non-fatal — we surface broken links via
       # comments / issues instead of failing the run. The action exposes
       # the underlying lychee exit code as `outputs.exit_code`, which the

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -8,7 +8,11 @@
 #   - On PRs that touch any markdown / link-check config — gives authors
 #     same-PR feedback without spamming check runs on unrelated PRs.
 #
-# Never fails the workflow. External link rot is reported via:
+# Doesn't fail on broken links — those get reported, not enforced. (An
+# action-level failure like the lychee binary failing to download or a
+# `.lycheerc` parse error WILL still fail the job, which is the right
+# signal: the link check stopped working.) External link rot is
+# surfaced via:
 #   - PRs: a comment on the PR (non-blocking; broken third-party links
 #     should not block a refactor PR).
 #   - Scheduled / manual: a single deduped tracking issue tagged with

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,131 @@
+# Catches external link rot across the markdown surface (README, CLAUDE.md,
+# SECURITY.md, eventually docs/). Runs:
+#
+#   - Weekly on Monday 14:00 UTC (09:00 EDT / 06:00 PDT — automated, so
+#     the early-Pacific hour is fine; the issue gets read whenever).
+#   - On manual workflow_dispatch — for re-running after a fix lands or
+#     to verify a one-off concern.
+#   - On PRs that touch any markdown / link-check config — gives authors
+#     same-PR feedback without spamming check runs on unrelated PRs.
+#
+# Never fails the workflow. External link rot is reported via:
+#   - PRs: a comment on the PR (non-blocking; broken third-party links
+#     should not block a refactor PR).
+#   - Scheduled / manual: a single deduped tracking issue tagged with
+#     `link-rot`. When a subsequent run is clean, the open tracking
+#     issue auto-closes.
+
+name: Link check
+
+on:
+  schedule:
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".lycheerc"
+      - ".lycheeignore"
+      - ".github/workflows/link-check.yml"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: link-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  link-check:
+    name: link check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # `fail: false` keeps lychee non-fatal — we surface broken links via
+      # comments / issues instead of failing the run. The action exposes
+      # the underlying lychee exit code as `outputs.exit_code`, which the
+      # branching steps below key off.
+      - name: Run lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: >-
+            --config .lycheerc
+            --no-progress
+            --format markdown
+            --output lychee-report.md
+            .
+          fail: false
+
+      # PR branch: post a single comment with the broken-link summary.
+      # No dedupe yet — repeated pushes will leave a trail of comments.
+      # If that gets noisy, swap to a sticky-comment helper or update via
+      # the issues-comments API.
+      - name: Comment on PR
+        if: github.event_name == 'pull_request' && steps.lychee.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo '<!-- link-check-bot -->'
+            echo '### Link check'
+            echo
+            echo "Lychee found broken links in the markdown this PR touches. Reported here for visibility — **does not block merge**."
+            echo
+            cat lychee-report.md
+            echo
+            echo "_Run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on \`${{ github.sha }}\`._"
+          } | gh pr comment "${{ github.event.pull_request.number }}" --body-file -
+
+      # Scheduled / manual runs with broken links: open or update a single
+      # tracking issue. Dedupe on the `link-rot` label so weekly runs don't
+      # pile up duplicates.
+      - name: Open or update link-rot tracking issue
+        if: github.event_name != 'pull_request' && steps.lychee.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Self-bootstrap the labels so a fresh fork or a label that was
+          # manually deleted doesn't break the run. `--force` is idempotent
+          # (creates if missing, updates colour/description if present).
+          gh label create link-rot --force \
+            --color "fbca04" \
+            --description "External link rot detected by the weekly link-check workflow"
+          gh label create "area:docs" --force \
+            --color "0075ca" \
+            --description "Documentation"
+          existing=$(gh issue list --label link-rot --state open --json number --jq '.[0].number // empty')
+          {
+            cat lychee-report.md
+            echo
+            echo "_Run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on \`${{ github.sha }}\`._"
+          } > issue-body.md
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file issue-body.md
+            gh issue comment "$existing" \
+              --body "Refreshed by run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on \`${{ github.sha }}\`."
+          else
+            gh issue create \
+              --title "Weekly link check: broken links detected" \
+              --body-file issue-body.md \
+              --label "bug,area:docs,link-rot"
+          fi
+
+      # Scheduled / manual runs that come back clean: close any open
+      # link-rot tracking issue with a comment that points back to the
+      # run that proved it clean.
+      - name: Close link-rot tracking issue when clean
+        if: github.event_name != 'pull_request' && steps.lychee.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label link-rot --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" \
+              --comment "Auto-closed: lychee found no broken links in run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on \`${{ github.sha }}\`."
+          fi

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -66,8 +66,22 @@ jobs:
       # No dedupe yet — repeated pushes will leave a trail of comments.
       # If that gets noisy, swap to a sticky-comment helper or update via
       # the issues-comments API.
+      #
+      # Skipped on forked-PR events: `GITHUB_TOKEN` is read-only on those
+      # by GitHub design, and `gh pr comment` would 403 ("Resource not
+      # accessible by integration") which would mark this step (and the
+      # job) failed — defeating the "never fails" guarantee. The
+      # scheduled / manual job still surfaces fork-introduced rot via
+      # the tracking issue once the PR merges.
+      #
+      # `continue-on-error: true` is a belt-and-suspenders: even if some
+      # unrelated gh-cli failure slips through, the job stays green.
       - name: Comment on PR
-        if: github.event_name == 'pull_request' && steps.lychee.outputs.exit_code != '0'
+        if: >-
+          github.event_name == 'pull_request'
+          && steps.lychee.outputs.exit_code != '0'
+          && github.event.pull_request.head.repo.fork == false
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -75,7 +89,7 @@ jobs:
             echo '<!-- link-check-bot -->'
             echo '### Link check'
             echo
-            echo "Lychee found broken links in the markdown this PR touches. Reported here for visibility — **does not block merge**."
+            echo "Lychee scanned the whole repo's markdown surface and found broken links. Reported here for visibility — **does not block merge**."
             echo
             cat lychee-report.md
             echo

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -128,7 +128,14 @@ jobs:
           gh label create "area:docs" --force \
             --color "0075ca" \
             --description "Documentation"
-          existing=$(gh issue list --label link-rot --state open --json number --jq '.[0].number // empty')
+          # Pick the oldest open `link-rot` issue as canonical (lowest
+          # number = longest history). If the dedupe contract was ever
+          # broken — manual creation, a previous bug — close the extras
+          # as duplicates pointing at the canonical so we converge back
+          # to a single open issue rather than silently leaving stragglers.
+          mapfile -t open_issues < <(gh issue list --label link-rot --state open --json number --jq '.[].number' | sort -n)
+          existing="${open_issues[0]:-}"
+          extras=("${open_issues[@]:1}")
           {
             cat lychee-report.md
             echo
@@ -138,6 +145,10 @@ jobs:
             gh issue edit "$existing" --body-file issue-body.md
             gh issue comment "$existing" \
               --body "Refreshed by run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on \`${{ github.sha }}\`."
+            for extra in "${extras[@]}"; do
+              gh issue close "$extra" \
+                --comment "Closed as duplicate of #${existing} — consolidating \`link-rot\` tracking into a single open issue per the workflow contract."
+            done
           else
             gh issue create \
               --title "Weekly link check: broken links detected" \
@@ -159,8 +170,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          existing=$(gh issue list --label link-rot --state open --json number --jq '.[0].number // empty')
-          if [ -n "$existing" ]; then
-            gh issue close "$existing" \
+          # Close every open `link-rot` issue, not just one — see the
+          # consolidation logic in the open/update step. A clean run is
+          # also our chance to mop up any duplicates.
+          mapfile -t open_issues < <(gh issue list --label link-rot --state open --json number --jq '.[].number' | sort -n)
+          for n in "${open_issues[@]}"; do
+            gh issue close "$n" \
               --comment "Auto-closed: lychee found no broken links in run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on \`${{ github.sha }}\`."
-          fi
+          done

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -126,6 +126,14 @@ jobs:
           # Self-bootstrap the labels so a fresh fork or a label that was
           # manually deleted doesn't break the run. `--force` is idempotent
           # (creates if missing, updates colour/description if present).
+          # `bug` is bootstrapped too even though the upstream repo defines
+          # it — without this, a fork or a manual cleanup could fail issue
+          # creation silently under `continue-on-error: true`. The colour
+          # and description match GitHub's defaults so existing issues
+          # don't visibly change.
+          gh label create bug --force \
+            --color "d73a4a" \
+            --description "Something isn't working"
           gh label create link-rot --force \
             --color "fbca04" \
             --description "External link rot detected by the weekly link-check workflow"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -48,16 +48,18 @@ jobs:
       # comments / issues instead of failing the run. The action exposes
       # the underlying lychee exit code as `outputs.exit_code`, which the
       # branching steps below key off.
+      #
+      # `args` deliberately omits `--output` and `--format`: lychee-action's
+      # entrypoint adds `--output <tempfile>` itself (then `cat`s the temp
+      # to whatever path the `output:` input names) and `--format markdown`
+      # is its default. Passing either inside `args` produces a duplicate
+      # flag that lychee errors on.
       - name: Run lychee
         id: lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
-          args: >-
-            --config .lycheerc
-            --no-progress
-            --format markdown
-            --output lychee-report.md
-            .
+          args: --config .lycheerc --no-progress .
+          output: lychee-report.md
           fail: false
 
       # PR branch: post a single comment with the broken-link summary.

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -49,15 +49,23 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Persist `.lycheecache` across runs so the weekly schedule doesn't
-      # rehit every endpoint each Monday. Cache key is unique per run
-      # (always saves), restore-keys does prefix-match against the most
-      # recent prior cache. Combined with `max_cache_age = "7d"` in
+      # rehit every endpoint each Monday. The cache key is bucketed by
+      # UTC year-week so all runs within the same week (including PR
+      # pushes) reuse one cache entry — without bucketing, a per-run key
+      # would create a fresh cache on every push and burn through the
+      # repo's 10GB cache quota fast. `restore-keys` falls back to the
+      # most recent prior week so the first run of a new week starts
+      # from last week's state. Combined with `max_cache_age = "7d"` in
       # .lycheerc, that's roughly: known-good URLs from the last week
       # don't get re-fetched; everything older or unseen does.
+      - name: Compute lychee cache bucket
+        id: lychee-cache-bucket
+        run: echo "year_week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .lycheecache
-          key: lychee-${{ runner.os }}-${{ github.run_id }}
+          key: lychee-${{ runner.os }}-${{ steps.lychee-cache-bucket.outputs.year_week }}
           restore-keys: |
             lychee-${{ runner.os }}-
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -99,8 +99,22 @@ jobs:
       # Scheduled / manual runs with broken links: open or update a single
       # tracking issue. Dedupe on the `link-rot` label so weekly runs don't
       # pile up duplicates.
+      #
+      # Gated to the repository default branch: `workflow_dispatch` can be
+      # triggered from any branch, and we don't want a feature-branch
+      # manual run to overwrite the shared default-branch signal with
+      # findings from a half-baked branch. `schedule` always runs from the
+      # default branch already.
+      #
+      # `continue-on-error: true` keeps the "never fails" guarantee intact
+      # against transient `gh` failures (rate limits, API blips, label
+      # creation racing another run).
       - name: Open or update link-rot tracking issue
-        if: github.event_name != 'pull_request' && steps.lychee.outputs.exit_code != '0'
+        if: >-
+          github.event_name != 'pull_request'
+          && github.ref_name == github.event.repository.default_branch
+          && steps.lychee.outputs.exit_code != '0'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -133,9 +147,14 @@ jobs:
 
       # Scheduled / manual runs that come back clean: close any open
       # link-rot tracking issue with a comment that points back to the
-      # run that proved it clean.
+      # run that proved it clean. Same default-branch gate and
+      # `continue-on-error` rationale as the open/update step.
       - name: Close link-rot tracking issue when clean
-        if: github.event_name != 'pull_request' && steps.lychee.outputs.exit_code == '0'
+        if: >-
+          github.event_name != 'pull_request'
+          && github.ref_name == github.event.repository.default_branch
+          && steps.lychee.outputs.exit_code == '0'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ src-tauri/WixTools/
 
 # TypeScript
 *.tsbuildinfo
+
+# Lychee link checker — per-runner HTTP cache populated when contributors
+# run lychee locally (e.g. for the smoke test or to reproduce a CI run).
+# Never commit; CI runs use a fresh cache each invocation.
+.lycheecache

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,6 @@
+# Per-URL ignore list for lychee (one regex per line; `#` starts a comment).
+#
+# Use this for URLs that don't fit the broader categories handled in
+# `.lycheerc`'s `exclude = [...]` — typically a single known-flaky
+# endpoint or a known-private resource that the wider patterns shouldn't
+# need to know about. Empty for now; add patterns as we discover them.

--- a/.lycheerc
+++ b/.lycheerc
@@ -1,0 +1,49 @@
+# Lychee configuration for the weekly link-check workflow
+# (.github/workflows/link-check.yml). Tuned to scan the markdown surface
+# of this repo without crying wolf about intentional or transient cases.
+
+# Skip URLs that lychee would fail to resolve through no fault of the
+# documentation. Keep this list short — broad excludes hide real rot.
+exclude = [
+  # Local-dev URLs referenced in setup docs.
+  "^http://localhost",
+  "^http://127\\.0\\.0\\.1",
+  # Anthropic session URLs from git-generated commit trailers — they are
+  # session-scoped by design and 404 from any other session.
+  "^https://claude\\.ai/code/session_",
+  # Pure anchor fragments (#section); lychee resolves these flakily and
+  # they're already validated by the markdown renderer at view time.
+  "^#",
+]
+
+# File-system paths to skip entirely. node_modules ships markdown READMEs
+# for every transitive dependency — scanning those would dwarf the run
+# and hammer third-party sites with traffic about links we don't own.
+exclude_path = [
+  "node_modules",
+  "target",
+  "dist",
+]
+
+# Retry transient failures before declaring a link broken. The defaults
+# err on the side of fast-failing; widening here is the difference
+# between "real rot" and "GitHub had a bad afternoon."
+max_retries = 3
+retry_wait_time = 10
+timeout = 20
+
+# Status codes that count as "working enough." Some sites legitimately
+# 403 bots (Cloudflare, GH abuse heuristics) or 429 under load while
+# the URL is fine for a human reader; 999 is LinkedIn's "we don't talk
+# to bots" signal.
+accept = [200, 204, 206, 403, 429, 999]
+
+# Identifiable but not browser-spoofing — server admins seeing rate
+# limits should be able to tell who's hitting them.
+user_agent = "claude-scope-linkcheck/1.0 (+https://github.com/bminier/claude-scope)"
+
+# Persist an HTTP cache between runs. Weekly runs shouldn't rehit every
+# endpoint when the markdown hasn't changed; 2d is short enough that
+# a real outage stops being silently hidden.
+cache = true
+max_cache_age = "2d"

--- a/.lycheerc
+++ b/.lycheerc
@@ -42,12 +42,11 @@ accept = [200, 204, 206, 403, 429, 999]
 # limits should be able to tell who's hitting them.
 user_agent = "claude-scope-linkcheck/1.0 (+https://github.com/bminier/claude-scope)"
 
-# Enable lychee's HTTP cache. The benefit here is purely *within* a
-# single run — the same URL appearing in multiple markdown files (e.g.
-# the project's GitHub URL in README, SECURITY, CONTRIBUTING) only gets
-# fetched once. There is no cross-run persistence today: CI doesn't
-# restore/save `.lycheecache` between runs, and `.lycheecache` is
-# .gitignored. If we want week-over-week reuse later, add an
-# `actions/cache` step to the workflow and set `max_cache_age` to
-# something >= the schedule cadence.
+# Enable lychee's HTTP cache. The workflow restores/saves `.lycheecache`
+# across runs via `actions/cache`, so a known-good URL from a previous
+# weekly run gets reused (within `max_cache_age`) instead of re-fetched.
+# 7d matches the schedule cadence — long enough that Mondays-to-Mondays
+# benefit, short enough that an outage during the gap surfaces on the
+# next run rather than being masked indefinitely.
 cache = true
+max_cache_age = "7d"

--- a/.lycheerc
+++ b/.lycheerc
@@ -42,8 +42,12 @@ accept = [200, 204, 206, 403, 429, 999]
 # limits should be able to tell who's hitting them.
 user_agent = "claude-scope-linkcheck/1.0 (+https://github.com/bminier/claude-scope)"
 
-# Persist an HTTP cache between runs. Weekly runs shouldn't rehit every
-# endpoint when the markdown hasn't changed; 2d is short enough that
-# a real outage stops being silently hidden.
+# Enable lychee's HTTP cache. The benefit here is purely *within* a
+# single run — the same URL appearing in multiple markdown files (e.g.
+# the project's GitHub URL in README, SECURITY, CONTRIBUTING) only gets
+# fetched once. There is no cross-run persistence today: CI doesn't
+# restore/save `.lycheecache` between runs, and `.lycheecache` is
+# .gitignored. If we want week-over-week reuse later, add an
+# `actions/cache` step to the workflow and set `max_cache_age` to
+# something >= the schedule cadence.
 cache = true
-max_cache_age = "2d"


### PR DESCRIPTION
Closes #28.

## Summary

Adds the weekly stale-link detection workflow proposed in #28. Three new files, all CI / config — no application code changes.

- **`.github/workflows/link-check.yml`** — runs lychee on `schedule` (Mondays 14:00 UTC), `workflow_dispatch`, and `pull_request` (only when the PR touches `**/*.md` or the link-check config). Never fails the workflow.
- **`.lycheerc`** — TOML config: excludes `localhost`, `claude.ai/code/session_*` URLs (intentionally session-scoped — Claude Code adds them to commit trailers and they 404 from any other session), bare anchor fragments. Excludes paths `node_modules` / `target` / `dist`. Accepts `403/429/999` because some sites block bots while the URL works for humans. 2-day cache so weekly runs don't hammer the same endpoints.
- **`.lycheeignore`** — empty placeholder for per-URL ignores discovered empirically.

### How findings surface

| Trigger | What happens on broken links | What happens on clean run |
| --- | --- | --- |
| `pull_request` | Posts a comment on the PR with the lychee report. **Non-blocking.** | No-op. |
| `schedule` / `workflow_dispatch` | Opens or updates a single tracking issue tagged `link-rot`. Dedupe on the label so weekly runs don't pile up. | If a `link-rot` issue is open, auto-closes it with a comment pointing back to the run that proved it clean. |

### Notes for the reviewer

- **Label bootstrap.** `link-rot` and `area:docs` don't exist in the repo yet. The workflow self-bootstraps them via `gh label create --force` (idempotent — creates if missing, updates colour/description if present). This way a fresh fork or an accidental delete doesn't break the run.
- **SHA pinning.** `actions/checkout@de0fac…` (v6) and `lycheeverse/lychee-action@8646ba…` (v2.8.0) per the convention #5 established. The lychee-action SHA was verified against `https://api.github.com/repos/lycheeverse/lychee-action/git/refs/tags/v2.8.0`.
- **Why not `peter-evans/create-issue-from-file`?** It doesn't dedupe; the issue's spec calls for one tracking issue, not one per run. `gh issue list --label link-rot` + `gh issue edit / create` is two lines and avoids a third-party action.

## Test plan

- [x] `pre-commit run --files …` clean (`check yaml` validates the workflow)
- [x] `python3 -m tomllib` parses `.lycheerc` clean
- [ ] CI on this PR runs the workflow itself (PR triggers it via the `paths:` rule on workflow file changes), so this PR exercises both the lychee invocation and the PR-comment branch
- [ ] After merge: a manual `workflow_dispatch` run on `dev` to verify the report doesn't cry-wolf about intentional fragments / session URLs
- [ ] Dedupe behavior: a second `workflow_dispatch` with the same findings should update the existing issue, not create a second one (verify after the workflow first creates one — easiest to confirm by re-running once the first run lands)

## Non-goals (per the issue)

- Replacing `mdbook-linkcheck` from #26 — that's the build-time check; this is the weekly drift detector.
- Auto-fixing broken links.
- Checking code on crates.io / npm.

https://claude.ai/code/session_016pgZdgEbJbciwr23tqVr2B

---
_Generated by [Claude Code](https://claude.ai/code/session_016pgZdgEbJbciwr23tqVr2B)_