### PR TITLE
fix(ci): add explicit permissions to build, msrv, and lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   build:
     name: build (${{ matrix.os }})
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +68,8 @@ jobs:
     # (darling, serde_with, time all require 1.88). If those deps bump again,
     # this job fails loudly rather than letting a stale MSRV ship.
     name: msrv (1.88)
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -107,6 +111,8 @@ jobs:
     # have failed locally. Splitting out as its own job keeps the signal
     # distinct from the matrix build, and runs in parallel so it's cheap.
     name: lint
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

Resolves CodeQL code-scanning alerts **#1, #4, #5** (rule: \ctions/missing-workflow-permissions\).

The \uild\, \msrv\, and \lint\ jobs had no explicit \permissions\ block, leaving them inheriting the repository-level defaults. Added \permissions: contents: read\ to each — the minimum required for a checkout-and-build job.

The \security\ job already had its own \permissions\ block and is unaffected.