### PR TITLE
docs: record version-bump file list and Windows lockfile trap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,18 @@ Desktop GUI for promoting Claude Code settings between scopes
 
 Work on feature branches. Open PRs targeting `dev`. Follow conventional commits.
 
+## Versioning
+
+A version bump must update four files in lockstep: `package.json`,
+`package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`.
+`src-tauri/Cargo.lock` regenerates on the next `cargo` run.
+
+Do **not** regenerate `package-lock.json` with `npm install --package-lock-only`
+on Windows — npm drops Linux-only optional deps (e.g. `@emnapi/*`,
+`@napi-rs/*`) and `npm ci` then fails on the Linux CI runner. For a pure
+version bump, edit only the two top-level `"version"` fields in the lockfile;
+leave the dependency tree alone.
+
 ## Bootstrap
 
 ## Origin


### PR DESCRIPTION
## Summary

Adds a **Versioning** section to `CLAUDE.md` so future agents (and humans) don't repeat the mistakes from #61:

- A version bump touches four files: `package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`. `Cargo.lock` regenerates on the next `cargo` run.
- `npm install --package-lock-only` on Windows drops Linux-only optional deps (`@emnapi/*`, `@napi-rs/*`) from the lockfile, which then breaks `npm ci` on the Linux CI runner. For pure version bumps, patch the two top-level `"version"` fields by hand and leave the dependency tree alone.

## Test plan

- [ ] Markdown renders cleanly on the PR diff.