### PR TITLE
fix(ui): disable Tauri OS drag-drop handler so HTML5 DnD works

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,8 @@
         "minWidth": 800,
         "minHeight": 500,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
## Summary

Tauri 2's `WindowConfig.dragDropEnabled` defaults to `true`, which registers a native OS-level file-drop target on the window. On Windows that handler intercepts drag events before the webview can dispatch HTML5 `dragover` / `drop`, so the browser falls back to the no-drop cursor and the rule never moves between scope columns. Setting it to `false` lets the existing HTML5 DnD wiring in `src/ui.ts` handle the gesture as designed.

One-line config change — no application logic touched.

Closes #64

## Test plan

- [ ] `cargo tauri dev`, drag a permission rule from one scope column to another, confirm the cursor stays in the move/copy state and the drop fires.
- [ ] Confirm source and target `settings.json` files are updated atomically (same path as the keyboard/click promote-demote flow).
- [ ] Sanity-check the keyboard / click promote-demote path is unchanged.