### PR TITLE
refactor(io): centralize pre-write JSON validation

### DIFF
--- a/src-tauri/src/io_atomic.rs
+++ b/src-tauri/src/io_atomic.rs
@@ -1,10 +1,20 @@
 //! Atomic read/write of settings files with per-session backup.
 //!
-//! Write strategy:
-//!   1. Serialize the updated JSON value.
-//!   2. Re-parse it to guarantee the output is valid JSON. Refuse otherwise.
+//! All write paths in the app funnel through [`atomic_write_json`]: the
+//! pre-write JSON revalidation, parent-directory creation, optional `.bak`
+//! handling, tempfile + sync + rename sequence all live there. Higher-level
+//! callers ([`save`] for `SettingsDoc`, `preferences::save` for the user
+//! preferences file) render their own bytes and hand them to the helper.
+//!
+//! Write strategy (enforced inside `atomic_write_json`):
+//!   1. Re-parse the produced bytes as JSON. Refuse before any disk I/O if
+//!      they don't parse — the caller's serializer being safe-by-construction
+//!      is not enough; the invariant lives at the I/O boundary so it can't
+//!      be lost in a future refactor.
+//!   2. Create the parent directory if missing.
 //!   3. On the first write of this process that targets a given path, copy
-//!      the existing file (if any) to `<file>.bak`.
+//!      the existing file (if any) to `<file>.bak` — opt-in per call site
+//!      via the `backups` argument.
 //!   4. Write the new contents to a tempfile in the same directory.
 //!   5. Rename the tempfile over the target (atomic on the same filesystem).
 
@@ -110,10 +120,37 @@ pub fn load(path: &Path) -> Result<Option<SettingsDoc>, IoError> {
 }
 
 /// Atomic write with revalidation and one-time-per-session backup.
+///
+/// Convenience wrapper that renders a [`SettingsDoc`] and routes the bytes
+/// through [`atomic_write_json`] with backups enabled.
 pub fn save(path: &Path, doc: &SettingsDoc, backups: &BackupTracker) -> Result<(), IoError> {
     let rendered = doc.render();
-    // Revalidate before touching disk.
-    serde_json::from_str::<Value>(&rendered).map_err(|e| IoError::Revalidate {
+    atomic_write_json(path, rendered.as_bytes(), Some(backups))
+}
+
+/// The single chokepoint every write path in the app must use.
+///
+/// **Invariant:** `bytes` is re-parsed as JSON before any disk I/O. On parse
+/// failure the function returns [`IoError::Revalidate`] and **no tempfile,
+/// `.bak`, or destination file is created or modified**. Funnelling every
+/// writer through here means a future caller — a manually-rendered config,
+/// a new asset type per #11, a "fast path" that skips serde — has to
+/// deliberately bypass this function to skip validation, not just forget
+/// a line.
+///
+/// `backups` is `Some(_)` for user-data files where a one-shot recovery copy
+/// is worth the surprise of an extra file on disk (e.g. `~/.claude/
+/// settings.json`), and `None` for ClaudeScope-owned files that are cheap to
+/// regenerate and would clutter their directory with `.bak`s (e.g. the
+/// preferences file under the OS config dir).
+pub fn atomic_write_json(
+    path: &Path,
+    bytes: &[u8],
+    backups: Option<&BackupTracker>,
+) -> Result<(), IoError> {
+    // Revalidate before touching disk. This is the load-bearing contract:
+    // bad bytes in => no observable filesystem effect.
+    serde_json::from_slice::<Value>(bytes).map_err(|e| IoError::Revalidate {
         path: path.to_path_buf(),
         reason: e.to_string(),
     })?;
@@ -125,10 +162,12 @@ pub fn save(path: &Path, doc: &SettingsDoc, backups: &BackupTracker) -> Result<(
 
     // Back up the pre-session file on the first save this session. The
     // tracker handles concurrency, missing-file, and existing-.bak cases.
-    backups.ensure_backed_up(path)?;
+    if let Some(backups) = backups {
+        backups.ensure_backed_up(path)?;
+    }
 
     let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(|e| IoError::io(parent, e))?;
-    tmp.write_all(rendered.as_bytes())
+    tmp.write_all(bytes)
         .map_err(|e| IoError::io(tmp.path(), e))?;
     tmp.as_file_mut()
         .sync_all()
@@ -261,5 +300,82 @@ mod tests {
         std::fs::write(&path, "[]").unwrap();
         let err = load(&path).unwrap_err();
         assert!(matches!(err, IoError::NotObject { .. }));
+    }
+
+    /// The load-bearing contract of `atomic_write_json`: invalid bytes in
+    /// must produce zero observable filesystem effect — no tempfile, no
+    /// `.bak`, and the existing destination file is left exactly as it was.
+    #[test]
+    fn atomic_write_json_rejects_invalid_bytes_without_touching_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        let bak = path.with_file_name("settings.json.bak");
+        std::fs::write(&path, r#"{"original":true}"#).unwrap();
+
+        let backups = BackupTracker::new();
+        let err = atomic_write_json(&path, b"{ not json", Some(&backups)).unwrap_err();
+        assert!(
+            matches!(err, IoError::Revalidate { .. }),
+            "expected Revalidate, got {err:?}"
+        );
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            after, r#"{"original":true}"#,
+            "destination file must not be touched on revalidation failure"
+        );
+        assert!(
+            !bak.exists(),
+            ".bak must not be created on revalidation failure"
+        );
+
+        // No stray tempfiles left in the parent directory.
+        let strays: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name() != "settings.json")
+            .map(|e| e.file_name())
+            .collect();
+        assert!(
+            strays.is_empty(),
+            "no extra files should remain in parent, got: {strays:?}"
+        );
+    }
+
+    #[test]
+    fn atomic_write_json_writes_valid_bytes_with_backup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        std::fs::write(&path, r#"{"original":true}"#).unwrap();
+
+        let backups = BackupTracker::new();
+        atomic_write_json(&path, br#"{"updated":true}"#, Some(&backups)).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            r#"{"updated":true}"#
+        );
+        let bak = path.with_file_name("settings.json.bak");
+        assert!(bak.exists(), "backup should be created on first write");
+        assert_eq!(
+            std::fs::read_to_string(&bak).unwrap(),
+            r#"{"original":true}"#
+        );
+    }
+
+    #[test]
+    fn atomic_write_json_skips_backup_when_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(&path, r#"{"original":true}"#).unwrap();
+
+        atomic_write_json(&path, br#"{"updated":true}"#, None).unwrap();
+
+        let bak = path.with_file_name("config.json.bak");
+        assert!(!bak.exists(), ".bak must not be created when backups: None");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            r#"{"updated":true}"#
+        );
     }
 }

--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -60,14 +60,16 @@ pub fn load() -> Preferences {
     serde_json::from_slice(&bytes).unwrap_or_default()
 }
 
-/// Save preferences atomically. Creates the parent directory if needed and
-/// writes via `tempfile::NamedTempFile` + `persist()` — the same pattern
-/// `io_atomic::save` uses — for two reasons:
-///   - `NamedTempFile` gives each in-flight save a unique filename, so a
-///     call that races with another can't scribble over its tempfile.
-///   - `persist()` uses platform-appropriate atomic replace semantics;
-///     `std::fs::rename` alone refuses to overwrite an existing destination
-///     on Windows, which would break every save after the first.
+/// Save preferences atomically. Routes through `io_atomic::atomic_write_json`
+/// so the pre-write JSON revalidation invariant is enforced at the same
+/// chokepoint the settings writer uses — even though `serde_json::to_vec_pretty`
+/// against a typed `Preferences` is safe-by-construction today, a future
+/// manual render or schema-evolution shortcut can't quietly skip validation
+/// without bypassing the helper on purpose.
+///
+/// `backups: None` is intentional: the preferences file lives in the OS
+/// config directory and is cheap to regenerate; a stray `.bak` next to it
+/// would be more surprise than safety.
 pub fn save(prefs: &Preferences) -> std::io::Result<()> {
     let path = config_path().ok_or_else(|| {
         std::io::Error::new(
@@ -75,22 +77,10 @@ pub fn save(prefs: &Preferences) -> std::io::Result<()> {
             "no OS config directory available",
         )
     })?;
-    let Some(parent) = path.parent() else {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "config path has no parent directory",
-        ));
-    };
-    std::fs::create_dir_all(parent)?;
-
     let body = serde_json::to_vec_pretty(prefs)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-
-    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
-    std::io::Write::write_all(&mut tmp, &body)?;
-    tmp.as_file_mut().sync_all()?;
-    tmp.persist(&path).map_err(|e| e.error)?;
-    Ok(())
+    crate::io_atomic::atomic_write_json(&path, &body, None)
+        .map_err(|e| std::io::Error::other(e.to_string()))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -79,8 +79,14 @@ pub fn save(prefs: &Preferences) -> std::io::Result<()> {
     })?;
     let body = serde_json::to_vec_pretty(prefs)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    crate::io_atomic::atomic_write_json(&path, &body, None)
-        .map_err(|e| std::io::Error::other(e.to_string()))
+    crate::io_atomic::atomic_write_json(&path, &body, None).map_err(|e| {
+        let kind = match &e {
+            crate::io_atomic::IoError::Io { source, .. } => source.kind(),
+            crate::io_atomic::IoError::Revalidate { .. } => std::io::ErrorKind::InvalidData,
+            _ => std::io::ErrorKind::Other,
+        };
+        std::io::Error::new(kind, e)
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Promotes the re-parse-before-write step into a shared `atomic_write_json(path, bytes, backups: Option<&BackupTracker>)` helper in `io_atomic`.
- `io_atomic::save` becomes a thin wrapper that renders the doc and calls the helper with backups enabled.
- `preferences::save` now also routes through the helper, with `backups: None` to preserve its intentional no-`.bak` behavior in the OS config dir.

The validation invariant — invalid bytes in => zero filesystem effect — now lives at the I/O boundary instead of being implicit in each caller's serializer. A future write path (manual render, new asset type per #11, a fast path that skips serde) has to bypass the helper on purpose to skip validation, not just forget a line. Doc-comment on the helper states the contract explicitly.

Closes #46.

## Test plan

- [x] `cargo test --lib` — all io_atomic, preferences, commands, watcher tests pass (3 new).
- [x] New test `atomic_write_json_rejects_invalid_bytes_without_touching_disk` verifies: no tempfile, no `.bak`, destination file unchanged on invalid input.
- [x] New test `atomic_write_json_writes_valid_bytes_with_backup` covers the happy path with backups.
- [x] New test `atomic_write_json_skips_backup_when_none` covers the preferences case.
- [x] `cargo fmt` + `cargo clippy` clean (run by pre-commit hooks).

## Notes

Two pre-existing scope tests fail locally on Windows (`scope::tests::falls_back_to_start_when_no_dot_claude`, `finds_project_root_when_dot_claude_exists`) because the test temp dir is inside `C:\Users\brian\` which has its own `.claude/` — confirmed they fail identically on `dev` without this change. CI should be unaffected since runners don't have a populated `~/.claude/`.