### PR TITLE
fix(io): detect concurrent modification on the move flow

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -354,10 +354,12 @@ fn apply_move_impl(
     let from_path = require_path(paths, req.from)?.to_path_buf();
     let to_path = require_path(paths, req.to)?.to_path_buf();
 
-    let mut to_doc = io_atomic::load(&to_path)?.unwrap_or_else(SettingsDoc::empty);
+    let (to_doc_loaded, to_stamp) = io_atomic::load_with_stamp(&to_path)?;
+    let mut to_doc = to_doc_loaded.unwrap_or_else(SettingsDoc::empty);
     let dest_mutated = to_doc.add_rule(req.kind, &req.rule);
 
-    let mut from_doc = match io_atomic::load(&from_path)? {
+    let (from_doc_loaded, from_stamp) = io_atomic::load_with_stamp(&from_path)?;
+    let mut from_doc = match from_doc_loaded {
         Some(d) => d,
         None => return Err(format!("source file {} does not exist", from_path.display()).into()),
     };
@@ -381,16 +383,23 @@ fn apply_move_impl(
     // would-be-legitimate external change would leave the UI stale for no
     // reason. Suppression is path-scoped, so we pass the exact path each
     // save touched.
+    //
+    // Each save passes the stamp captured at load time. A third party that
+    // edited the file between our load and our save aborts with
+    // `ConcurrentModification` rather than getting silently overwritten.
     if dest_mutated {
-        io_atomic::save(&to_path, &to_doc, backups)?;
+        io_atomic::save(&to_path, &to_doc, backups, Some(&to_stamp))?;
         watch.note_self_write(&to_path);
     }
     // If the source write fails after the destination was updated, roll back
     // the destination so the rule doesn't end up duplicated in both scopes.
-    if let Err(source_err) = io_atomic::save(&from_path, &from_doc, backups) {
+    if let Err(source_err) = io_atomic::save(&from_path, &from_doc, backups, Some(&from_stamp)) {
         if dest_mutated {
             to_doc.remove_rule(req.kind, &req.rule);
-            if let Err(rollback_err) = io_atomic::save(&to_path, &to_doc, backups) {
+            // Rollback skips the stamp check: we are the canonical writer of
+            // the destination at this point, and the stamp we'd want is the
+            // one our own successful write just produced.
+            if let Err(rollback_err) = io_atomic::save(&to_path, &to_doc, backups, None) {
                 return Err(format!(
                     "source save failed: {source_err}; destination rollback also failed: {rollback_err}"
                 )
@@ -485,7 +494,8 @@ fn apply_move_key_impl(
     let from_path = require_path(paths, req.from)?.to_path_buf();
     let to_path = require_path(paths, req.to)?.to_path_buf();
 
-    let mut from_doc = match io_atomic::load(&from_path)? {
+    let (from_doc_loaded, from_stamp) = io_atomic::load_with_stamp(&from_path)?;
+    let mut from_doc = match from_doc_loaded {
         Some(d) => d,
         None => return Err(format!("source file {} does not exist", from_path.display()).into()),
     };
@@ -505,7 +515,8 @@ fn apply_move_key_impl(
     // touched it, so a later rollback can tell "restore the old contents"
     // apart from "we created this file, so removing it is the rollback."
     let to_existed_before = to_path.exists();
-    let to_doc_before = io_atomic::load(&to_path)?.unwrap_or_else(SettingsDoc::empty);
+    let (to_doc_loaded, to_stamp) = io_atomic::load_with_stamp(&to_path)?;
+    let to_doc_before = to_doc_loaded.unwrap_or_else(SettingsDoc::empty);
     let to_before = to_doc_before.get_top_level(&req.key).cloned();
     let mut to_doc = to_doc_before.clone();
     to_doc.merge_top_level(&req.key, src_value.clone());
@@ -517,18 +528,22 @@ fn apply_move_key_impl(
     // Destination first, then source — same ordering + rollback shape as
     // apply_move_impl. Skipping the destination save when nothing changed
     // avoids writing a .bak for a file we aren't actually touching.
+    //
+    // Stamp checks: each save passes the stamp captured at load. Rollback
+    // saves pass `None` because we are the canonical writer at that point
+    // (see apply_move_impl for the same reasoning).
     if dest_mutated {
-        io_atomic::save(&to_path, &to_doc, backups)?;
+        io_atomic::save(&to_path, &to_doc, backups, Some(&to_stamp))?;
         watch.note_self_write(&to_path);
     }
-    if let Err(source_err) = io_atomic::save(&from_path, &from_doc, backups) {
+    if let Err(source_err) = io_atomic::save(&from_path, &from_doc, backups, Some(&from_stamp)) {
         if dest_mutated {
             // Roll back the destination. If the file already existed before
             // we wrote to it, restore the pre-merge snapshot. If the save
             // newly created the file, delete it outright — re-saving the
             // empty snapshot would leave a stray `{}` file behind.
             let rollback_result: Result<(), Box<dyn std::error::Error>> = if to_existed_before {
-                io_atomic::save(&to_path, &to_doc_before, backups).map_err(Into::into)
+                io_atomic::save(&to_path, &to_doc_before, backups, None).map_err(Into::into)
             } else {
                 std::fs::remove_file(&to_path).map_err(Into::into)
             };

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -514,8 +514,13 @@ fn apply_move_key_impl(
     // Snapshot whether the destination file existed on disk before we
     // touched it, so a later rollback can tell "restore the old contents"
     // apart from "we created this file, so removing it is the rollback."
-    let to_existed_before = to_path.exists();
+    // Derive the existence flag from the load result rather than a separate
+    // `exists()` call: a third party that creates the file between our
+    // `exists()` and our `load_with_stamp` would otherwise leave us with
+    // `to_existed_before = false` plus a present stamp, and on rollback
+    // we'd `remove_file` a file we never created.
     let (to_doc_loaded, to_stamp) = io_atomic::load_with_stamp(&to_path)?;
+    let to_existed_before = to_doc_loaded.is_some();
     let to_doc_before = to_doc_loaded.unwrap_or_else(SettingsDoc::empty);
     let to_before = to_doc_before.get_top_level(&req.key).cloned();
     let mut to_doc = to_doc_before.clone();

--- a/src-tauri/src/io_atomic.rs
+++ b/src-tauri/src/io_atomic.rs
@@ -17,16 +17,21 @@
 //!      via the `backups` argument.
 //!   4. Write the new contents to a tempfile in the same directory and
 //!      `sync_all()` the file's data + metadata.
-//!   5. Rename the tempfile over the target (atomic on the same filesystem).
-//!   6. On Unix, `sync_all()` the parent directory so the rename itself is
+//!   5. If the caller passed an expected [`FileStamp`], re-stat the target
+//!      and refuse with [`IoError::ConcurrentModification`] when the stamp
+//!      differs — this app should not silently overwrite an edit a hand-edit
+//!      session or another tool made between our load and our save.
+//!   6. Rename the tempfile over the target (atomic on the same filesystem).
+//!   7. On Unix, `sync_all()` the parent directory so the rename itself is
 //!      durable across a crash. Windows skips this step — see the
 //!      `atomic_write_json` doc-comment for the rationale.
 
 use std::collections::HashSet;
 use std::fs;
-use std::io::Write;
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::time::SystemTime;
 
 use serde_json::Value;
 
@@ -50,6 +55,8 @@ pub enum IoError {
     Revalidate { path: PathBuf, reason: String },
     #[error("settings root must be a JSON object in {path}")]
     NotObject { path: PathBuf },
+    #[error("{path} changed on disk between load and save; reload and retry")]
+    ConcurrentModification { path: PathBuf },
 }
 
 impl IoError {
@@ -57,6 +64,38 @@ impl IoError {
         Self::Io {
             path: path.to_path_buf(),
             source,
+        }
+    }
+}
+
+/// Snapshot captured at load time, used to detect concurrent modification
+/// before a save overwrites someone else's edit. Pairs `(mtime, len)` so a
+/// rewrite that lands on the same mtime tick (mtime granularity is as coarse
+/// as 1s on FAT, 2s on some Windows configurations) is still distinguishable
+/// when the size differs.
+///
+/// `Missing` represents "the file did not exist when we read it" so a save
+/// expecting `Missing` correctly fails if a third party has since created
+/// the file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileStamp {
+    Missing,
+    Present { mtime: SystemTime, len: u64 },
+}
+
+impl FileStamp {
+    /// Stat `path` and capture a stamp for it.
+    pub fn of(path: &Path) -> Result<Self, IoError> {
+        match fs::metadata(path) {
+            Ok(m) => {
+                let mtime = m.modified().map_err(|e| IoError::io(path, e))?;
+                Ok(FileStamp::Present {
+                    mtime,
+                    len: m.len(),
+                })
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(FileStamp::Missing),
+            Err(e) => Err(IoError::io(path, e)),
         }
     }
 }
@@ -102,34 +141,68 @@ impl BackupTracker {
 /// Load a settings file, returning `Ok(None)` when the file does not exist.
 /// A missing file is a normal state (e.g. a project without a `settings.json`).
 pub fn load(path: &Path) -> Result<Option<SettingsDoc>, IoError> {
-    match fs::read_to_string(path) {
-        Ok(text) => {
-            if text.trim().is_empty() {
-                return Ok(Some(SettingsDoc::empty()));
-            }
-            let value: Value = serde_json::from_str(&text).map_err(|e| IoError::Parse {
-                path: path.to_path_buf(),
-                source: e,
-            })?;
-            if !value.is_object() {
-                return Err(IoError::NotObject {
-                    path: path.to_path_buf(),
-                });
-            }
-            Ok(Some(SettingsDoc::from_value(value, detect_indent(&text))))
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(e) => Err(IoError::io(path, e)),
+    load_with_stamp(path).map(|(doc, _)| doc)
+}
+
+/// Load a settings file along with a [`FileStamp`] capturing its on-disk
+/// state. Pass the stamp back into [`save`] / [`atomic_write_json`] to refuse
+/// the write when the file was modified by another process between the
+/// load and the save.
+///
+/// The stamp is taken from the same open file handle the contents are read
+/// from, closing the small TOCTOU window a separate `metadata()` + `read`
+/// pair would have. `FileStamp::Missing` is returned for a non-existent
+/// file, distinguishing "no file when we looked" from any present-state
+/// stamp.
+pub fn load_with_stamp(path: &Path) -> Result<(Option<SettingsDoc>, FileStamp), IoError> {
+    let mut file = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok((None, FileStamp::Missing)),
+        Err(e) => return Err(IoError::io(path, e)),
+    };
+    let meta = file.metadata().map_err(|e| IoError::io(path, e))?;
+    let stamp = FileStamp::Present {
+        mtime: meta.modified().map_err(|e| IoError::io(path, e))?,
+        len: meta.len(),
+    };
+    let mut text = String::new();
+    file.read_to_string(&mut text)
+        .map_err(|e| IoError::io(path, e))?;
+    drop(file);
+
+    if text.trim().is_empty() {
+        return Ok((Some(SettingsDoc::empty()), stamp));
     }
+    let value: Value = serde_json::from_str(&text).map_err(|e| IoError::Parse {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    if !value.is_object() {
+        return Err(IoError::NotObject {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok((
+        Some(SettingsDoc::from_value(value, detect_indent(&text))),
+        stamp,
+    ))
 }
 
 /// Atomic write with revalidation and one-time-per-session backup.
 ///
 /// Convenience wrapper that renders a [`SettingsDoc`] and routes the bytes
-/// through [`atomic_write_json`] with backups enabled.
-pub fn save(path: &Path, doc: &SettingsDoc, backups: &BackupTracker) -> Result<(), IoError> {
+/// through [`atomic_write_json`] with backups enabled. `expected` carries
+/// the [`FileStamp`] the caller captured at load time so a concurrent edit
+/// is detected and refused — pass `None` to skip the check (e.g. on a
+/// rollback path where the app is the canonical writer).
+pub fn save(
+    path: &Path,
+    doc: &SettingsDoc,
+    backups: &BackupTracker,
+    expected: Option<&FileStamp>,
+) -> Result<(), IoError> {
     let rendered = doc.render();
-    atomic_write_json(path, rendered.as_bytes(), Some(backups))
+    atomic_write_json(path, rendered.as_bytes(), Some(backups), expected)
 }
 
 /// The single chokepoint every write path in the app must use.
@@ -147,6 +220,14 @@ pub fn save(path: &Path, doc: &SettingsDoc, backups: &BackupTracker) -> Result<(
 /// settings.json`), and `None` for ClaudeScope-owned files that are cheap to
 /// regenerate and would clutter their directory with `.bak`s (e.g. the
 /// preferences file under the OS config dir).
+///
+/// `expected` is `Some(_)` to refuse the write when the destination has
+/// changed on disk since the caller's load — paired with a [`FileStamp`]
+/// captured by [`load_with_stamp`] or [`FileStamp::of`]. The check is
+/// best-effort: a third-party writer that lands between the stamp recheck
+/// and `tempfile::persist` (a microsecond-scale window) will still be
+/// overwritten. For coordinated rollback paths where this app is the
+/// canonical writer, pass `None`.
 ///
 /// **Durability:** after the rename, on Unix this also opens the parent
 /// directory and `sync_all()`s it — without that, a crash between the
@@ -172,6 +253,7 @@ pub fn atomic_write_json(
     path: &Path,
     bytes: &[u8],
     backups: Option<&BackupTracker>,
+    expected: Option<&FileStamp>,
 ) -> Result<(), IoError> {
     // Revalidate before touching disk. This is the load-bearing contract:
     // bad bytes in => no observable filesystem effect.
@@ -197,6 +279,21 @@ pub fn atomic_write_json(
     tmp.as_file_mut()
         .sync_all()
         .map_err(|e| IoError::io(tmp.path(), e))?;
+
+    // Stamp recheck immediately before persist — the closer to the rename,
+    // the smaller the race window. Done after the tempfile is fsynced so a
+    // mismatch doesn't waste the write to a tempfile we'd otherwise have
+    // to clean up: NamedTempFile's Drop removes it for us when we return
+    // without persisting.
+    if let Some(expected) = expected {
+        let current = FileStamp::of(path)?;
+        if &current != expected {
+            return Err(IoError::ConcurrentModification {
+                path: path.to_path_buf(),
+            });
+        }
+    }
+
     tmp.persist(path).map_err(|e| IoError::io(path, e.error))?;
 
     // After `persist`, the destination path has already been replaced. A
@@ -308,14 +405,14 @@ mod tests {
 
         let backups = BackupTracker::new();
         let doc = load(&path).unwrap().unwrap();
-        save(&path, &doc, &backups).unwrap();
+        save(&path, &doc, &backups, None).unwrap();
 
         let bak = path.with_file_name("settings.json.bak");
         assert!(bak.exists(), "first save should create .bak");
 
         // Second save should not update the .bak.
         let bak_mtime = std::fs::metadata(&bak).unwrap().modified().unwrap();
-        save(&path, &doc, &backups).unwrap();
+        save(&path, &doc, &backups, None).unwrap();
         let bak_mtime2 = std::fs::metadata(&bak).unwrap().modified().unwrap();
         assert_eq!(bak_mtime, bak_mtime2);
     }
@@ -331,7 +428,7 @@ mod tests {
 
         let backups = BackupTracker::new();
         let doc = load(&path).unwrap().unwrap();
-        save(&path, &doc, &backups).unwrap();
+        save(&path, &doc, &backups, None).unwrap();
 
         let bak_contents = std::fs::read_to_string(&bak).unwrap();
         assert!(
@@ -360,7 +457,7 @@ mod tests {
         std::fs::write(&path, r#"{"original":true}"#).unwrap();
 
         let backups = BackupTracker::new();
-        let err = atomic_write_json(&path, b"{ not json", Some(&backups)).unwrap_err();
+        let err = atomic_write_json(&path, b"{ not json", Some(&backups), None).unwrap_err();
         assert!(
             matches!(err, IoError::Revalidate { .. }),
             "expected Revalidate, got {err:?}"
@@ -396,7 +493,7 @@ mod tests {
         std::fs::write(&path, r#"{"original":true}"#).unwrap();
 
         let backups = BackupTracker::new();
-        atomic_write_json(&path, br#"{"updated":true}"#, Some(&backups)).unwrap();
+        atomic_write_json(&path, br#"{"updated":true}"#, Some(&backups), None).unwrap();
 
         assert_eq!(
             std::fs::read_to_string(&path).unwrap(),
@@ -416,7 +513,7 @@ mod tests {
         let path = tmp.path().join("config.json");
         std::fs::write(&path, r#"{"original":true}"#).unwrap();
 
-        atomic_write_json(&path, br#"{"updated":true}"#, None).unwrap();
+        atomic_write_json(&path, br#"{"updated":true}"#, None, None).unwrap();
 
         let bak = path.with_file_name("config.json.bak");
         assert!(!bak.exists(), ".bak must not be created when backups: None");
@@ -424,5 +521,108 @@ mod tests {
             std::fs::read_to_string(&path).unwrap(),
             r#"{"updated":true}"#
         );
+    }
+
+    /// Bump the file's mtime far enough that any filesystem timestamp
+    /// granularity (1s on FAT, 2s on some Windows configs) reads it as
+    /// distinct from the original.
+    fn touch_mtime_in_the_past(path: &Path) {
+        let earlier = SystemTime::now() - std::time::Duration::from_secs(10);
+        let f = fs::File::options().write(true).open(path).unwrap();
+        f.set_modified(earlier).unwrap();
+    }
+
+    #[test]
+    fn atomic_write_json_refuses_when_stamp_changed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        std::fs::write(&path, r#"{"original":true}"#).unwrap();
+
+        // Snapshot stamp, then someone else edits the file.
+        let stamp = FileStamp::of(&path).unwrap();
+        std::fs::write(&path, r#"{"hand_edited":true}"#).unwrap();
+        touch_mtime_in_the_past(&path); // make sure mtime is observably different
+
+        let backups = BackupTracker::new();
+        let err = atomic_write_json(
+            &path,
+            br#"{"our_overwrite":true}"#,
+            Some(&backups),
+            Some(&stamp),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, IoError::ConcurrentModification { .. }),
+            "expected ConcurrentModification, got {err:?}"
+        );
+
+        // The hand edit must survive.
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            r#"{"hand_edited":true}"#
+        );
+    }
+
+    #[test]
+    fn atomic_write_json_refuses_when_expected_missing_but_file_appeared() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        // We expected the file to be missing — caller's load returned None.
+        let stamp = FileStamp::Missing;
+        // Then someone else created it.
+        std::fs::write(&path, r#"{"created_by_other":true}"#).unwrap();
+
+        let backups = BackupTracker::new();
+        let err = atomic_write_json(
+            &path,
+            br#"{"our_create":true}"#,
+            Some(&backups),
+            Some(&stamp),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, IoError::ConcurrentModification { .. }),
+            "expected ConcurrentModification when stamp said Missing but file now present, got {err:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            r#"{"created_by_other":true}"#,
+            "third-party content must survive"
+        );
+    }
+
+    #[test]
+    fn atomic_write_json_succeeds_when_stamp_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        std::fs::write(&path, r#"{"original":true}"#).unwrap();
+
+        let stamp = FileStamp::of(&path).unwrap();
+        let backups = BackupTracker::new();
+        atomic_write_json(&path, br#"{"updated":true}"#, Some(&backups), Some(&stamp)).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            r#"{"updated":true}"#
+        );
+    }
+
+    #[test]
+    fn load_with_stamp_returns_missing_for_absent_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (doc, stamp) = load_with_stamp(&tmp.path().join("nope.json")).unwrap();
+        assert!(doc.is_none());
+        assert_eq!(stamp, FileStamp::Missing);
+    }
+
+    #[test]
+    fn load_with_stamp_returns_present_for_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        std::fs::write(&path, r#"{"a":1}"#).unwrap();
+
+        let (doc, stamp) = load_with_stamp(&path).unwrap();
+        assert!(doc.is_some());
+        assert!(matches!(stamp, FileStamp::Present { .. }));
     }
 }

--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -79,7 +79,7 @@ pub fn save(prefs: &Preferences) -> std::io::Result<()> {
     })?;
     let body = serde_json::to_vec_pretty(prefs)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    crate::io_atomic::atomic_write_json(&path, &body, None).map_err(|e| {
+    crate::io_atomic::atomic_write_json(&path, &body, None, None).map_err(|e| {
         let kind = match &e {
             crate::io_atomic::IoError::Io { source, .. } => source.kind(),
             crate::io_atomic::IoError::Revalidate { .. } => std::io::ErrorKind::InvalidData,


### PR DESCRIPTION
## Summary

The move flow (rules and top-level keys) now refuses to silently overwrite a file that was edited by another process between our load and our save — important for a tool whose entire premise is coexisting with hand-edited JSON.

- New `FileStamp` (`Missing` | `Present { mtime, len }`) captured at load time and rechecked just before `tempfile::persist`.
- New `load_with_stamp` reads contents and metadata from a single open file handle, closing the small TOCTOU window a separate `metadata()` + `read` pair would have.
- New `IoError::ConcurrentModification` variant surfaces with a "reload and retry" message.
- `io_atomic::save` and `atomic_write_json` gained an `expected: Option<&FileStamp>` parameter — pass `None` to skip the check.
- `apply_move_impl` and `apply_move_key_impl` plumb stamps through both source and destination saves; rollback paths intentionally pass `None` (the app is the canonical writer at that point).

Closes #34.

## Test plan

- [x] 5 new tests in `io_atomic`: stamp mismatch ⇒ `ConcurrentModification`; expected `Missing` but file appeared ⇒ same; stamp match ⇒ success; `load_with_stamp` returns `Missing` for absent and `Present` for existing files.
- [x] All 23 existing `commands` tests pass — happy path of move flow is unchanged (stamps match by definition when no third party touches the file).
- [x] `cargo fmt` + `cargo clippy` clean.

## Notes

- Race window between the stamp recheck and `persist` is microsecond-scale and unavoidable without OS-level rename-only-if-stamp-matches; documented in the helper doc-comment.
- Preferences writes still pass `None` for `expected` — the preferences file isn't externally edited, so the check would be ceremony.
- 2 pre-existing scope tests fail locally on Windows (env-specific to the dev box); unaffected by this change.