### PR TITLE
fix(ui): rename "Effective permissions" to "Combined permissions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Claude Code reads settings from JSON files at several scopes. Moving a permissio
 
 ### Features
 
-- **Four-column scope view** — User / User-Local / Project / Local, laid out broadest-on-the-left, with a panel above them currently labelled "Effective permissions" in the UI. That panel is a union across scopes; it is not a full precedence-aware evaluation of what Claude Code resolves at runtime. The label is being walked back as part of [#30](https://github.com/bminier/claude-scope/issues/30).
+- **Four-column scope view** — User / User-Local / Project / Local, laid out broadest-on-the-left, with a "Combined permissions" panel above them. That panel is a union across scopes; it is not a full precedence-aware evaluation of what Claude Code resolves at runtime, and the subtitle says so.
 - **Atomic writes with revalidation** — serialize → re-parse the produced JSON → tempfile + rename, with one-shot `.bak` backup per file per session. See [Write strategy](#write-strategy) for the fine print.
 - **Diff preview modal** — shows before/after for both sides of a move with a proper diff, Esc/Enter/Tab-trap keyboard handling, focus restored to the triggering button on close
 - **Rule search / filter** — press `/` anywhere to focus, case-insensitive substring, `m/n` match counts per group

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -59,8 +59,9 @@ reviewer.
 ## Golden path
 
 - [ ] **All four scope columns render.** User / User-Local / Project / Local
-      appear left-to-right; the "Effective" panel shows the merged union on
-      top.
+      appear left-to-right; the "Combined permissions" panel shows the union
+      across scopes on top, with the precedence-aware-evaluation caveat in
+      its subtitle.
 - [ ] **Click-to-move a permission rule.** From any populated scope, click a
       `→ <Scope>` button on a rule → diff modal opens with before/after for
       both sides → click **Apply** → modal closes, rule disappears from

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -37,7 +37,7 @@ pub struct ScopeView {
 pub struct LoadedScopes {
     pub project_dir: String,
     pub scopes: Vec<ScopeView>,
-    pub effective_permissions: PermissionRules,
+    pub combined_permissions: PermissionRules,
 }
 
 #[derive(Debug, Deserialize)]
@@ -197,12 +197,12 @@ fn build_loaded(paths: &ScopePaths) -> Result<LoadedScopes, Box<dyn std::error::
         views.push(load_scope_view(scope, paths.path_for(scope)));
     }
 
-    let effective = effective_permissions(&views);
+    let combined = combined_permissions(&views);
 
     Ok(LoadedScopes {
         project_dir: paths.project_dir.display().to_string(),
         scopes: views,
-        effective_permissions: effective,
+        combined_permissions: combined,
     })
 }
 
@@ -233,13 +233,18 @@ fn load_scope_view(scope: Scope, path: Option<&Path>) -> ScopeView {
     view
 }
 
-/// Build the effective permission view. For v1 we union `allow` / `deny` /
-/// `ask` across the recognized scopes and deduplicate while preserving the
-/// order Local → Project → UserLocal → User (highest precedence first).
-/// That's a faithful first approximation of "what Claude Code sees" for
-/// list-valued rule sets; precedence-sensitive semantics like conflict
-/// resolution are a future concern.
-fn effective_permissions(views: &[ScopeView]) -> PermissionRules {
+/// Build the combined permission view: union `allow` / `deny` / `ask`
+/// across the recognized scopes and deduplicate while preserving the order
+/// Local → Project → UserLocal → User (highest precedence first).
+///
+/// This is intentionally *not* a precedence-aware effective evaluation.
+/// When a rule appears in both an `allow` and a `deny` list across scopes,
+/// both copies appear in their respective lists and no resolution happens.
+/// Naming it "combined" rather than "effective" keeps the UI honest about
+/// what the panel shows; modelling Claude Code's full conflict semantics is
+/// out of scope for v1 and would require grammar Claude Code does not
+/// publicly document.
+fn combined_permissions(views: &[ScopeView]) -> PermissionRules {
     let mut out = PermissionRules::default();
     for view in views {
         for rule in &view.permissions.allow {
@@ -978,7 +983,7 @@ mod tests {
     }
 
     #[test]
-    fn effective_unions_across_scopes() {
+    fn combined_unions_across_scopes() {
         let views = vec![
             ScopeView {
                 scope: Scope::Local,
@@ -1013,10 +1018,50 @@ mod tests {
                 parse_error: None,
             },
         ];
-        let eff = effective_permissions(&views);
-        assert_eq!(eff.allow, vec!["Bash(git status)", "Read(**)"]);
-        assert_eq!(eff.deny, vec!["WebFetch(domain:evil.example)"]);
-        assert!(eff.ask.is_empty());
+        let combined = combined_permissions(&views);
+        assert_eq!(combined.allow, vec!["Bash(git status)", "Read(**)"]);
+        assert_eq!(combined.deny, vec!["WebFetch(domain:evil.example)"]);
+        assert!(combined.ask.is_empty());
+    }
+
+    /// When the same rule appears in `allow` at one scope and `deny` at
+    /// another, the combined view surfaces both copies in their respective
+    /// lists rather than resolving the conflict. This is the documented
+    /// behavior of `combined_permissions`: it is a union, not a
+    /// precedence-aware evaluation. Locking it down so a future "let's
+    /// silently make this smarter" change has to delete this test.
+    #[test]
+    fn combined_surfaces_allow_deny_overlap_without_resolving() {
+        let views = vec![
+            ScopeView {
+                scope: Scope::Local,
+                path: None,
+                exists: true,
+                permissions: PermissionRules {
+                    allow: vec!["Bash(git push)".into()],
+                    deny: vec![],
+                    ask: vec![],
+                },
+                other_values: serde_json::Map::new(),
+                parse_error: None,
+            },
+            ScopeView {
+                scope: Scope::Project,
+                path: None,
+                exists: true,
+                permissions: PermissionRules {
+                    allow: vec![],
+                    deny: vec!["Bash(git push)".into()],
+                    ask: vec![],
+                },
+                other_values: serde_json::Map::new(),
+                parse_error: None,
+            },
+        ];
+        let combined = combined_permissions(&views);
+        assert_eq!(combined.allow, vec!["Bash(git push)"]);
+        assert_eq!(combined.deny, vec!["Bash(git push)"]);
+        assert!(combined.ask.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/scope.rs
+++ b/src-tauri/src/scope.rs
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn scope_all_includes_user_local_between_project_and_user() {
         // Precedence: highest first. UserLocal sits above User so that the
-        // effective-permissions union iterates in the right order.
+        // combined-permissions union iterates in the right order.
         assert_eq!(
             Scope::ALL,
             [Scope::Local, Scope::Project, Scope::UserLocal, Scope::User]

--- a/src/styles.css
+++ b/src/styles.css
@@ -175,30 +175,37 @@ button:disabled {
   color: var(--muted);
 }
 
-.effective {
+.combined {
   padding: 12px 16px;
   background: var(--panel);
   border-bottom: 1px solid var(--border);
 }
 
-.effective h2 {
-  margin: 0 0 8px 0;
+.combined h2 {
+  margin: 0;
   font-size: 13px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--muted);
 }
 
+.combined-subtitle {
+  margin: 2px 0 8px 0;
+  font-size: 11px;
+  color: var(--muted);
+  font-style: italic;
+}
+
 /* Three side-by-side group columns. Mirrors `.grid` below so the
    breakpoint behavior stays in lockstep — both collapse to a single
    column at the same viewport width. */
-.eff-groups {
+.combo-groups {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 12px;
 }
 
-.eff-group {
+.combo-group {
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -210,7 +217,7 @@ button:disabled {
      allow list pushes the scope grid below the fold, which is acceptable. */
 }
 
-.eff-label {
+.combo-label {
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -218,13 +225,13 @@ button:disabled {
   padding-bottom: 2px;
 }
 
-.eff-allow .eff-label {
+.combo-allow .combo-label {
   color: var(--allow);
 }
-.eff-deny .eff-label {
+.combo-deny .combo-label {
   color: var(--deny);
 }
-.eff-ask .eff-label {
+.combo-ask .combo-label {
   color: var(--ask);
 }
 
@@ -662,7 +669,7 @@ button:disabled {
 }
 
 /* Keeps the chip + ⚠ badge together as a single flex item inside
-   `.eff-group`; without this they can wrap to separate lines and orphan
+   `.combo-group`; without this they can wrap to separate lines and orphan
    the warning. */
 .chip-wrap {
   display: inline-flex;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export type Scope = "local" | "project" | "user_local" | "user";
 // UI-side scope order: broadest scope on the left, narrowest on the right.
 // That's the opposite of precedence order, so this list intentionally
 // diverges from Rust's `Scope::ALL` (which still iterates highest-precedence
-// first to drive the effective-permissions union). The only keep-in-sync
+// first to drive the combined-permissions union). The only keep-in-sync
 // invariant is membership: every scope variant must appear here so column
 // rendering and move-target buttons cover the full set.
 export const SCOPES: readonly Scope[] = ["user", "user_local", "project", "local"] as const;
@@ -42,7 +42,7 @@ export type PermissionKind = "allow" | "deny" | "ask";
 export interface LoadedScopes {
   project_dir: string;
   scopes: ScopeView[];
-  effective_permissions: PermissionRules;
+  combined_permissions: PermissionRules;
 }
 
 export interface MoveRequest {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -103,9 +103,9 @@ export function renderApp(root: HTMLElement, props: AppProps): void {
   }
 
   // Lowercase the query once per render instead of per rule; scopeGrid/
-  // effectivePanel push this down into every filter call.
+  // combinedPanel push this down into every filter call.
   const lowerQuery = props.query.toLowerCase();
-  root.appendChild(effectivePanel(props.scopes, props.query, lowerQuery));
+  root.appendChild(combinedPanel(props.scopes, props.query, lowerQuery));
   root.appendChild(scopeGrid(props, lowerQuery));
   restoreSearchFocus(preserveSearchFocus, caret);
 }
@@ -213,29 +213,33 @@ function searchBox(props: AppProps): HTMLElement {
   return wrap;
 }
 
-function effectivePanel(loaded: LoadedScopes, query: string, lowerQuery: string): HTMLElement {
+function combinedPanel(loaded: LoadedScopes, query: string, lowerQuery: string): HTMLElement {
   const panel = document.createElement("section");
-  panel.className = "effective";
+  panel.className = "combined";
   const title = document.createElement("h2");
-  title.textContent = "Effective permissions";
+  title.textContent = "Combined permissions";
   panel.appendChild(title);
+  const subtitle = document.createElement("p");
+  subtitle.className = "combined-subtitle";
+  subtitle.textContent = "Union across scopes — not a precedence-aware evaluation.";
+  panel.appendChild(subtitle);
 
   // Three side-by-side group columns instead of stacked rows. The grid
   // mirrors the scope-grid breakpoint below (auto-fit + minmax) so the
   // panel collapses to a single column on narrow viewports in lockstep
   // with the rest of the layout.
   const groupsWrap = document.createElement("div");
-  groupsWrap.className = "eff-groups";
+  groupsWrap.className = "combo-groups";
 
   const kinds: PermissionKind[] = ["allow", "deny", "ask"];
   for (const kind of kinds) {
-    const all = loaded.effective_permissions[kind];
+    const all = loaded.combined_permissions[kind];
     // Fast path when the filter is empty — no allocation, no iteration.
     const matched = lowerQuery === "" ? all : all.filter((r) => matchesLoweredQuery(r, lowerQuery));
     const group = document.createElement("div");
-    group.className = `eff-group eff-${kind}`;
+    group.className = `combo-group combo-${kind}`;
     const label = document.createElement("span");
-    label.className = "eff-label";
+    label.className = "combo-label";
     // Show matched/total when a filter is active AND the group isn't empty —
     // otherwise "(0/0)" reads as noise. Unfiltered groups and empty groups
     // fall back to the plain "(N)" format.
@@ -246,7 +250,7 @@ function effectivePanel(loaded: LoadedScopes, query: string, lowerQuery: string)
     group.appendChild(label);
     for (const rule of matched) {
       // Chip + optional badge wrap as a single flex item. Originally added
-      // because `.eff-group` used `flex-wrap: wrap` (badges could orphan to
+      // because `.combo-group` used `flex-wrap: wrap` (badges could orphan to
       // a new line without their chip); the group is now a vertical stack,
       // but the wrap still keeps badge + chip baseline-aligned and lets the
       // hover popover anchor relative to the pair.


### PR DESCRIPTION
Closes #30.

## Summary

The top panel was labelled "Effective permissions" but the implementation only unions `allow` / `deny` / `ask` across scopes — no precedence resolution, no conflict semantics. A label that promises evaluation when the code only does combination is exactly the kind of overclaim the v0.3 hardening line is meant to walk back.

Picking option 2 from the issue (rename + honest copy) over option 1 (model real precedence). Implementing real effective evaluation would require modelling Claude Code's full conflict semantics, which aren't publicly documented; the rename is the honest fix for a promote/demote tool.

## Changes

- **UI**: panel title is now `Combined permissions` with a subtitle `Union across scopes — not a precedence-aware evaluation.` The subtitle is a `<p>` sibling of the `<h2>`, not nested inside it (so screen readers don't mis-announce the heading).
- **IPC rename in lockstep**: Rust `LoadedScopes.effective_permissions` → `combined_permissions`, function `effective_permissions()` → `combined_permissions()`, TS type field, CSS classes (`.effective` → `.combined`, `.eff-*` → `.combo-*`), references in `scope.rs` / `types.ts` comments and the existing test name.
- **New test** `combined_surfaces_allow_deny_overlap_without_resolving` — locks down the documented union behavior on an allow/deny overlap so a future "let's silently make this smarter" change has to delete this test (AC: "Tests cover at least one conflict / overlap case").
- **Docs**: README drops the `#30`-pending hedge from the doc-overclaim PR and describes the new panel directly. `docs/SMOKE_TEST.md` updated.

`CLAUDE.md` still uses "effective" in the original problem statement — that's the project brief and intentionally describes a v1+ goal the implementation does not yet meet, not a guarantee of current behavior. Left untouched.

## Test plan

- [x] `cargo test --lib --locked` — 73 passed; the two pre-existing `scope::tests` that trip on the user's home dir actually containing a `.claude` still fail identically on `dev` HEAD.
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --locked -- -D warnings`
- [x] `tsc --noEmit`
- [x] pre-commit hooks pass on the commit
- [ ] **Manual smoke-test still required** — this is a UI rename and per `docs/SMOKE_TEST.md` the maintainer should drive `npm run tauri dev` before merge to confirm the panel title, subtitle, and CSS layout still render correctly.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)