### PR TITLE
fix(backend): explicit per-key merge policy table for top-level moves

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 
 use crate::io_atomic::{self, BackupTracker};
-use crate::model::{PermissionKind, PermissionRules, SettingsDoc};
+use crate::model::{key_policy, KeyPolicy, PermissionKind, PermissionRules, SettingsDoc};
 use crate::preferences::{self, Preferences};
 use crate::scope::{self, Scope, ScopePaths};
 use crate::watcher::WatchState;
@@ -461,10 +461,7 @@ fn diff_move_key_impl(
     } else if !to_path_exists {
         Some("Destination file will be created.".to_string())
     } else if to_before.is_some() {
-        Some(
-            "Destination already has this key; values will be merged with a generic shape-based policy. Review the diff before applying."
-                .to_string(),
-        )
+        Some(policy_preview_note(&req.key))
     } else {
         None
     };
@@ -574,6 +571,20 @@ fn apply_move_key_impl(
     }
     watch.note_self_write(&from_path);
     Ok(())
+}
+
+/// Human-readable note explaining how the destination's existing value will
+/// be combined with the incoming source value, given the documented merge
+/// policy for `key`. Shown in the diff preview so the user can confirm
+/// before applying the move.
+fn policy_preview_note(key: &str) -> String {
+    match key_policy(key) {
+        KeyPolicy::Replace => "Override-only key: the destination's previous value will be replaced. The original is saved to a .bak alongside the file.".to_string(),
+        KeyPolicy::DeepMerge => "Deep-merged key: source values override destination values on conflict; other destination keys are preserved.".to_string(),
+        KeyPolicy::ArrayUnion => "Array-union key: source items are appended to the destination and deduplicated.".to_string(),
+        KeyPolicy::ReplaceComplex => "Complex per-subkey merge semantics not yet implemented; the destination's value will be replaced wholesale. The original is saved to a .bak alongside the file. Review the diff carefully.".to_string(),
+        KeyPolicy::ReplaceUnknown => "Unknown key — ClaudeScope has no documented merge policy for it. The destination's value will be replaced. The original is saved to a .bak alongside the file. Review the diff carefully.".to_string(),
+    }
 }
 
 fn validate_move_key(req: &MoveKeyRequest) -> Result<(), Box<dyn std::error::Error>> {
@@ -1212,16 +1223,60 @@ mod tests {
     }
 
     #[test]
-    fn move_key_dedupes_hook_arrays() {
+    fn move_key_dedupes_array_union_keys() {
+        // allowedHttpHookUrls is a documented array-union key: entries from
+        // every scope are concatenated and deduplicated. Moving from project
+        // into user with overlap should yield the destination's entries
+        // followed by the source's, with the duplicate dropped.
         let tmp = tempfile::tempdir().unwrap();
         let paths = paths_in(tmp.path());
         write(
             paths.project.as_ref().unwrap(),
-            r#"{"hooks": ["PreToolUse", "PostToolUse"]}"#,
+            r#"{"allowedHttpHookUrls": ["https://a.example", "https://b.example"]}"#,
         );
         write(
             paths.user.as_ref().unwrap(),
-            r#"{"hooks": ["PostToolUse", "UserPromptSubmit"]}"#,
+            r#"{"allowedHttpHookUrls": ["https://b.example", "https://c.example"]}"#,
+        );
+        apply_move_key_impl(
+            &paths,
+            &MoveKeyRequest {
+                key: "allowedHttpHookUrls".to_string(),
+                from: Scope::Project,
+                to: Scope::User,
+            },
+            &BackupTracker::new(),
+            &WatchState::default(),
+        )
+        .unwrap();
+        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            user_doc.get_top_level("allowedHttpHookUrls").unwrap(),
+            &serde_json::json!([
+                "https://b.example",
+                "https://c.example",
+                "https://a.example"
+            ])
+        );
+    }
+
+    #[test]
+    fn move_key_replaces_override_only_hooks() {
+        // hooks is override-only per Claude Code's docs: the highest-precedence
+        // scope wins, scopes are not merged. Moving hooks from project into
+        // user must overwrite the destination's existing hooks block, not
+        // merge into it.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(
+            paths.project.as_ref().unwrap(),
+            r#"{"hooks": {"PreToolUse": [{"command": "from-project"}]}}"#,
+        );
+        write(
+            paths.user.as_ref().unwrap(),
+            r#"{"hooks": {"PostToolUse": [{"command": "from-user"}]}}"#,
         );
         apply_move_key_impl(
             &paths,
@@ -1239,7 +1294,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             user_doc.get_top_level("hooks").unwrap(),
-            &serde_json::json!(["PostToolUse", "UserPromptSubmit", "PreToolUse"])
+            &serde_json::json!({"PreToolUse": [{"command": "from-project"}]})
         );
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -460,10 +460,10 @@ fn diff_move_key_impl(
         )
     } else if !to_path_exists {
         Some("Destination file will be created.".to_string())
-    } else if to_before.is_some() {
-        Some(policy_preview_note(&req.key))
     } else {
-        None
+        to_before
+            .as_ref()
+            .map(|before| policy_preview_note(&req.key, before, &src_value))
     };
 
     Ok(MoveKeyPreview {
@@ -577,11 +577,34 @@ fn apply_move_key_impl(
 /// be combined with the incoming source value, given the documented merge
 /// policy for `key`. Shown in the diff preview so the user can confirm
 /// before applying the move.
-fn policy_preview_note(key: &str) -> String {
+///
+/// `to_before` and `src_value` are inspected so that `DeepMerge` /
+/// `ArrayUnion` keys whose runtime shapes don't match the policy (e.g. a
+/// hand-edited file where `allowedHttpHookUrls` ended up as a string) get
+/// an accurate "will be replaced instead" message rather than the nominal
+/// merge description. The model layer's own fallback to overwrite on shape
+/// mismatch then matches what the preview promised.
+fn policy_preview_note(
+    key: &str,
+    to_before: &serde_json::Value,
+    src_value: &serde_json::Value,
+) -> String {
     match key_policy(key) {
         KeyPolicy::Replace => "Override-only key: the destination's previous value will be replaced. The original is saved to a .bak alongside the file.".to_string(),
-        KeyPolicy::DeepMerge => "Deep-merged key: source values override destination values on conflict; other destination keys are preserved.".to_string(),
-        KeyPolicy::ArrayUnion => "Array-union key: source items are appended to the destination and deduplicated.".to_string(),
+        KeyPolicy::DeepMerge => {
+            if to_before.is_object() && src_value.is_object() {
+                "Deep-merged key: source values override destination values on conflict; other destination keys are preserved.".to_string()
+            } else {
+                "Deep-merged key, but the destination or source value is not a JSON object — the destination's value will be replaced instead. The original is saved to a .bak alongside the file.".to_string()
+            }
+        }
+        KeyPolicy::ArrayUnion => {
+            if to_before.is_array() && src_value.is_array() {
+                "Array-union key: source items are appended to the destination and deduplicated.".to_string()
+            } else {
+                "Array-union key, but the destination or source value is not a JSON array — the destination's value will be replaced instead. The original is saved to a .bak alongside the file.".to_string()
+            }
+        }
         KeyPolicy::ReplaceComplex => "Complex per-subkey merge semantics not yet implemented; the destination's value will be replaced wholesale. The original is saved to a .bak alongside the file. Review the diff carefully.".to_string(),
         KeyPolicy::ReplaceUnknown => "Unknown key — ClaudeScope has no documented merge policy for it. The destination's value will be replaced. The original is saved to a .bak alongside the file. Review the diff carefully.".to_string(),
     }
@@ -1260,6 +1283,95 @@ mod tests {
                 "https://a.example"
             ])
         );
+    }
+
+    #[test]
+    fn preview_note_for_replace_keys_calls_out_override_only() {
+        let note = policy_preview_note(
+            "hooks",
+            &serde_json::json!({"PreToolUse": []}),
+            &serde_json::json!({"PostToolUse": []}),
+        );
+        assert!(
+            note.contains("Override-only"),
+            "expected override-only language for hooks, got: {note}"
+        );
+        assert!(note.contains(".bak"));
+    }
+
+    #[test]
+    fn preview_note_for_deep_merge_uses_merge_language_when_shapes_match() {
+        let note = policy_preview_note(
+            "env",
+            &serde_json::json!({"A": "1"}),
+            &serde_json::json!({"B": "2"}),
+        );
+        assert!(note.contains("Deep-merged"));
+        assert!(note.contains("source values override"));
+    }
+
+    #[test]
+    fn preview_note_for_deep_merge_warns_on_shape_mismatch() {
+        // Hand-edited file where env ended up as a string. The nominal
+        // policy is DeepMerge, but the model layer falls back to replace
+        // and the preview must say so.
+        let note = policy_preview_note(
+            "env",
+            &serde_json::json!("oops-not-an-object"),
+            &serde_json::json!({"A": "1"}),
+        );
+        assert!(
+            note.contains("not a JSON object"),
+            "expected shape-mismatch warning, got: {note}"
+        );
+        assert!(note.contains("replaced instead"));
+    }
+
+    #[test]
+    fn preview_note_for_array_union_uses_union_language_when_shapes_match() {
+        let note = policy_preview_note(
+            "allowedHttpHookUrls",
+            &serde_json::json!(["https://a.example"]),
+            &serde_json::json!(["https://b.example"]),
+        );
+        assert!(note.contains("Array-union"));
+        assert!(note.contains("appended"));
+    }
+
+    #[test]
+    fn preview_note_for_array_union_warns_on_shape_mismatch() {
+        let note = policy_preview_note(
+            "allowedHttpHookUrls",
+            &serde_json::json!("not-an-array"),
+            &serde_json::json!(["https://b.example"]),
+        );
+        assert!(
+            note.contains("not a JSON array"),
+            "expected shape-mismatch warning, got: {note}"
+        );
+        assert!(note.contains("replaced instead"));
+    }
+
+    #[test]
+    fn preview_note_for_sandbox_calls_out_complex_semantics() {
+        let note = policy_preview_note(
+            "sandbox",
+            &serde_json::json!({"enabled": false}),
+            &serde_json::json!({"enabled": true}),
+        );
+        assert!(note.contains("Complex"));
+        assert!(note.contains("replaced"));
+    }
+
+    #[test]
+    fn preview_note_for_unknown_key_warns_user() {
+        let note = policy_preview_note(
+            "notARealKey",
+            &serde_json::json!({"a": 1}),
+            &serde_json::json!({"b": 2}),
+        );
+        assert!(note.contains("Unknown key"));
+        assert!(note.contains("replaced"));
     }
 
     #[test]

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -228,7 +228,7 @@ fn ensure_object(value: &mut Value) -> &mut Map<String, Value> {
 /// ClaudeScope produces an effective config consistent with the documented
 /// semantics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KeyPolicy {
+pub(crate) enum KeyPolicy {
     /// Override-only key — Claude Code uses the highest-precedence scope's
     /// value verbatim. Moving overwrites the destination's existing value.
     Replace,
@@ -251,12 +251,15 @@ pub enum KeyPolicy {
 
 /// Documented merge semantics for a top-level Claude Code settings key.
 ///
-/// Sourced from the official Claude Code settings reference. The lists of
-/// override-only keys are exhaustive as of the current docs so that real
-/// keys land on `Replace` rather than the `ReplaceUnknown` warning fallback.
-/// Caller note: `permissions` is handled by the per-rule move flow, not the
-/// key-move flow, and is rejected upstream by `validate_move_key`.
-pub fn key_policy(key: &str) -> KeyPolicy {
+/// `OVERRIDE_ONLY_KEYS` covers the override-only keys from the official
+/// Claude Code settings reference plus a few legacy/project-supported keys
+/// (e.g. `theme`) that this crate's contract advertises in
+/// `CLAUDE.md`. Anything missing falls through to `ReplaceUnknown`, which
+/// shows a "no documented policy" warning rather than silently picking
+/// behavior. Caller note: `permissions` is handled by the per-rule move
+/// flow, not the key-move flow, and is rejected upstream by
+/// `validate_move_key`.
+pub(crate) fn key_policy(key: &str) -> KeyPolicy {
     match key {
         "env" => KeyPolicy::DeepMerge,
         "allowedHttpHookUrls" | "httpHookAllowedEnvVars" => KeyPolicy::ArrayUnion,
@@ -302,6 +305,8 @@ const OVERRIDE_ONLY_KEYS: &[&str] = &[
     "effortLevel",
     "enableAllProjectMcpServers",
     "enabledMcpjsonServers",
+    "enabledPlugins",
+    "extraKnownMarketplaces",
     "fastModePerSessionOptIn",
     "feedbackSurveyRate",
     "fileSuggestion",
@@ -334,6 +339,11 @@ const OVERRIDE_ONLY_KEYS: &[&str] = &[
     "strictKnownMarketplaces",
     "teammateMode",
     "terminalProgressBarEnabled",
+    // `theme` isn't in the current Claude Code settings reference, but this
+    // project's CLAUDE.md and tests advertise it as a supported top-level
+    // key, so users who still carry it in settings.json see Replace rather
+    // than the unknown-key warning.
+    "theme",
     "tui",
     "useAutoModeDuringPlan",
     "viewMode",
@@ -642,6 +652,14 @@ mod tests {
             *doc.get_top_level("hooks").unwrap(),
             serde_json::json!({"PostToolUse": [{"command": "new"}]})
         );
+    }
+
+    #[test]
+    fn project_supported_legacy_keys_resolve_to_replace_not_unknown() {
+        // theme isn't in the current Claude Code settings reference, but
+        // CLAUDE.md and the project tests advertise it as supported, so it
+        // must land on Replace rather than the ReplaceUnknown warning.
+        assert_eq!(key_policy("theme"), KeyPolicy::Replace);
     }
 
     #[test]

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -165,30 +165,37 @@ impl SettingsDoc {
             .is_some()
     }
 
-    /// Merge `value` into the top-level `key` with type-aware semantics:
+    /// Merge `value` into the top-level `key` using the documented Claude
+    /// Code semantics for that key (see [`key_policy`]).
     ///
-    /// - If both the existing and new values are objects, their keys are
-    ///   merged recursively (new values win on conflict for scalars, arrays
-    ///   accumulate with dedup, nested objects recurse).
-    /// - If both are arrays, the new items are appended to the existing
-    ///   array, skipping any that compare equal to an existing element.
-    /// - In any other combination (scalar, or mismatched shapes), the new
-    ///   value replaces whatever was there.
+    /// If the key isn't present yet, the value is inserted unchanged. If the
+    /// key already exists, the policy decides what happens:
     ///
-    /// If `key` didn't exist before, the new value is inserted as-is.
-    ///
-    /// This is a generic, *shape-based* policy: it does not know what each
-    /// key actually means to Claude Code. Some keys may be replacement-only,
-    /// some order-sensitive, some additive in ways that don't match
-    /// "append + dedup". For keys where shape-based merge does not match the
-    /// real semantics, this can silently change meaning. Tracked by
-    /// <https://github.com/bminier/claude-scope/issues/33>.
+    /// - [`KeyPolicy::Replace`] / [`KeyPolicy::ReplaceComplex`] /
+    ///   [`KeyPolicy::ReplaceUnknown`]: the destination is overwritten.
+    /// - [`KeyPolicy::DeepMerge`]: object trees are merged recursively, with
+    ///   source values winning on scalar/non-object conflicts.
+    /// - [`KeyPolicy::ArrayUnion`]: arrays are concatenated with duplicates
+    ///   removed; mismatched shapes fall back to overwrite.
     pub fn merge_top_level(&mut self, key: &str, value: Value) {
+        let policy = key_policy(key);
         let obj = ensure_object(&mut self.root);
-        if let Some(existing) = obj.get_mut(key) {
-            merge_value_in_place(existing, value);
-        } else {
-            obj.insert(key.to_string(), value);
+        match policy {
+            KeyPolicy::Replace | KeyPolicy::ReplaceComplex | KeyPolicy::ReplaceUnknown => {
+                obj.insert(key.to_string(), value);
+            }
+            KeyPolicy::DeepMerge => match obj.get_mut(key) {
+                Some(existing) => deep_merge_in_place(existing, value),
+                None => {
+                    obj.insert(key.to_string(), value);
+                }
+            },
+            KeyPolicy::ArrayUnion => match obj.get_mut(key) {
+                Some(existing) => array_union_in_place(existing, value),
+                None => {
+                    obj.insert(key.to_string(), value);
+                }
+            },
         }
     }
 
@@ -215,21 +222,153 @@ fn ensure_object(value: &mut Value) -> &mut Map<String, Value> {
     value.as_object_mut().expect("just made it an object")
 }
 
-/// Merge `src` into `dest` in place with the shape-aware rules documented
-/// on `SettingsDoc::merge_top_level`. This is the recursive worker: object
-/// nodes merge key-by-key, arrays accumulate with dedup, everything else
-/// overwrites.
-fn merge_value_in_place(dest: &mut Value, src: Value) {
+/// How a top-level settings key should be combined when its value is moved
+/// from one scope into another that already has the same key. Modelled on
+/// how Claude Code itself reads each key across scopes, so that a move in
+/// ClaudeScope produces an effective config consistent with the documented
+/// semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyPolicy {
+    /// Override-only key — Claude Code uses the highest-precedence scope's
+    /// value verbatim. Moving overwrites the destination's existing value.
+    Replace,
+    /// `env` — nested object, deep-merged across scopes by Claude Code, with
+    /// the higher-precedence scope winning on conflicts. Source wins here
+    /// because the move's intent is "make the destination carry this value".
+    DeepMerge,
+    /// Array-valued key whose entries are concatenated and deduplicated
+    /// across scopes (e.g. `allowedHttpHookUrls`).
+    ArrayUnion,
+    /// Known key with complex per-subkey merge semantics that ClaudeScope
+    /// doesn't model yet (currently `sandbox`). Replace-with-warning so the
+    /// user sees the diff and can decide; structured merge is a follow-up.
+    ReplaceComplex,
+    /// Key not in our known-keys table. Conservative replace-with-warning so
+    /// new Claude Code keys still work but the user is told we don't have a
+    /// documented policy for them.
+    ReplaceUnknown,
+}
+
+/// Documented merge semantics for a top-level Claude Code settings key.
+///
+/// Sourced from the official Claude Code settings reference. The lists of
+/// override-only keys are exhaustive as of the current docs so that real
+/// keys land on `Replace` rather than the `ReplaceUnknown` warning fallback.
+/// Caller note: `permissions` is handled by the per-rule move flow, not the
+/// key-move flow, and is rejected upstream by `validate_move_key`.
+pub fn key_policy(key: &str) -> KeyPolicy {
+    match key {
+        "env" => KeyPolicy::DeepMerge,
+        "allowedHttpHookUrls" | "httpHookAllowedEnvVars" => KeyPolicy::ArrayUnion,
+        "sandbox" => KeyPolicy::ReplaceComplex,
+        k if OVERRIDE_ONLY_KEYS.contains(&k) => KeyPolicy::Replace,
+        _ => KeyPolicy::ReplaceUnknown,
+    }
+}
+
+/// Top-level keys documented as override-only (highest-precedence scope
+/// wins; values are not merged across scopes). Kept as a sorted slice so
+/// future additions stay easy to scan and `contains` is fine at this size.
+const OVERRIDE_ONLY_KEYS: &[&str] = &[
+    "agent",
+    "allowManagedHooksOnly",
+    "allowManagedMcpServersOnly",
+    "allowManagedPermissionRulesOnly",
+    "allowedChannelPlugins",
+    "allowedMcpServers",
+    "alwaysThinkingEnabled",
+    "apiKeyHelper",
+    "attribution",
+    "autoMemoryDirectory",
+    "autoMode",
+    "autoScrollEnabled",
+    "autoUpdatesChannel",
+    "availableModels",
+    "awaySummaryEnabled",
+    "awsAuthRefresh",
+    "awsCredentialExport",
+    "blockedMarketplaces",
+    "channelsEnabled",
+    "cleanupPeriodDays",
+    "companyAnnouncements",
+    "defaultShell",
+    "deniedMcpServers",
+    "disableAllHooks",
+    "disableAutoMode",
+    "disableDeepLinkRegistration",
+    "disableSkillShellExecution",
+    "disabledMcpjsonServers",
+    "editorMode",
+    "effortLevel",
+    "enableAllProjectMcpServers",
+    "enabledMcpjsonServers",
+    "fastModePerSessionOptIn",
+    "feedbackSurveyRate",
+    "fileSuggestion",
+    "forceLoginMethod",
+    "forceLoginOrgUUID",
+    "forceRemoteSettingsRefresh",
+    "hooks",
+    "includeCoAuthoredBy",
+    "includeGitInstructions",
+    "language",
+    "minimumVersion",
+    "model",
+    "modelOverrides",
+    "otelHeadersHelper",
+    "outputStyle",
+    "plansDirectory",
+    "pluginTrustMessage",
+    "prefersReducedMotion",
+    "prUrlTemplate",
+    "respectGitignore",
+    "showClearContextOnPlanAccept",
+    "showThinkingSummaries",
+    "showTurnDuration",
+    "skipWebFetchPreflight",
+    "spinnerTipsEnabled",
+    "spinnerTipsOverride",
+    "spinnerVerbs",
+    "sshConfigs",
+    "statusLine",
+    "strictKnownMarketplaces",
+    "teammateMode",
+    "terminalProgressBarEnabled",
+    "tui",
+    "useAutoModeDuringPlan",
+    "viewMode",
+    "voice",
+    "voiceEnabled",
+    "worktree",
+    "wslInheritsWindowsSettings",
+];
+
+/// Recursive object merge: nested objects merge key-by-key, source wins on
+/// any non-object collision. Used for [`KeyPolicy::DeepMerge`] keys.
+fn deep_merge_in_place(dest: &mut Value, src: Value) {
     match (dest, src) {
         (Value::Object(d), Value::Object(s)) => {
             for (k, v) in s {
-                if let Some(existing) = d.get_mut(&k) {
-                    merge_value_in_place(existing, v);
-                } else {
-                    d.insert(k, v);
+                match d.get_mut(&k) {
+                    Some(existing) => deep_merge_in_place(existing, v),
+                    None => {
+                        d.insert(k, v);
+                    }
                 }
             }
         }
+        (dest_slot, src) => {
+            *dest_slot = src;
+        }
+    }
+}
+
+/// Append items from `src` onto `dest`, skipping any that compare equal to
+/// an existing entry. If either side isn't an array, the source replaces
+/// the destination — `merge_top_level`'s preview note tells the user when
+/// this falls back to overwrite behavior. Used for [`KeyPolicy::ArrayUnion`].
+fn array_union_in_place(dest: &mut Value, src: Value) {
+    match (dest, src) {
         (Value::Array(d), Value::Array(s)) => {
             for item in s {
                 if !d.iter().any(|v| v == &item) {
@@ -427,7 +566,8 @@ mod tests {
     }
 
     #[test]
-    fn merge_top_level_object_merges_keys_new_wins() {
+    fn env_uses_deep_merge_with_source_winning() {
+        assert_eq!(key_policy("env"), KeyPolicy::DeepMerge);
         let mut doc = SettingsDoc::from_value(
             serde_json::json!({"env": {"PATH": "/old", "HOME": "/home/a"}}),
             Indent::Spaces(2),
@@ -440,24 +580,67 @@ mod tests {
     }
 
     #[test]
-    fn merge_top_level_array_appends_and_dedupes() {
+    fn env_deep_merge_recurses_into_nested_objects() {
         let mut doc = SettingsDoc::from_value(
-            serde_json::json!({"hooks": ["PreToolUse", "PostToolUse"]}),
+            serde_json::json!({"env": {"group": {"A": "1", "B": "2"}}}),
+            Indent::Spaces(2),
+        );
+        doc.merge_top_level("env", serde_json::json!({"group": {"B": "new", "C": "3"}}));
+        let group = &doc.get_top_level("env").unwrap()["group"];
+        assert_eq!(group["A"], "1");
+        assert_eq!(group["B"], "new");
+        assert_eq!(group["C"], "3");
+    }
+
+    #[test]
+    fn allowed_http_hook_urls_uses_array_union() {
+        assert_eq!(key_policy("allowedHttpHookUrls"), KeyPolicy::ArrayUnion);
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"allowedHttpHookUrls": ["https://a.example", "https://b.example"]}),
             Indent::Spaces(2),
         );
         doc.merge_top_level(
-            "hooks",
-            serde_json::json!(["PostToolUse", "UserPromptSubmit"]),
+            "allowedHttpHookUrls",
+            serde_json::json!(["https://b.example", "https://c.example"]),
         );
-        let hooks = doc.get_top_level("hooks").unwrap();
         assert_eq!(
-            *hooks,
-            serde_json::json!(["PreToolUse", "PostToolUse", "UserPromptSubmit"])
+            *doc.get_top_level("allowedHttpHookUrls").unwrap(),
+            serde_json::json!([
+                "https://a.example",
+                "https://b.example",
+                "https://c.example"
+            ])
         );
     }
 
     #[test]
-    fn merge_top_level_scalar_overwrites() {
+    fn http_hook_allowed_env_vars_uses_array_union() {
+        assert_eq!(key_policy("httpHookAllowedEnvVars"), KeyPolicy::ArrayUnion);
+    }
+
+    #[test]
+    fn hooks_is_override_only_replace_not_deep_merge() {
+        // Regression: pre-#33, the generic shape-based merge would deep-merge
+        // hooks objects across scopes. Claude Code itself reads hooks
+        // override-only, so a move must replace, not merge.
+        assert_eq!(key_policy("hooks"), KeyPolicy::Replace);
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"hooks": {"PreToolUse": [{"command": "old"}]}}),
+            Indent::Spaces(2),
+        );
+        doc.merge_top_level(
+            "hooks",
+            serde_json::json!({"PostToolUse": [{"command": "new"}]}),
+        );
+        assert_eq!(
+            *doc.get_top_level("hooks").unwrap(),
+            serde_json::json!({"PostToolUse": [{"command": "new"}]})
+        );
+    }
+
+    #[test]
+    fn scalar_keys_replace() {
+        assert_eq!(key_policy("model"), KeyPolicy::Replace);
         let mut doc =
             SettingsDoc::from_value(serde_json::json!({"theme": "dark"}), Indent::Spaces(2));
         doc.merge_top_level("theme", serde_json::json!("light"));
@@ -468,33 +651,70 @@ mod tests {
     }
 
     #[test]
-    fn merge_top_level_inserts_when_missing() {
+    fn missing_destination_inserts_value_unchanged() {
         let mut doc = SettingsDoc::empty();
         doc.merge_top_level("env", serde_json::json!({"A": "1"}));
         assert_eq!(doc.get_top_level("env").unwrap()["A"], "1");
+        let mut doc = SettingsDoc::empty();
+        doc.merge_top_level("hooks", serde_json::json!({"PreToolUse": []}));
+        assert_eq!(
+            *doc.get_top_level("hooks").unwrap(),
+            serde_json::json!({"PreToolUse": []})
+        );
     }
 
     #[test]
-    fn merge_top_level_mismatched_shapes_overwrite() {
-        // Existing is a string, new value is an object — shape mismatch, so
-        // the new value replaces the old one rather than trying to coerce.
-        let mut doc =
-            SettingsDoc::from_value(serde_json::json!({"x": "scalar"}), Indent::Spaces(2));
-        doc.merge_top_level("x", serde_json::json!({"nested": true}));
-        assert_eq!(doc.get_top_level("x").unwrap()["nested"], true);
-    }
-
-    #[test]
-    fn merge_recurses_into_nested_objects() {
+    fn sandbox_uses_replace_complex_pending_structured_merge() {
+        // sandbox has per-subkey merge semantics (some arrays union, some
+        // scalars override) that ClaudeScope doesn't model yet. Until then
+        // the destination is replaced wholesale; the user sees this in the
+        // preview note. See the follow-up issue tracked in commands.rs.
+        assert_eq!(key_policy("sandbox"), KeyPolicy::ReplaceComplex);
         let mut doc = SettingsDoc::from_value(
-            serde_json::json!({"env": {"group": {"A": "1", "B": "2"}}}),
+            serde_json::json!({"sandbox": {"enabled": false, "filesystem": {"allowWrite": ["/old"]}}}),
             Indent::Spaces(2),
         );
-        doc.merge_top_level("env", serde_json::json!({"group": {"B": "new", "C": "3"}}));
-        let group = &doc.get_top_level("env").unwrap()["group"];
-        assert_eq!(group["A"], "1");
-        assert_eq!(group["B"], "new");
-        assert_eq!(group["C"], "3");
+        doc.merge_top_level(
+            "sandbox",
+            serde_json::json!({"enabled": true, "filesystem": {"allowWrite": ["/new"]}}),
+        );
+        assert_eq!(
+            *doc.get_top_level("sandbox").unwrap(),
+            serde_json::json!({"enabled": true, "filesystem": {"allowWrite": ["/new"]}})
+        );
+    }
+
+    #[test]
+    fn unknown_keys_replace_with_warning_policy() {
+        assert_eq!(key_policy("notARealKey"), KeyPolicy::ReplaceUnknown);
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"notARealKey": {"existing": true}}),
+            Indent::Spaces(2),
+        );
+        doc.merge_top_level("notARealKey", serde_json::json!({"new": 1}));
+        assert_eq!(
+            *doc.get_top_level("notARealKey").unwrap(),
+            serde_json::json!({"new": 1})
+        );
+    }
+
+    #[test]
+    fn array_union_falls_back_to_replace_on_shape_mismatch() {
+        // If the destination's existing value isn't an array (corrupted or
+        // hand-edited file), array-union has nothing to append to. Source
+        // replaces — the diff preview shows the user what happened.
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"allowedHttpHookUrls": "not-an-array"}),
+            Indent::Spaces(2),
+        );
+        doc.merge_top_level(
+            "allowedHttpHookUrls",
+            serde_json::json!(["https://a.example"]),
+        );
+        assert_eq!(
+            *doc.get_top_level("allowedHttpHookUrls").unwrap(),
+            serde_json::json!(["https://a.example"])
+        );
     }
 
     #[test]

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -344,7 +344,11 @@ const OVERRIDE_ONLY_KEYS: &[&str] = &[
 ];
 
 /// Recursive object merge: nested objects merge key-by-key, source wins on
-/// any non-object collision. Used for [`KeyPolicy::DeepMerge`] keys.
+/// any non-object collision. Used for [`KeyPolicy::DeepMerge`] keys. If
+/// either side isn't an object the source replaces the destination outright;
+/// the move flow's preview note inspects the runtime shapes (see
+/// `policy_preview_note` in `commands.rs`) so the user is warned ahead of
+/// time when this fallback applies.
 fn deep_merge_in_place(dest: &mut Value, src: Value) {
     match (dest, src) {
         (Value::Object(d), Value::Object(s)) => {
@@ -364,9 +368,11 @@ fn deep_merge_in_place(dest: &mut Value, src: Value) {
 }
 
 /// Append items from `src` onto `dest`, skipping any that compare equal to
-/// an existing entry. If either side isn't an array, the source replaces
-/// the destination — `merge_top_level`'s preview note tells the user when
-/// this falls back to overwrite behavior. Used for [`KeyPolicy::ArrayUnion`].
+/// an existing entry. Used for [`KeyPolicy::ArrayUnion`]. If either side
+/// isn't an array the source replaces the destination outright; the move
+/// flow's preview note inspects the runtime shapes (see `policy_preview_note`
+/// in `commands.rs`) so the user is warned ahead of time when this fallback
+/// applies.
 fn array_union_in_place(dest: &mut Value, src: Value) {
     match (dest, src) {
         (Value::Array(d), Value::Array(s)) => {
@@ -695,6 +701,23 @@ mod tests {
         assert_eq!(
             *doc.get_top_level("notARealKey").unwrap(),
             serde_json::json!({"new": 1})
+        );
+    }
+
+    #[test]
+    fn deep_merge_falls_back_to_replace_on_shape_mismatch() {
+        // If the destination's existing value isn't an object (corrupted or
+        // hand-edited file), deep-merge has nothing to recurse into. Source
+        // replaces — the diff preview note flags this so the user isn't
+        // surprised.
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"env": "not-an-object"}),
+            Indent::Spaces(2),
+        );
+        doc.merge_top_level("env", serde_json::json!({"A": "1"}));
+        assert_eq!(
+            *doc.get_top_level("env").unwrap(),
+            serde_json::json!({"A": "1"})
         );
     }
 


### PR DESCRIPTION
## Summary

- Replaces the generic shape-based merge in `merge_top_level` with an explicit `KeyPolicy` table sourced from the official Claude Code settings reference.
- Fixes a silent semantic mismatch where `hooks` (object, but **override-only** per the docs) was being deep-merged across scopes — ClaudeScope could write a merged hooks block whose effective behavior didn't match what Claude Code would actually execute.
- Surfaces the actual per-key merge policy in the move preview note instead of a generic "shape-based policy" disclaimer.

## Policies

| Policy | Keys |
|---|---|
| `Replace` (override-only) | `hooks`, `model`, `theme`, `statusLine`, `apiKeyHelper`, `cleanupPeriodDays`, `editorMode`, `outputStyle`, `language`, `attribution`, `voice`, `agent`, `availableModels`, `modelOverrides`, `respectGitignore`, … (full list in `OVERRIDE_ONLY_KEYS`) |
| `DeepMerge` | `env` (only documented deep-merged key) |
| `ArrayUnion` | `allowedHttpHookUrls`, `httpHookAllowedEnvVars` |
| `ReplaceComplex` | `sandbox` (per-subkey semantics; structured merge will be a follow-up issue) |
| `ReplaceUnknown` | fallback for any key not in the table — replace with a loud preview note so new Claude Code keys still work without silently picking the wrong policy |

## Decisions

- **Unknown-key fallback**: replace-with-warning rather than block. Otherwise the tool would break every time Anthropic ships a new top-level key.
- **`sandbox` in v0.3**: replace-with-warning for now; structured per-subkey merge tracked as a follow-up issue. The current behavior is conservative (user sees the diff, original is preserved in `.bak`) and unblocks closing #33.

Closes #33

## Test plan

- [x] `cargo test --lib` — all 86 tests pass that pass on `dev`. Two `scope::tests::*` failures are pre-existing on `dev` HEAD (filesystem walk hits a real `~/.claude` on the dev box), unrelated to this change.
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `npm run lint` and `npm run build` clean
- [ ] Manual smoke: launch app, move `hooks` from one scope to another that already has `hooks`; preview note should say "Override-only key … will be replaced"; destination `hooks` should be the source value (not deep-merged)
- [ ] Manual smoke: move `env` between scopes; preview note should say "Deep-merged key …"; destination should contain union of keys with source winning on conflict
- [ ] Manual smoke: move an unknown/typo key; preview note should call it out as unknown

🤖 Generated with [Claude Code](https://claude.com/claude-code)