### PR TITLE
feat(ui): scope-origin tooltip on permission rules (#82)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -298,7 +298,13 @@ fn accumulate(
 ) {
     for rule in incoming {
         if let Some(existing) = out_rules.iter().position(|r| r == rule) {
-            out_origins[existing].push(scope);
+            // Guard against the same scope file listing the rule twice
+            // (legal JSON, possible after hand-editing): without this check
+            // the tooltip would render "Local, Local, User" instead of
+            // "Local, User". `contains` is O(scopes) and scopes maxes at 4.
+            if !out_origins[existing].contains(&scope) {
+                out_origins[existing].push(scope);
+            }
         } else {
             out_rules.push(rule.clone());
             out_origins.push(vec![scope]);
@@ -1213,6 +1219,44 @@ mod tests {
         assert_eq!(origins.allow[2], vec![Scope::User]);
         assert!(origins.deny.is_empty());
         assert!(origins.ask.is_empty());
+    }
+
+    #[test]
+    fn combined_origins_dedupe_repeated_rule_within_one_scope() {
+        // A single settings file can legally contain the same rule string
+        // more than once after hand-editing. The combined rule list
+        // already de-dupes (via the cross-scope position check), but the
+        // origins list must also collapse same-scope repeats so the
+        // tooltip doesn't render "Local, Local, User".
+        let views = vec![
+            ScopeView {
+                scope: Scope::Local,
+                path: None,
+                exists: true,
+                permissions: PermissionRules {
+                    allow: vec!["Bash(git status)".into(), "Bash(git status)".into()],
+                    deny: vec![],
+                    ask: vec![],
+                },
+                other_values: serde_json::Map::new(),
+                parse_error: None,
+            },
+            ScopeView {
+                scope: Scope::User,
+                path: None,
+                exists: true,
+                permissions: PermissionRules {
+                    allow: vec!["Bash(git status)".into()],
+                    deny: vec![],
+                    ask: vec![],
+                },
+                other_values: serde_json::Map::new(),
+                parse_error: None,
+            },
+        ];
+        let (combined, origins) = combined_permissions(&views);
+        assert_eq!(combined.allow, vec!["Bash(git status)"]);
+        assert_eq!(origins.allow[0], vec![Scope::Local, Scope::User]);
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -38,6 +38,21 @@ pub struct LoadedScopes {
     pub project_dir: String,
     pub scopes: Vec<ScopeView>,
     pub combined_permissions: PermissionRules,
+    /// Parallel to `combined_permissions`: for each rule in
+    /// `allow`/`deny`/`ask`, the list of scopes that contribute that rule, in
+    /// precedence order (highest first). Drives the front-end's
+    /// scope-origin tooltip on combined rule rows.
+    pub combined_origins: PermissionRuleOrigins,
+}
+
+/// Per-rule provenance for the combined permissions view: for each rule in
+/// the parallel `PermissionRules` array (same kind, same index), the scopes
+/// that contributed it, in precedence order.
+#[derive(Debug, Default, Serialize)]
+pub struct PermissionRuleOrigins {
+    pub allow: Vec<Vec<Scope>>,
+    pub deny: Vec<Vec<Scope>>,
+    pub ask: Vec<Vec<Scope>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -197,12 +212,13 @@ fn build_loaded(paths: &ScopePaths) -> Result<LoadedScopes, Box<dyn std::error::
         views.push(load_scope_view(scope, paths.path_for(scope)));
     }
 
-    let combined = combined_permissions(&views);
+    let (combined, origins) = combined_permissions(&views);
 
     Ok(LoadedScopes {
         project_dir: paths.project_dir.display().to_string(),
         scopes: views,
         combined_permissions: combined,
+        combined_origins: origins,
     })
 }
 
@@ -244,26 +260,50 @@ fn load_scope_view(scope: Scope, path: Option<&Path>) -> ScopeView {
 /// what the panel shows; modelling Claude Code's full conflict semantics is
 /// out of scope for v1 and would require grammar Claude Code does not
 /// publicly document.
-fn combined_permissions(views: &[ScopeView]) -> PermissionRules {
-    let mut out = PermissionRules::default();
+fn combined_permissions(views: &[ScopeView]) -> (PermissionRules, PermissionRuleOrigins) {
+    let mut rules = PermissionRules::default();
+    let mut origins = PermissionRuleOrigins::default();
+    // `views` is built from `Scope::ALL`, which iterates in precedence order
+    // (highest first), so an `origins` Vec built by appending in iteration
+    // order naturally lists contributing scopes highest-first too — matching
+    // the tooltip's documented order.
     for view in views {
-        for rule in &view.permissions.allow {
-            if !out.allow.iter().any(|r| r == rule) {
-                out.allow.push(rule.clone());
-            }
-        }
-        for rule in &view.permissions.deny {
-            if !out.deny.iter().any(|r| r == rule) {
-                out.deny.push(rule.clone());
-            }
-        }
-        for rule in &view.permissions.ask {
-            if !out.ask.iter().any(|r| r == rule) {
-                out.ask.push(rule.clone());
-            }
+        accumulate(
+            &view.permissions.allow,
+            view.scope,
+            &mut rules.allow,
+            &mut origins.allow,
+        );
+        accumulate(
+            &view.permissions.deny,
+            view.scope,
+            &mut rules.deny,
+            &mut origins.deny,
+        );
+        accumulate(
+            &view.permissions.ask,
+            view.scope,
+            &mut rules.ask,
+            &mut origins.ask,
+        );
+    }
+    (rules, origins)
+}
+
+fn accumulate(
+    incoming: &[String],
+    scope: Scope,
+    out_rules: &mut Vec<String>,
+    out_origins: &mut Vec<Vec<Scope>>,
+) {
+    for rule in incoming {
+        if let Some(existing) = out_rules.iter().position(|r| r == rule) {
+            out_origins[existing].push(scope);
+        } else {
+            out_rules.push(rule.clone());
+            out_origins.push(vec![scope]);
         }
     }
-    out
 }
 
 fn diff_move_impl(
@@ -1058,7 +1098,7 @@ mod tests {
                 parse_error: None,
             },
         ];
-        let combined = combined_permissions(&views);
+        let (combined, _origins) = combined_permissions(&views);
         assert_eq!(combined.allow, vec!["Bash(git status)", "Read(**)"]);
         assert_eq!(combined.deny, vec!["WebFetch(domain:evil.example)"]);
         assert!(combined.ask.is_empty());
@@ -1098,10 +1138,81 @@ mod tests {
                 parse_error: None,
             },
         ];
-        let combined = combined_permissions(&views);
+        let (combined, _origins) = combined_permissions(&views);
         assert_eq!(combined.allow, vec!["Bash(git push)"]);
         assert_eq!(combined.deny, vec!["Bash(git push)"]);
         assert!(combined.ask.is_empty());
+    }
+
+    #[test]
+    fn combined_origins_list_contributing_scopes_in_precedence_order() {
+        // A rule that appears in three scopes should surface all three in
+        // origins, ordered highest-precedence first (Local before
+        // UserLocal before User). A rule unique to one scope lists only
+        // that scope. Locks down the contract the front-end tooltip relies
+        // on.
+        let views = vec![
+            ScopeView {
+                scope: Scope::Local,
+                path: None,
+                exists: true,
+                permissions: PermissionRules {
+                    allow: vec!["Bash(git status)".into(), "Read(**)".into()],
+                    deny: vec![],
+                    ask: vec![],
+                },
+                other_values: serde_json::Map::new(),
+                parse_error: None,
+            },
+            ScopeView {
+                scope: Scope::Project,
+                path: None,
+                exists: true,
+                permissions: PermissionRules::default(),
+                other_values: serde_json::Map::new(),
+                parse_error: None,
+            },
+            ScopeView {
+                scope: Scope::UserLocal,
+                path: None,
+                exists: true,
+                permissions: PermissionRules {
+                    allow: vec!["Bash(git status)".into()],
+                    deny: vec![],
+                    ask: vec![],
+                },
+                other_values: serde_json::Map::new(),
+                parse_error: None,
+            },
+            ScopeView {
+                scope: Scope::User,
+                path: None,
+                exists: true,
+                permissions: PermissionRules {
+                    allow: vec!["Bash(git status)".into(), "Bash(ls)".into()],
+                    deny: vec![],
+                    ask: vec![],
+                },
+                other_values: serde_json::Map::new(),
+                parse_error: None,
+            },
+        ];
+        let (combined, origins) = combined_permissions(&views);
+        assert_eq!(
+            combined.allow,
+            vec!["Bash(git status)", "Read(**)", "Bash(ls)"]
+        );
+        // Same rule across Local + UserLocal + User, in precedence order.
+        assert_eq!(
+            origins.allow[0],
+            vec![Scope::Local, Scope::UserLocal, Scope::User]
+        );
+        // Rule only in Local.
+        assert_eq!(origins.allow[1], vec![Scope::Local]);
+        // Rule only in User.
+        assert_eq!(origins.allow[2], vec![Scope::User]);
+        assert!(origins.deny.is_empty());
+        assert!(origins.ask.is_empty());
     }
 
     #[test]

--- a/src/styles.css
+++ b/src/styles.css
@@ -798,6 +798,91 @@ button:disabled {
   pointer-events: auto;
 }
 
+/* Scope-origin tooltip (issue #82). Wraps every permission-rule chip so
+   hovering or keyboard-focusing the chip reveals which scope(s) the rule
+   originates from. Reuses the lint-warn popover visuals so the two hover
+   surfaces feel like the same family of affordance. */
+.rule-origin-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Inside `.rule` (per-scope columns), the wrapper takes over `.rule-text`'s
+   former role as the flex-grow child so the chip still fills the row and
+   ellipsis-truncates. The chip inside re-receives `flex:1` so the wrap
+   doesn't collapse around the rule string. */
+.rule > .rule-origin-wrap {
+  flex: 1;
+  min-width: 0;
+}
+.rule > .rule-origin-wrap > .rule-text {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Make the chip's keyboard focus state visible without an outline-jolt. */
+.rule-origin-wrap > .chip:focus-visible,
+.rule-origin-wrap > .rule-text:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-radius: 4px;
+}
+
+.rule-origin-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 30;
+  min-width: 180px;
+  max-width: 280px;
+  padding: 8px 10px;
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  font-size: 12px;
+  line-height: 1.35;
+  white-space: normal;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 120ms ease,
+    visibility 120ms ease;
+}
+
+.rule-origin-popover-heading {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+
+.rule-origin-popover-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.rule-origin-popover-list li {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.rule-origin-wrap:hover > .rule-origin-popover,
+.rule-origin-wrap:focus-within > .rule-origin-popover {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
 /* Settings dialog — reuses `.modal` shell with a different body layout.
    The modal defaults to a wide 2-column diff for moves; the settings
    body is narrower and vertical, so size + padding are tuned here. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,12 +37,22 @@ export interface PermissionRules {
   ask: string[];
 }
 
+// Parallel to PermissionRules: for each rule at the same kind/index in
+// `combined_permissions`, the scopes that contribute it, in precedence order
+// (highest first). Drives the scope-origin tooltip on combined rule rows.
+export interface PermissionRuleOrigins {
+  allow: Scope[][];
+  deny: Scope[][];
+  ask: Scope[][];
+}
+
 export type PermissionKind = "allow" | "deny" | "ask";
 
 export interface LoadedScopes {
   project_dir: string;
   scopes: ScopeView[];
   combined_permissions: PermissionRules;
+  combined_origins: PermissionRuleOrigins;
 }
 
 export interface MoveRequest {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -234,8 +234,19 @@ function combinedPanel(loaded: LoadedScopes, query: string, lowerQuery: string):
   const kinds: PermissionKind[] = ["allow", "deny", "ask"];
   for (const kind of kinds) {
     const all = loaded.combined_permissions[kind];
-    // Fast path when the filter is empty — no allocation, no iteration.
-    const matched = lowerQuery === "" ? all : all.filter((r) => matchesLoweredQuery(r, lowerQuery));
+    const allOrigins = loaded.combined_origins[kind];
+    // Iterate `all` by index so each chip can pull its parallel origin
+    // entry. Track match count separately for the "(m/n)" label without
+    // building a filtered copy.
+    let matchedCount = 0;
+    const isFiltering = lowerQuery !== "";
+    if (!isFiltering) {
+      matchedCount = all.length;
+    } else {
+      for (const rule of all) {
+        if (matchesLoweredQuery(rule, lowerQuery)) matchedCount++;
+      }
+    }
     const group = document.createElement("div");
     group.className = `combo-group combo-${kind}`;
     const label = document.createElement("span");
@@ -246,9 +257,11 @@ function combinedPanel(loaded: LoadedScopes, query: string, lowerQuery: string):
     label.textContent =
       query === "" || all.length === 0
         ? `${KIND_LABELS[kind]} (${all.length})`
-        : `${KIND_LABELS[kind]} (${matched.length}/${all.length})`;
+        : `${KIND_LABELS[kind]} (${matchedCount}/${all.length})`;
     group.appendChild(label);
-    for (const rule of matched) {
+    for (let i = 0; i < all.length; i++) {
+      const rule = all[i];
+      if (isFiltering && !matchesLoweredQuery(rule, lowerQuery)) continue;
       // Chip + optional badge wrap as a single flex item. Originally added
       // because `.combo-group` used `flex-wrap: wrap` (badges could orphan to
       // a new line without their chip); the group is now a vertical stack,
@@ -259,7 +272,8 @@ function combinedPanel(loaded: LoadedScopes, query: string, lowerQuery: string):
       const chip = document.createElement("code");
       chip.className = "chip";
       chip.textContent = rule;
-      chipWrap.appendChild(chip);
+      const originWrap = wrapWithOriginTooltip(chip, allOrigins[i] ?? []);
+      chipWrap.appendChild(originWrap);
       const badge = lintBadge(rule);
       if (badge) chipWrap.appendChild(badge);
       group.appendChild(chipWrap);
@@ -339,6 +353,54 @@ function lintBadge(rule: string): HTMLElement | null {
   wrap.appendChild(pop);
   return wrap;
 }
+
+/**
+ * Wrap a rule chip so it carries a hover/focus tooltip listing the scope(s)
+ * the rule originates from. Returns a positioned wrapper that should be
+ * inserted in place of the bare chip; the chip itself is appended inside.
+ *
+ * `scopes` is expected in precedence order (highest first); for combined
+ * rule rows that's all contributing scopes, for per-scope rule rows it's
+ * just that one scope. The chip is given `tabindex=0` so keyboard users
+ * can reveal the tooltip without a pointer (issue #82's a11y AC).
+ */
+function wrapWithOriginTooltip(chip: HTMLElement, scopes: Scope[]): HTMLElement {
+  const wrap = document.createElement("span");
+  wrap.className = "rule-origin-wrap";
+  wrap.appendChild(chip);
+  if (scopes.length === 0) {
+    // No origin data — render the wrap shell only so the layout stays
+    // consistent. Skip the popover and tabindex/aria wiring entirely so
+    // we don't introduce a focus stop with nothing behind it.
+    return wrap;
+  }
+  chip.tabIndex = 0;
+  const popoverId = `rule-origin-${++ruleOriginPopoverSeq}`;
+  chip.setAttribute("aria-describedby", popoverId);
+
+  const pop = document.createElement("span");
+  pop.id = popoverId;
+  pop.className = "rule-origin-popover";
+  pop.setAttribute("role", "tooltip");
+
+  const heading = document.createElement("span");
+  heading.className = "rule-origin-popover-heading";
+  heading.textContent = scopes.length === 1 ? "Defined in" : "Defined in (precedence order)";
+  pop.appendChild(heading);
+
+  const list = document.createElement("ul");
+  list.className = "rule-origin-popover-list";
+  for (const scope of scopes) {
+    const li = document.createElement("li");
+    li.textContent = SCOPE_LABELS[scope];
+    list.appendChild(li);
+  }
+  pop.appendChild(list);
+  wrap.appendChild(pop);
+  return wrap;
+}
+
+let ruleOriginPopoverSeq = 0;
 
 // Pinned-popover state. Hover/focus reveals are handled purely in CSS; this
 // state only tracks popovers that the user clicked to keep open.
@@ -768,7 +830,10 @@ function ruleRow(scope: Scope, kind: PermissionKind, rule: string, props: AppPro
   if (!props.busy) {
     setupRuleDragSource(code, rule, kind, scope);
   }
-  row.appendChild(code);
+  // Per-scope rule rows share the same tooltip helper as the combined
+  // panel for consistency (issue #82). Origins is just `[scope]` here
+  // since the rule lives in exactly this scope's file.
+  row.appendChild(wrapWithOriginTooltip(code, [scope]));
 
   const badge = lintBadge(rule);
   if (badge) row.appendChild(badge);


### PR DESCRIPTION
## Summary
- Hovering or keyboard-focusing an `allow`/`deny`/`ask` rule now reveals a tooltip listing the scope(s) the rule originates from, in precedence order (highest first).
- Backend tracks per-rule provenance through `combined_origins`, a parallel structure to `combined_permissions` shaped as `{allow: Scope[][], deny: Scope[][], ask: Scope[][]}` — so rule strings stay unchanged on the wire and the move flow is unaffected.
- Frontend wraps every rule chip in a focusable `.rule-origin-wrap` and reuses the existing lint-warn popover visuals so the two hover surfaces feel like the same family of affordance. The chip gets `tabindex=0` + `aria-describedby`, satisfying the keyboard-accessibility AC.
- Per-scope columns get the tooltip too. A single-scope tooltip is redundant with column position, but keeping the affordance consistent across all rule rows matches the issue's notes and avoids inventing a second focus pattern.

Closes #82.

## Test plan
- [x] `cargo test` (passes; two pre-existing `scope::tests` failures on Brian's Windows box are environment-only — `~/.claude/` hijacks `find_project_root`'s walk-up — and unrelated to this change. CI Linux/macOS will run them clean.)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `npm run lint` (biome)
- [x] `npm run build` (vite)
- [x] Manual: hover and tab-focus rule chips in the combined panel for a project with rules in multiple scopes; confirm tooltip lists all contributing scopes in precedence order
- [x] Manual: same in per-scope columns; confirm tooltip lists just that scope
- [x] Manual: drag-and-drop of rule chips still works (chip is the drag source; tabindex doesn't interfere)