### PR TITLE
feat(ui): drop commits the move without confirmation popup (#70)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import type {
   LoadedScopes,
   MoveKeyPreview,
   MoveKeyRequest,
+  MoveOptions,
   MovePreview,
   MoveRequest,
   Preferences,
@@ -96,25 +97,35 @@ async function reload(): Promise<void> {
   await load(state.projectDir);
 }
 
-async function moveRule(req: MoveRequest, trigger?: HTMLElement): Promise<void> {
+async function moveRule(
+  req: MoveRequest,
+  trigger?: HTMLElement,
+  opts?: MoveOptions,
+): Promise<void> {
   if (moveInFlight) return;
   moveInFlight = true;
   try {
     const projectDir = state.projectDir;
-    // Intentionally *don't* flip state.busy / re-render before diff_move:
-    // it's fast, the modal itself blocks interaction once open, and keeping
-    // the triggering button alive lets confirmMove restore focus to it on
-    // Cancel/Esc.
-    let preview: MovePreview;
-    try {
-      preview = await invoke<MovePreview>("diff_move", { req, project_dir: projectDir });
-    } catch (err) {
-      alert(`Move failed: ${err}`);
-      return;
-    }
+    // Drag-and-drop drops set `skipConfirm`: the user already expressed
+    // intent by dragging onto a target column, so the diff/confirm modal
+    // becomes friction (#70). Click-to-move stays gated on the modal as
+    // the safer default for the less-explicit click gesture.
+    if (!opts?.skipConfirm) {
+      // Intentionally *don't* flip state.busy / re-render before diff_move:
+      // it's fast, the modal itself blocks interaction once open, and keeping
+      // the triggering button alive lets confirmMove restore focus to it on
+      // Cancel/Esc.
+      let preview: MovePreview;
+      try {
+        preview = await invoke<MovePreview>("diff_move", { req, project_dir: projectDir });
+      } catch (err) {
+        alert(`Move failed: ${err}`);
+        return;
+      }
 
-    const apply = await confirmMove(preview, trigger);
-    if (!apply) return;
+      const apply = await confirmMove(preview, trigger);
+      if (!apply) return;
+    }
 
     state.busy = true;
     render();
@@ -142,21 +153,29 @@ async function moveRule(req: MoveRequest, trigger?: HTMLElement): Promise<void> 
   }
 }
 
-async function moveKey(req: MoveKeyRequest, trigger?: HTMLElement): Promise<void> {
+async function moveKey(
+  req: MoveKeyRequest,
+  trigger?: HTMLElement,
+  opts?: MoveOptions,
+): Promise<void> {
   if (moveInFlight) return;
   moveInFlight = true;
   try {
     const projectDir = state.projectDir;
-    let preview: MoveKeyPreview;
-    try {
-      preview = await invoke<MoveKeyPreview>("diff_move_key", { req, project_dir: projectDir });
-    } catch (err) {
-      alert(`Move failed: ${err}`);
-      return;
-    }
+    // Same skip-confirm contract as moveRule (#70): drops bypass the
+    // diff/confirm modal because dragging already expresses intent.
+    if (!opts?.skipConfirm) {
+      let preview: MoveKeyPreview;
+      try {
+        preview = await invoke<MoveKeyPreview>("diff_move_key", { req, project_dir: projectDir });
+      } catch (err) {
+        alert(`Move failed: ${err}`);
+        return;
+      }
 
-    const apply = await confirmMoveKey(preview, trigger);
-    if (!apply) return;
+      const apply = await confirmMoveKey(preview, trigger);
+      if (!apply) return;
+    }
 
     state.busy = true;
     render();

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,18 @@ export interface MoveRequest {
   to: Scope;
 }
 
+/**
+ * Caller hints for `onMove` / `onMoveKey`. Drop handlers pass
+ * `skipConfirm: true` because dragging onto a target column already
+ * expresses intent — the diff/confirm modal is friction at that point.
+ * Click-to-move keeps the modal as the safer default for less explicit
+ * gestures. Recovery on accidental drops still falls back to the
+ * per-write `.bak` files until an audit log / undo lands (#19).
+ */
+export interface MoveOptions {
+  skipConfirm?: boolean;
+}
+
 export interface MoveSide {
   scope: Scope;
   path: string;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -5,6 +5,7 @@ import type {
   MoveKeyPreview,
   MoveKeyRequest,
   MoveKeySide,
+  MoveOptions,
   MovePreview,
   MoveRequest,
   MoveSide,
@@ -23,8 +24,8 @@ interface AppProps {
   preferences: Preferences;
   onPickProject: () => void;
   onReload: () => void;
-  onMove: (req: MoveRequest, trigger?: HTMLElement) => void;
-  onMoveKey: (req: MoveKeyRequest, trigger?: HTMLElement) => void;
+  onMove: (req: MoveRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
+  onMoveKey: (req: MoveKeyRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
   onOpenSettings: (trigger?: HTMLElement) => void;
   onQueryChange: (next: string) => void;
 }
@@ -720,15 +721,24 @@ function scopeColumn(view: ScopeView, props: AppProps, lowerQuery: string): HTML
     col.classList.remove("col-drop-active");
     if (!dragSource || dragSource.from === view.scope || props.busy) return;
     const src = dragSource;
-    // Clear the singleton before dispatching the move — onMove can open a
-    // modal synchronously, and we don't want a stale `dragSource` lingering
-    // through the user's confirm interaction.
+    // Clear the singleton before dispatching the move so a stale
+    // `dragSource` doesn't linger past the dispatch.
     dragSource = null;
     const trigger = src.el.isConnected ? src.el : undefined;
+    // Drop on a target column expresses intent unambiguously, so skip the
+    // diff/confirm modal (#70). Click-to-move keeps the modal as the
+    // safer default for the less-explicit click gesture. The
+    // per-destination `.bak` is the recovery path until an audit log /
+    // undo lands (#19).
+    const opts: MoveOptions = { skipConfirm: true };
     if (src.kind === "rule") {
-      props.onMove({ rule: src.rule, kind: src.ruleKind, from: src.from, to: view.scope }, trigger);
+      props.onMove(
+        { rule: src.rule, kind: src.ruleKind, from: src.from, to: view.scope },
+        trigger,
+        opts,
+      );
     } else {
-      props.onMoveKey({ key: src.key, from: src.from, to: view.scope }, trigger);
+      props.onMoveKey({ key: src.key, from: src.from, to: view.scope }, trigger, opts);
     }
   });
 


### PR DESCRIPTION
## Summary
- Drag-and-drop drops now commit the move directly — no diff/confirm modal. Click-to-move move-buttons keep the modal as the safer default for the less-explicit click gesture.
- Implements **option 1** from issue #70 (\"auto-commit on drop\"), which the issue calls out as the cleanest of the three options.
- New `MoveOptions { skipConfirm?: boolean }` is threaded from the drop handler in `scopeColumn` through `onMove`/`onMoveKey` to `moveRule`/`moveKey`. When set, both the `diff_move` IPC and `confirmMove` modal are skipped; `apply_move` does the same validation atomically and surfaces errors via the existing alert path.

Closes #70.

## Trade-off
Without an audit log / undo (#19), accidental drops can't be undone in-app. Recovery still falls back to the per-write `.bak` file the move flow already creates next to each touched settings file. If that's too hot, option 2 (\"don't ask again\" preference checkbox) is a one-PR retreat.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint` (biome)
- [x] `npm run build` (vite)
- [x] `cargo test -- --skip scope::` (101 passing; the two skipped scope tests are pre-existing env failures on Brian's Windows box, unrelated to this change)
- [ ] Manual: drag a rule chip across columns — move applies immediately, no modal
- [ ] Manual: drag a top-level key (env, hooks, theme) across columns — same
- [ ] Manual: click → move-button still opens the diff/confirm modal
- [ ] Manual: drop a rule onto a column whose backing file would 409 (e.g. concurrent external edit) — error alert surfaces, source side untouched