### PR TITLE
feat(sandbox): --home / --project overrides for scratch dogfooding (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,41 @@ npm install
 npm run tauri dev
 ```
 
+### Testing safely (sandbox / scratch home)
+
+Running ClaudeScope against your real `~/.claude/` while developing risks corrupting your actual Claude Code settings if a write path regresses. Two ways to dogfood without that risk (#66):
+
+#### `--home` / `--project` flags + `CLAUDE_SCOPE_*` env vars
+
+Override scope discovery so all "user" / "user-local" lookups root at a throwaway directory instead of your real `$HOME` / `%USERPROFILE%`. The current project root can be pinned with `--project` (otherwise the front-end picker / cwd walk-up behave normally).
+
+For `npm run tauri dev`, **use the env vars** — the npm → tauri-cli → cargo chain mangles `--` separators and tauri-cli forwards trailing args as cargo flags (so `cargo run --home …` errors out). Env vars sidestep the whole chain. CLI flags work fine against a built binary.
+
+```sh
+# Dev build (Linux / macOS):
+CLAUDE_SCOPE_HOME=/tmp/scratch CLAUDE_SCOPE_PROJECT=/tmp/scratch/project npm run tauri dev
+
+# Dev build (Windows PowerShell):
+$env:CLAUDE_SCOPE_HOME = "$env:TEMP\cs-scratch"
+$env:CLAUDE_SCOPE_PROJECT = "$env:TEMP\cs-scratch\project"
+npm run tauri dev
+
+# Built binary — CLI flags:
+claude-scope --home /tmp/scratch --project /tmp/scratch/project
+```
+
+When either override is active, a yellow **Sandbox mode** banner sits under the toolbar showing the active paths, so you can't forget you're in scratch mode. The picker still works — `--home` keeps redirecting user-scope writes regardless of which project you switch to mid-session.
+
+#### `scripts/scratch-home.py`
+
+One-shot helper that seeds a fresh scratch dir with realistic example settings (allow / deny / ask rules across all four scopes, plus `env` / `hooks` / `theme` blocks so the move-key flow has data) and prints the launch command.
+
+```sh
+python scripts/scratch-home.py            # seeds a temp dir, prints launch line
+python scripts/scratch-home.py /tmp/sb    # seeds /tmp/sb explicitly, idempotent
+python scripts/scratch-home.py /tmp/sb --force   # wipe + reseed
+```
+
 ### Tests
 
 ```sh

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -11,9 +11,28 @@ reviewer.
    ```sh
    npm install
    ```
-2. Point at a throwaway `.claude/` to avoid mutating your real config.
-   Pick any temp directory you don't mind deleting; the examples use
-   `/tmp/cs-smoke` on macOS / Linux and `$env:TEMP\cs-smoke` on Windows.
+2. **Recommended:** seed a sandbox tree with the helper script and launch
+   ClaudeScope against it. The `--home` override (#66) redirects User /
+   User-Local writes away from your real `~/.claude/`, so every move is
+   safe regardless of which target column you pick.
+
+   ```sh
+   python scripts/scratch-home.py
+   # → prints the exact env-var + npm command for your shell.
+   ```
+
+   For `npm run tauri dev`, use the env-var form (`CLAUDE_SCOPE_HOME` /
+   `CLAUDE_SCOPE_PROJECT`) — passing CLI flags through `npm`/`cargo run`
+   doesn't survive the arg-passing chain. CLI flags work against a built
+   binary. When the app launches, a yellow **Sandbox mode** banner sits
+   under the toolbar showing the active scratch paths.
+
+3. **Alternative (no sandbox flags):** if you're testing the non-sandbox
+   bootstrap path, point at a throwaway `.claude/` for the *project*
+   scope by hand and accept that User / User-Local writes hit your real
+   home. Either back those up (`cp ~/.claude/settings.json{,.smoke.bak}`),
+   or open **Settings** after launch and hide the User + User-Local
+   columns so the only available move targets are Project ↔ Local.
 
    **macOS / Linux (bash):**
    ```sh
@@ -22,6 +41,8 @@ reviewer.
      > /tmp/cs-smoke/.claude/settings.json
    echo '{"permissions":{"allow":["WebFetch(domain:example.com)"]}}' \
      > /tmp/cs-smoke/.claude/settings.local.json
+   npm run tauri dev
+   # → Open project… → pick /tmp/cs-smoke
    ```
 
    **Windows (PowerShell):**
@@ -35,26 +56,9 @@ reviewer.
      | Set-Content -Encoding utf8 "$proj\.claude\settings.json"
    '{"permissions":{"allow":["WebFetch(domain:example.com)"]}}' `
      | Set-Content -Encoding utf8 "$proj\.claude\settings.local.json"
-   ```
-3. Launch the dev build:
-   ```sh
    npm run tauri dev
+   # → Open project… → pick $env:TEMP\cs-smoke
    ```
-4. Click **Open project…** → pick the throwaway dir from step 2.
-
-> ⚠ **User-scope safety.** Moves targeting the **User** or
-> **User-Local** columns write to your real `~/.claude/` — the throwaway
-> project only isolates the Project / Local scopes. Either back those
-> files up first (e.g. `cp ~/.claude/settings.json{,.smoke.bak}`), or
-> after launch open **Settings** and hide the User + User-Local columns
-> so you can only move between Project ↔ Local. The app's own one-shot
-> `.bak` covers the *first* mutation per file per session, but not
-> subsequent ones in the same run.
-
-> Reminder: a real `~/.claude/settings.json` will be read regardless. If
-> you want the User column visibly populated, drop a couple of throwaway
-> entries there; otherwise expect User / User-Local to show
-> `(file not present)`.
 
 ## Golden path
 
@@ -139,6 +143,27 @@ After exercising the moves above, in the throwaway `.claude/` dir:
 - [ ] **No leftover tempfiles.** No `*.tmp*` / `.settings.json.swp`-style
       siblings — the atomic write should rename the temp into place and
       leave nothing behind on success.
+
+## Sandbox mode (only when launched with `--home` / `--project`)
+
+Skip this section if you set up via the "Alternative" path. Run when you
+launched via `scripts/scratch-home.py` so the sandbox plumbing is exercised.
+
+- [ ] **Banner present.** Yellow **Sandbox mode** banner sits directly
+      under the toolbar, listing both `home: <path>` and
+      `project: <path>` from the launch flags.
+- [ ] **User-scope writes land in the sandbox.** Move a rule from Project
+      to User. The destination column updates as expected, and the new
+      file is `<sandbox-home>/.claude/settings.json` — *not* your real
+      `~/.claude/settings.json`. (Confirm by inspecting both paths after
+      the move.)
+- [ ] **Real home is untouched.** After several moves across all four
+      scopes, `~/.claude/settings.json` and `~/.claude/settings.local.json`
+      have unchanged mtimes (compare against a `stat` taken before launch).
+- [ ] **Picker still works under `--home`.** Click **Open project…** and
+      pick a different directory. The Project + Local columns retarget,
+      but the banner still shows the original `home:` path and User /
+      User-Local stay rooted in the sandbox.
 
 ## When you're done
 

--- a/scripts/scratch-home.py
+++ b/scripts/scratch-home.py
@@ -192,9 +192,13 @@ def main() -> int:
         print(f'    $env:CLAUDE_SCOPE_PROJECT = "{project}"')
         print("    npm run tauri dev")
         print()
+        # cmd.exe: wrap the whole NAME=VALUE in double quotes so spaces in
+        # the dest path don't get split into separate tokens. The `set
+        # "VAR=value"` form is the canonical cmd-safe spelling — the outer
+        # quotes are stripped by `set` and never end up in the variable.
         print("    # Dev build (cmd.exe):")
-        print(f'    set CLAUDE_SCOPE_HOME={dest}')
-        print(f'    set CLAUDE_SCOPE_PROJECT={project}')
+        print(f'    set "CLAUDE_SCOPE_HOME={dest}"')
+        print(f'    set "CLAUDE_SCOPE_PROJECT={project}"')
         print("    npm run tauri dev")
     else:
         print("    # Dev build:")
@@ -203,8 +207,13 @@ def main() -> int:
             f"CLAUDE_SCOPE_PROJECT='{project}' npm run tauri dev"
         )
     print()
+    # Quote the path arguments for the same reason — a built binary call
+    # `claude-scope --home C:\path with spaces\X` would otherwise split.
     print("    # Built binary (CLI flags):")
-    print(f"    claude-scope --home {dest} --project {project}")
+    if sys.platform == "win32":
+        print(f'    claude-scope --home "{dest}" --project "{project}"')
+    else:
+        print(f"    claude-scope --home '{dest}' --project '{project}'")
     return 0
 
 

--- a/scripts/scratch-home.py
+++ b/scripts/scratch-home.py
@@ -28,8 +28,8 @@ preserves anything else under `<dest>` (your hand-edits, .bak trail from
 the last run, etc.). Pass `--force` to wipe `<dest>/.claude` and
 `<dest>/project/.claude` before reseeding.
 
-Why Python: Brian's global preference is portable scripts so the same file
-runs on Windows / macOS / Linux without dragging shell quirks into the repo.
+Why Python: keeps the script portable so the same file runs on
+Windows / macOS / Linux without dragging shell quirks into the repo.
 """
 
 from __future__ import annotations

--- a/scripts/scratch-home.py
+++ b/scripts/scratch-home.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Seed a throwaway home + project tree for sandbox-mode dogfooding (#66).
+
+Usage:
+    python scripts/scratch-home.py [<dest>]
+
+`<dest>` defaults to a temp dir if omitted. Creates four `.claude/settings*`
+files — one per recognized scope — populated with realistic-looking
+permission rules and `env` / `hooks` blocks so every UI feature has data to
+exercise.
+
+Layout produced:
+
+    <dest>/
+        .claude/settings.json           # user
+        .claude/settings.local.json     # user-local
+        project/
+            .git/                       # marks the project root for scope discovery
+            .claude/settings.json       # project
+            .claude/settings.local.json # local
+
+Then prints the recommended launch command for ClaudeScope:
+
+    claude-scope --home <dest> --project <dest>/project
+
+The script is idempotent — re-running it overwrites the seeded files but
+preserves anything else under `<dest>` (your hand-edits, .bak trail from
+the last run, etc.). Pass `--force` to wipe `<dest>/.claude` and
+`<dest>/project/.claude` before reseeding.
+
+Why Python: Brian's global preference is portable scripts so the same file
+runs on Windows / macOS / Linux without dragging shell quirks into the repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+# Default seed contents. Picked to cover every visible UI surface:
+#   - allow / deny / ask permission rules across all four scopes
+#   - duplicate rules that show up in multiple scopes (combined-tooltip test)
+#   - top-level `env` (DeepMerge) so move-key flow has data
+#   - top-level `hooks` (Replace) so the override-only note appears
+#   - top-level `theme` (Replace) for the simple scalar case
+#   - one rule whose shape will trip the lint badge so you can see the warn UI
+
+
+USER_SETTINGS = {
+    "permissions": {
+        "allow": [
+            "Bash(git status)",
+            "Bash(git log)",
+            "Read(**)",
+        ],
+        "deny": [
+            "WebFetch(domain:evil.example)",
+        ],
+        "ask": [],
+    },
+    "theme": "dark",
+    "env": {
+        "PATH": "/usr/local/bin:/usr/bin",
+        "EDITOR": "vim",
+    },
+}
+
+USER_LOCAL_SETTINGS = {
+    "permissions": {
+        "allow": [
+            "Bash(npm test)",
+            "Bash(git status)",
+        ],
+        "deny": [],
+        "ask": [],
+    },
+}
+
+PROJECT_SETTINGS = {
+    "permissions": {
+        "allow": [
+            "Bash(cargo test)",
+            "Bash(cargo build)",
+            "WebFetch(domain:docs.rs)",
+            "Read(./src/**)",
+        ],
+        "deny": [
+            "Bash(rm -rf *)",
+        ],
+        "ask": [
+            "Bash(git push *)",
+        ],
+    },
+    "hooks": {
+        "PreToolUse": [
+            {"matcher": "Bash", "command": "echo project hook"}
+        ]
+    },
+    "env": {
+        "RUST_BACKTRACE": "1",
+    },
+}
+
+LOCAL_SETTINGS = {
+    "permissions": {
+        "allow": [
+            "Bash(cargo run)",
+            "lookslikegarbage",  # exercises the lint badge
+        ],
+        "deny": [],
+        "ask": [],
+    },
+    "env": {
+        "DEV_OVERRIDE": "1",
+    },
+}
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def seed(dest: Path, force: bool) -> None:
+    user_claude = dest / ".claude"
+    project_dir = dest / "project"
+    project_claude = project_dir / ".claude"
+
+    if force:
+        for d in (user_claude, project_claude):
+            if d.exists():
+                shutil.rmtree(d)
+
+    write_json(user_claude / "settings.json", USER_SETTINGS)
+    write_json(user_claude / "settings.local.json", USER_LOCAL_SETTINGS)
+    write_json(project_claude / "settings.json", PROJECT_SETTINGS)
+    write_json(project_claude / "settings.local.json", LOCAL_SETTINGS)
+
+    # find_project_root prefers a `.git` ancestor over a `.claude` ancestor,
+    # so we plant a stub `.git` directory in the project dir to make sure the
+    # scope walker locks onto `<dest>/project` and not some ancestor that
+    # happens to have its own `.claude/`.
+    git_marker = project_dir / ".git"
+    git_marker.mkdir(parents=True, exist_ok=True)
+    # An empty .git directory satisfies the existence check; a regular file
+    # named HEAD avoids confusing other tools that scan for git repos.
+    (git_marker / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", maxsplit=1)[0])
+    parser.add_argument(
+        "dest",
+        nargs="?",
+        default=None,
+        help="Destination directory (default: a fresh temp dir).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Wipe existing .claude/ trees under dest before reseeding.",
+    )
+    args = parser.parse_args()
+
+    if args.dest:
+        dest = Path(args.dest).expanduser().resolve()
+        dest.mkdir(parents=True, exist_ok=True)
+    else:
+        dest = Path(tempfile.mkdtemp(prefix="claude-scope-scratch-"))
+
+    seed(dest, force=args.force)
+
+    project = dest / "project"
+    print(f"Seeded sandbox at: {dest}")
+    print()
+    # Env vars are the recommended path for `npm run tauri dev` because the
+    # npm → tauri-cli → cargo chain mangles `--` separators and tauri-cli
+    # forwards CLI args as cargo flags rather than binary flags. Env vars
+    # bypass that chain entirely. CLI flags work fine against a built binary.
+    print("Launch ClaudeScope against the scratch tree with:")
+    print()
+    if sys.platform == "win32":
+        print("    # Dev build (PowerShell):")
+        print(f'    $env:CLAUDE_SCOPE_HOME = "{dest}"')
+        print(f'    $env:CLAUDE_SCOPE_PROJECT = "{project}"')
+        print("    npm run tauri dev")
+        print()
+        print("    # Dev build (cmd.exe):")
+        print(f'    set CLAUDE_SCOPE_HOME={dest}')
+        print(f'    set CLAUDE_SCOPE_PROJECT={project}')
+        print("    npm run tauri dev")
+    else:
+        print("    # Dev build:")
+        print(
+            f"    CLAUDE_SCOPE_HOME='{dest}' "
+            f"CLAUDE_SCOPE_PROJECT='{project}' npm run tauri dev"
+        )
+    print()
+    print("    # Built binary (CLI flags):")
+    print(f"    claude-scope --home {dest} --project {project}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scratch-home.py
+++ b/scripts/scratch-home.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import shutil
 import sys
 import tempfile
@@ -201,11 +202,13 @@ def main() -> int:
         print(f'    set "CLAUDE_SCOPE_PROJECT={project}"')
         print("    npm run tauri dev")
     else:
+        # shlex.quote handles embedded single quotes (`O'Reilly` etc.) and
+        # other shell metacharacters, which a hand-written single-quote wrap
+        # would silently break.
+        dest_q = shlex.quote(str(dest))
+        project_q = shlex.quote(str(project))
         print("    # Dev build:")
-        print(
-            f"    CLAUDE_SCOPE_HOME='{dest}' "
-            f"CLAUDE_SCOPE_PROJECT='{project}' npm run tauri dev"
-        )
+        print(f"    CLAUDE_SCOPE_HOME={dest_q} CLAUDE_SCOPE_PROJECT={project_q} npm run tauri dev")
     print()
     # Quote the path arguments for the same reason — a built binary call
     # `claude-scope --home C:\path with spaces\X` would otherwise split.
@@ -213,7 +216,10 @@ def main() -> int:
     if sys.platform == "win32":
         print(f'    claude-scope --home "{dest}" --project "{project}"')
     else:
-        print(f"    claude-scope --home '{dest}' --project '{project}'")
+        print(
+            f"    claude-scope --home {shlex.quote(str(dest))} "
+            f"--project {shlex.quote(str(project))}"
+        )
     return 0
 
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,6 @@
 //! Tauri command handlers exposed to the front-end.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
@@ -9,6 +9,7 @@ use tauri::{AppHandle, Emitter, State};
 use crate::io_atomic::{self, BackupTracker};
 use crate::model::{key_policy, KeyPolicy, PermissionKind, PermissionRules, SettingsDoc};
 use crate::preferences::{self, Preferences};
+use crate::runtime::{RuntimeInfo, RuntimeOverrides};
 use crate::scope::{self, Scope, ScopePaths};
 use crate::watcher::WatchState;
 
@@ -128,14 +129,32 @@ pub struct MoveKeySide {
     pub note: Option<String>,
 }
 
+/// Resolve scope paths honoring the launch-time overrides. The `home`
+/// override is always applied so user / user-local lookups stay redirected for
+/// the whole session. The `project` override only kicks in when the
+/// front-end didn't supply its own `project_dir` (i.e. on first load before
+/// the user has picked a project) — once the user picks something explicitly
+/// we want that to win.
+fn resolve_with_overrides(
+    project_dir: Option<&str>,
+    overrides: &RuntimeOverrides,
+) -> std::io::Result<ScopePaths> {
+    let project_path: Option<PathBuf> = match project_dir {
+        Some(s) => Some(PathBuf::from(s)),
+        None => overrides.project().map(Path::to_path_buf),
+    };
+    scope::resolve_with_home(project_path.as_deref(), overrides.home())
+}
+
 #[tauri::command]
 pub fn load_scopes(
     project_dir: Option<String>,
     app: AppHandle,
     watch: State<'_, WatchState>,
+    overrides: State<'_, RuntimeOverrides>,
 ) -> Result<LoadedScopes, String> {
-    let start = project_dir.as_ref().map(Path::new);
-    let paths = scope::resolve(start).map_err(|e| e.to_string())?;
+    let paths =
+        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
     let loaded = build_loaded(&paths).map_err(|e| e.to_string())?;
     // (Re)install the watcher every time we load. This handles both first
     // load and project-switch with no extra command surface area for the
@@ -151,9 +170,13 @@ pub fn load_scopes(
 }
 
 #[tauri::command]
-pub fn diff_move(req: MoveRequest, project_dir: Option<String>) -> Result<MovePreview, String> {
-    let start = project_dir.as_ref().map(Path::new);
-    let paths = scope::resolve(start).map_err(|e| e.to_string())?;
+pub fn diff_move(
+    req: MoveRequest,
+    project_dir: Option<String>,
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<MovePreview, String> {
+    let paths =
+        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
     diff_move_impl(&paths, &req).map_err(|e| e.to_string())
 }
 
@@ -162,9 +185,10 @@ pub fn apply_move(
     req: MoveRequest,
     project_dir: Option<String>,
     watch: State<'_, WatchState>,
+    overrides: State<'_, RuntimeOverrides>,
 ) -> Result<(), String> {
-    let start = project_dir.as_ref().map(Path::new);
-    let paths = scope::resolve(start).map_err(|e| e.to_string())?;
+    let paths =
+        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
     apply_move_impl(&paths, &req, backups(), &watch).map_err(|e| e.to_string())
 }
 
@@ -172,9 +196,10 @@ pub fn apply_move(
 pub fn diff_move_key(
     req: MoveKeyRequest,
     project_dir: Option<String>,
+    overrides: State<'_, RuntimeOverrides>,
 ) -> Result<MoveKeyPreview, String> {
-    let start = project_dir.as_ref().map(Path::new);
-    let paths = scope::resolve(start).map_err(|e| e.to_string())?;
+    let paths =
+        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
     diff_move_key_impl(&paths, &req).map_err(|e| e.to_string())
 }
 
@@ -183,10 +208,19 @@ pub fn apply_move_key(
     req: MoveKeyRequest,
     project_dir: Option<String>,
     watch: State<'_, WatchState>,
+    overrides: State<'_, RuntimeOverrides>,
 ) -> Result<(), String> {
-    let start = project_dir.as_ref().map(Path::new);
-    let paths = scope::resolve(start).map_err(|e| e.to_string())?;
+    let paths =
+        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
     apply_move_key_impl(&paths, &req, backups(), &watch).map_err(|e| e.to_string())
+}
+
+/// Snapshot of the launch-time overrides — the front-end uses this to
+/// surface a "Sandbox: <path>" warning in the title bar so the user can't
+/// forget they're in scratch mode.
+#[tauri::command]
+pub fn load_runtime_info(overrides: State<'_, RuntimeOverrides>) -> RuntimeInfo {
+    RuntimeInfo::from_overrides(&overrides)
 }
 
 /// Read user preferences. A missing / malformed config file falls back to

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -216,7 +216,7 @@ pub fn apply_move_key(
 }
 
 /// Snapshot of the launch-time overrides — the front-end uses this to
-/// surface a "Sandbox: <path>" warning in the title bar so the user can't
+/// render a persistent sandbox banner under the toolbar so the user can't
 /// forget they're in scratch mode.
 #[tauri::command]
 pub fn load_runtime_info(overrides: State<'_, RuntimeOverrides>) -> RuntimeInfo {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,8 +12,18 @@ pub fn run() {
     // from argv and `CLAUDE_SCOPE_HOME` / `CLAUDE_SCOPE_PROJECT` from env at
     // launch. Stored as managed state so every subsequent scope::resolve
     // routes through the override when set.
-    let overrides =
-        runtime::RuntimeOverrides::from_env_and_args(std::env::args(), &runtime::RealEnv);
+    //
+    // `args_os` + `to_string_lossy` instead of `args`: `std::env::args` panics
+    // when any argv element is not valid UTF-8. On Unix that's a real risk
+    // (filesystem paths can be arbitrary bytes), and crashing before the UI
+    // loads is the worst possible failure mode. Lossy conversion replaces
+    // invalid bytes with the replacement char; the override paths still
+    // resolve sensibly when valid, and the parser silently drops anything it
+    // can't classify.
+    let overrides = runtime::RuntimeOverrides::from_env_and_args(
+        std::env::args_os().map(|a| a.to_string_lossy().into_owned()),
+        &runtime::RealEnv,
+    );
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,14 +2,23 @@ mod commands;
 mod io_atomic;
 mod model;
 mod preferences;
+mod runtime;
 mod scope;
 mod watcher;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Sandbox / scratch-home overrides (#66): parse `--home` / `--project`
+    // from argv and `CLAUDE_SCOPE_HOME` / `CLAUDE_SCOPE_PROJECT` from env at
+    // launch. Stored as managed state so every subsequent scope::resolve
+    // routes through the override when set.
+    let overrides =
+        runtime::RuntimeOverrides::from_env_and_args(std::env::args(), &runtime::RealEnv);
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .manage(watcher::WatchState::default())
+        .manage(overrides)
         .invoke_handler(tauri::generate_handler![
             commands::load_scopes,
             commands::diff_move,
@@ -18,6 +27,7 @@ pub fn run() {
             commands::apply_move_key,
             commands::load_preferences,
             commands::save_preferences,
+            commands::load_runtime_info,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/runtime.rs
+++ b/src-tauri/src/runtime.rs
@@ -43,9 +43,10 @@ impl RuntimeOverrides {
     {
         let mut overrides = Self::default();
         let mut iter = args.into_iter().map(Into::into).peekable();
-        // Skip argv[0] (the executable path). Don't unwrap — tests pass an
-        // explicit slice that omits it, and an empty argv from a malformed
-        // launcher shouldn't panic the app.
+        // Skip argv[0] (the executable path). Tests still include a stub
+        // first element so this drop matches production behavior. Use
+        // `.next()` discard instead of unwrap so an empty argv from a
+        // malformed launcher doesn't panic the app.
         let _ = iter.next();
         // Consume the next arg as the value for `flag` only when it's a real
         // value (non-empty, doesn't itself start with `--`). Without the

--- a/src-tauri/src/runtime.rs
+++ b/src-tauri/src/runtime.rs
@@ -11,8 +11,8 @@
 //!   3. Real `dirs::home_dir()` and the front-end's project picker
 //!
 //! Both overrides survive the lifetime of the process and are exposed to the
-//! front-end via `load_runtime_info` so the title bar can warn the user that
-//! they're in scratch mode.
+//! front-end via `load_runtime_info` so the UI can render a persistent banner
+//! under the toolbar warning the user that they're in scratch mode.
 
 use std::path::{Path, PathBuf};
 
@@ -42,22 +42,40 @@ impl RuntimeOverrides {
         S: Into<String>,
     {
         let mut overrides = Self::default();
-        let mut iter = args.into_iter().map(Into::into);
+        let mut iter = args.into_iter().map(Into::into).peekable();
         // Skip argv[0] (the executable path). Don't unwrap — tests pass an
         // explicit slice that omits it, and an empty argv from a malformed
         // launcher shouldn't panic the app.
         let _ = iter.next();
+        // Consume the next arg as the value for `flag` only when it's a real
+        // value (non-empty, doesn't itself start with `--`). Without the
+        // flag-shape guard, `--home --project /p` would set home="--project"
+        // and silently drop the real project override; without the empty-
+        // string guard, `--home=` would set home to PathBuf("") instead of
+        // matching the env-var convention where empty means unset.
+        fn take_value<I: Iterator<Item = String>>(
+            iter: &mut std::iter::Peekable<I>,
+        ) -> Option<String> {
+            match iter.peek() {
+                Some(v) if !v.is_empty() && !v.starts_with("--") => iter.next(),
+                _ => None,
+            }
+        }
         while let Some(arg) = iter.next() {
             if let Some(rest) = arg.strip_prefix("--home=") {
-                overrides.home = Some(PathBuf::from(rest));
+                if !rest.is_empty() {
+                    overrides.home = Some(PathBuf::from(rest));
+                }
             } else if arg == "--home" {
-                if let Some(value) = iter.next() {
+                if let Some(value) = take_value(&mut iter) {
                     overrides.home = Some(PathBuf::from(value));
                 }
             } else if let Some(rest) = arg.strip_prefix("--project=") {
-                overrides.project = Some(PathBuf::from(rest));
+                if !rest.is_empty() {
+                    overrides.project = Some(PathBuf::from(rest));
+                }
             } else if arg == "--project" {
-                if let Some(value) = iter.next() {
+                if let Some(value) = take_value(&mut iter) {
                     overrides.project = Some(PathBuf::from(value));
                 }
             }
@@ -97,8 +115,8 @@ impl EnvSource for RealEnv {
 }
 
 /// Snapshot exposed to the front-end. Paths are stringified for IPC; both
-/// fields are `None` when the user is running unsandboxed, so the title bar
-/// can render the override hint conditionally.
+/// fields are `None` when the user is running unsandboxed, so the sandbox
+/// banner is omitted in that case.
 #[derive(Debug, Default, Serialize)]
 pub struct RuntimeInfo {
     pub home_override: Option<String>,
@@ -180,6 +198,38 @@ mod tests {
         // rather than panic on a missing iterator next().
         let got = RuntimeOverrides::from_env_and_args(["claude-scope", "--home"], &empty_env());
         assert!(got.home().is_none());
+    }
+
+    #[test]
+    fn flag_followed_by_another_flag_does_not_consume_it() {
+        // Regression: `--home --project /p` previously set home="--project"
+        // and silently dropped the real project flag. Now `--home` finds no
+        // value (next token is flag-shaped), home stays unset, and parsing
+        // continues so `--project /p` is honored.
+        let args = ["claude-scope", "--home", "--project", "/p"];
+        let got = RuntimeOverrides::from_env_and_args(args, &empty_env());
+        assert!(got.home().is_none(), "home should not be set to --project");
+        assert_eq!(got.project(), Some(Path::new("/p")));
+    }
+
+    #[test]
+    fn empty_equals_form_is_treated_as_unset() {
+        // Match the env-var convention: an explicitly empty value means
+        // "no override" rather than "override with the empty path".
+        let args = ["claude-scope", "--home=", "--project="];
+        let got = RuntimeOverrides::from_env_and_args(args, &empty_env());
+        assert!(got.home().is_none());
+        assert!(got.project().is_none());
+    }
+
+    #[test]
+    fn empty_separated_value_is_treated_as_unset() {
+        // `--home ""` (empty string passed as the next arg) — same convention
+        // as the equals form. Drops home rather than path-of-empty-string.
+        let args = ["claude-scope", "--home", "", "--project", "/p"];
+        let got = RuntimeOverrides::from_env_and_args(args, &empty_env());
+        assert!(got.home().is_none());
+        assert_eq!(got.project(), Some(Path::new("/p")));
     }
 
     #[test]

--- a/src-tauri/src/runtime.rs
+++ b/src-tauri/src/runtime.rs
@@ -1,0 +1,195 @@
+//! Launch-time runtime overrides for sandbox / scratch-home mode (#66).
+//!
+//! These overrides redirect scope discovery away from the real user home (and
+//! optionally the cwd-derived project root) so the app can be exercised
+//! against a throwaway directory without putting the user's actual
+//! `~/.claude/` at risk.
+//!
+//! Resolution order, highest priority first:
+//!   1. `--home <path>` / `--project <path>` CLI flags
+//!   2. `CLAUDE_SCOPE_HOME` / `CLAUDE_SCOPE_PROJECT` env vars
+//!   3. Real `dirs::home_dir()` and the front-end's project picker
+//!
+//! Both overrides survive the lifetime of the process and are exposed to the
+//! front-end via `load_runtime_info` so the title bar can warn the user that
+//! they're in scratch mode.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+#[derive(Debug, Default, Clone)]
+pub struct RuntimeOverrides {
+    pub home: Option<PathBuf>,
+    pub project: Option<PathBuf>,
+}
+
+impl RuntimeOverrides {
+    pub fn home(&self) -> Option<&Path> {
+        self.home.as_deref()
+    }
+
+    pub fn project(&self) -> Option<&Path> {
+        self.project.as_deref()
+    }
+
+    /// Build from process argv + env. Unknown args are ignored so Tauri / the
+    /// platform launcher can still pass their own flags through. Argv-supplied
+    /// values win over env-var values; env vars win over real home / cwd.
+    pub fn from_env_and_args<I, S>(args: I, env: &dyn EnvSource) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut overrides = Self::default();
+        let mut iter = args.into_iter().map(Into::into);
+        // Skip argv[0] (the executable path). Don't unwrap — tests pass an
+        // explicit slice that omits it, and an empty argv from a malformed
+        // launcher shouldn't panic the app.
+        let _ = iter.next();
+        while let Some(arg) = iter.next() {
+            if let Some(rest) = arg.strip_prefix("--home=") {
+                overrides.home = Some(PathBuf::from(rest));
+            } else if arg == "--home" {
+                if let Some(value) = iter.next() {
+                    overrides.home = Some(PathBuf::from(value));
+                }
+            } else if let Some(rest) = arg.strip_prefix("--project=") {
+                overrides.project = Some(PathBuf::from(rest));
+            } else if arg == "--project" {
+                if let Some(value) = iter.next() {
+                    overrides.project = Some(PathBuf::from(value));
+                }
+            }
+            // Unknown args fall through silently. Tauri / WebView2 / OS
+            // launchers occasionally pass diagnostic flags we don't care about.
+        }
+        if overrides.home.is_none() {
+            if let Some(v) = env.get("CLAUDE_SCOPE_HOME") {
+                if !v.is_empty() {
+                    overrides.home = Some(PathBuf::from(v));
+                }
+            }
+        }
+        if overrides.project.is_none() {
+            if let Some(v) = env.get("CLAUDE_SCOPE_PROJECT") {
+                if !v.is_empty() {
+                    overrides.project = Some(PathBuf::from(v));
+                }
+            }
+        }
+        overrides
+    }
+}
+
+/// Tiny indirection so the parser is unit-testable without poking
+/// `std::env::var`. Production passes a `RealEnv`; tests pass a fake map.
+pub trait EnvSource {
+    fn get(&self, key: &str) -> Option<String>;
+}
+
+pub struct RealEnv;
+
+impl EnvSource for RealEnv {
+    fn get(&self, key: &str) -> Option<String> {
+        std::env::var(key).ok()
+    }
+}
+
+/// Snapshot exposed to the front-end. Paths are stringified for IPC; both
+/// fields are `None` when the user is running unsandboxed, so the title bar
+/// can render the override hint conditionally.
+#[derive(Debug, Default, Serialize)]
+pub struct RuntimeInfo {
+    pub home_override: Option<String>,
+    pub project_override: Option<String>,
+}
+
+impl RuntimeInfo {
+    pub fn from_overrides(overrides: &RuntimeOverrides) -> Self {
+        Self {
+            home_override: overrides.home().map(|p| p.display().to_string()),
+            project_override: overrides.project().map(|p| p.display().to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    struct FakeEnv(HashMap<String, String>);
+    impl EnvSource for FakeEnv {
+        fn get(&self, key: &str) -> Option<String> {
+            self.0.get(key).cloned()
+        }
+    }
+    fn empty_env() -> FakeEnv {
+        FakeEnv(HashMap::new())
+    }
+
+    #[test]
+    fn parses_separate_home_and_project_flags() {
+        let args = ["claude-scope", "--home", "/tmp/h", "--project", "/tmp/p"];
+        let got = RuntimeOverrides::from_env_and_args(args, &empty_env());
+        assert_eq!(got.home(), Some(Path::new("/tmp/h")));
+        assert_eq!(got.project(), Some(Path::new("/tmp/p")));
+    }
+
+    #[test]
+    fn parses_equals_form() {
+        let args = ["claude-scope", "--home=/tmp/h", "--project=/tmp/p"];
+        let got = RuntimeOverrides::from_env_and_args(args, &empty_env());
+        assert_eq!(got.home(), Some(Path::new("/tmp/h")));
+        assert_eq!(got.project(), Some(Path::new("/tmp/p")));
+    }
+
+    #[test]
+    fn cli_wins_over_env() {
+        let mut env = HashMap::new();
+        env.insert("CLAUDE_SCOPE_HOME".to_string(), "/env/h".to_string());
+        env.insert("CLAUDE_SCOPE_PROJECT".to_string(), "/env/p".to_string());
+        let args = ["claude-scope", "--home", "/cli/h"];
+        let got = RuntimeOverrides::from_env_and_args(args, &FakeEnv(env));
+        assert_eq!(got.home(), Some(Path::new("/cli/h")));
+        // project came from env since CLI didn't override it.
+        assert_eq!(got.project(), Some(Path::new("/env/p")));
+    }
+
+    #[test]
+    fn ignores_unknown_args() {
+        // Tauri / WebView2 occasionally inject their own flags. Ignoring them
+        // (instead of erroring) keeps the launch resilient.
+        let args = ["claude-scope", "--webview-arg=foo", "--home", "/h"];
+        let got = RuntimeOverrides::from_env_and_args(args, &empty_env());
+        assert_eq!(got.home(), Some(Path::new("/h")));
+    }
+
+    #[test]
+    fn empty_env_value_is_treated_as_unset() {
+        let mut env = HashMap::new();
+        env.insert("CLAUDE_SCOPE_HOME".to_string(), String::new());
+        let got = RuntimeOverrides::from_env_and_args(["claude-scope"], &FakeEnv(env));
+        assert!(got.home().is_none());
+    }
+
+    #[test]
+    fn missing_value_for_trailing_flag_is_dropped() {
+        // `--home` at end of argv with no value should leave home unset
+        // rather than panic on a missing iterator next().
+        let got = RuntimeOverrides::from_env_and_args(["claude-scope", "--home"], &empty_env());
+        assert!(got.home().is_none());
+    }
+
+    #[test]
+    fn runtime_info_serializes_present_overrides() {
+        let overrides = RuntimeOverrides {
+            home: Some(PathBuf::from("/h")),
+            project: None,
+        };
+        let info = RuntimeInfo::from_overrides(&overrides);
+        assert_eq!(info.home_override.as_deref(), Some("/h"));
+        assert!(info.project_override.is_none());
+    }
+}

--- a/src-tauri/src/scope.rs
+++ b/src-tauri/src/scope.rs
@@ -117,11 +117,20 @@ pub fn find_project_root(start: Option<&Path>) -> std::io::Result<PathBuf> {
 /// directory. The starting directory becomes the project dir after
 /// [`find_project_root`] walks upward looking for a `.git` entry (preferred)
 /// and then a `.claude/` directory.
-pub fn resolve(start: Option<&Path>) -> std::io::Result<ScopePaths> {
+///
+/// When `home_override` is `Some`, that path replaces what `dirs::home_dir()`
+/// would return, so the `User` and `UserLocal` scopes look at
+/// `<override>/.claude/settings*.json` instead of the real user home. Used by
+/// sandbox / scratch-home mode (#66) so the app can be exercised without
+/// putting the user's actual Claude Code settings at risk.
+pub fn resolve_with_home(
+    start: Option<&Path>,
+    home_override: Option<&Path>,
+) -> std::io::Result<ScopePaths> {
     let project_dir = find_project_root(start)?;
     let local = Some(project_dir.join(".claude").join("settings.local.json"));
     let project = Some(project_dir.join(".claude").join("settings.json"));
-    let home = dirs::home_dir();
+    let home = home_override.map(Path::to_path_buf).or_else(dirs::home_dir);
     let user_local = home
         .as_ref()
         .map(|h| h.join(".claude").join("settings.local.json"));
@@ -242,7 +251,7 @@ mod tests {
     fn resolve_builds_local_and_project_paths() {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
-        let paths = resolve(Some(tmp.path())).unwrap();
+        let paths = resolve_with_home(Some(tmp.path()), None).unwrap();
         assert_eq!(
             paths.local.as_deref().unwrap().file_name().unwrap(),
             "settings.local.json"
@@ -259,7 +268,7 @@ mod tests {
         // first-class scope, not hidden under the shared home-dir path
         // computation.
         let tmp = tempfile::tempdir().unwrap();
-        let paths = resolve(Some(tmp.path())).unwrap();
+        let paths = resolve_with_home(Some(tmp.path()), None).unwrap();
         if let (Some(ul), Some(u)) = (paths.user_local.as_deref(), paths.user.as_deref()) {
             assert_eq!(ul.file_name().unwrap(), "settings.local.json");
             assert_eq!(u.file_name().unwrap(), "settings.json");
@@ -269,6 +278,40 @@ mod tests {
             // then both must be None together.
             assert!(paths.user_local.is_none() && paths.user.is_none());
         }
+    }
+
+    #[test]
+    fn resolve_with_home_redirects_user_scopes() {
+        // Sandbox mode (#66): when home_override is set, User and UserLocal
+        // must root at that path — not the real $HOME and not None — so a
+        // dogfood session can't accidentally clobber the user's real
+        // ~/.claude/.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        let fake_home = tmp.path().join("scratch-home");
+        std::fs::create_dir_all(project.join(".claude")).unwrap();
+        std::fs::create_dir_all(fake_home.join(".claude")).unwrap();
+        let paths = resolve_with_home(Some(&project), Some(&fake_home)).unwrap();
+        assert_eq!(
+            paths.user.as_deref().unwrap(),
+            fake_home.join(".claude").join("settings.json"),
+        );
+        assert_eq!(
+            paths.user_local.as_deref().unwrap(),
+            fake_home.join(".claude").join("settings.local.json"),
+        );
+        // Project + Local must still root at the project_dir, not the home
+        // override — promotion target columns should stay distinct.
+        assert!(paths
+            .project
+            .as_deref()
+            .unwrap()
+            .starts_with(&paths.project_dir));
+        assert!(paths
+            .local
+            .as_deref()
+            .unwrap()
+            .starts_with(&paths.project_dir));
     }
 
     #[test]

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,8 +38,8 @@ const state: {
   busy: false,
   query: "",
   preferences: DEFAULT_PREFERENCES,
-  // Default to "no overrides" until load_runtime_info resolves; the title
-  // bar simply omits the sandbox banner in that case, so a slow IPC boot
+  // Default to "no overrides" until load_runtime_info resolves; the
+  // sandbox banner is simply omitted in that case, so a slow IPC boot
   // doesn't flash a misleading "Sandbox: …" line.
   runtime: { home_override: null, project_override: null },
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import type {
   MovePreview,
   MoveRequest,
   Preferences,
+  RuntimeInfo,
   Scope,
 } from "./types.ts";
 import { SCOPES, SEARCH_INPUT_ID } from "./types.ts";
@@ -30,12 +31,17 @@ const state: {
   busy: boolean;
   query: string;
   preferences: Preferences;
+  runtime: RuntimeInfo;
 } = {
   scopes: null,
   projectDir: null,
   busy: false,
   query: "",
   preferences: DEFAULT_PREFERENCES,
+  // Default to "no overrides" until load_runtime_info resolves; the title
+  // bar simply omits the sandbox banner in that case, so a slow IPC boot
+  // doesn't flash a misleading "Sandbox: …" line.
+  runtime: { home_override: null, project_override: null },
 };
 
 // Set by the scopes-changed listener when it fires while another load or
@@ -262,6 +268,7 @@ function render(): void {
     busy: state.busy,
     query: state.query,
     preferences: state.preferences,
+    runtime: state.runtime,
     onPickProject: pickProject,
     onReload: reload,
     onMove: moveRule,
@@ -326,14 +333,23 @@ listen<string>("watcher-error", (evt) => {
 });
 
 async function bootstrap(): Promise<void> {
-  // Load preferences before the first scope load so the initial render
-  // applies them (e.g. column visibility) instead of flashing defaults
-  // first and then switching. A failed load falls back to defaults;
-  // there's no useful user action on "couldn't read config file."
-  try {
-    state.preferences = await invoke<Preferences>("load_preferences");
-  } catch (err) {
-    console.warn("failed to load preferences, using defaults:", err);
+  // Load preferences + runtime info before the first scope load so the
+  // initial render applies them (column visibility, sandbox banner)
+  // instead of flashing defaults first and then switching. Both calls are
+  // independent — fire them in parallel and tolerate either failing.
+  const [prefsResult, runtimeResult] = await Promise.allSettled([
+    invoke<Preferences>("load_preferences"),
+    invoke<RuntimeInfo>("load_runtime_info"),
+  ]);
+  if (prefsResult.status === "fulfilled") {
+    state.preferences = prefsResult.value;
+  } else {
+    console.warn("failed to load preferences, using defaults:", prefsResult.reason);
+  }
+  if (runtimeResult.status === "fulfilled") {
+    state.runtime = runtimeResult.value;
+  } else {
+    console.warn("failed to load runtime info:", runtimeResult.reason);
   }
   await load(null);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -56,6 +56,11 @@ body {
   flex-wrap: wrap;
   gap: 4px;
   align-items: baseline;
+  /* Long Windows paths (e.g. C:\Users\…\AppData\Local\Temp\…) are unbroken
+   * tokens and would force horizontal scroll inside the flex layout
+   * otherwise. `anywhere` lets the browser break inside the path so the
+   * banner stays inside the viewport. */
+  overflow-wrap: anywhere;
 }
 
 .sandbox-banner strong {

--- a/src/styles.css
+++ b/src/styles.css
@@ -43,6 +43,25 @@ body {
   flex-wrap: wrap;
 }
 
+/* Sandbox banner — only rendered when --home / --project (or env-var
+ * equivalent) is set at launch. Amber on dark amber to read as a warning
+ * without escalating to an error red. */
+.sandbox-banner {
+  background: #3a2e10;
+  color: #ffd479;
+  border-bottom: 1px solid #5a4416;
+  padding: 8px 16px;
+  font-size: 13px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: baseline;
+}
+
+.sandbox-banner strong {
+  color: #ffe2a0;
+}
+
 .search {
   position: relative;
   flex: 0 1 320px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,3 +132,14 @@ export const SEARCH_INPUT_ID = "rule-search";
 export interface Preferences {
   visible_scopes: Scope[];
 }
+
+/**
+ * Launch-time override snapshot from the Rust side. Mirrors `RuntimeInfo`
+ * in `src-tauri/src/runtime.rs`. Both fields are null when the app is
+ * running unsandboxed; either being set means the user is in scratch mode
+ * (#66) and the title bar should warn them.
+ */
+export interface RuntimeInfo {
+  home_override: string | null;
+  project_override: string | null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,8 @@ export interface Preferences {
  * Launch-time override snapshot from the Rust side. Mirrors `RuntimeInfo`
  * in `src-tauri/src/runtime.rs`. Both fields are null when the app is
  * running unsandboxed; either being set means the user is in scratch mode
- * (#66) and the title bar should warn them.
+ * (#66) and the UI should show the persistent warning banner under the
+ * toolbar.
  */
 export interface RuntimeInfo {
   home_override: string | null;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -11,6 +11,7 @@ import type {
   MoveSide,
   PermissionKind,
   Preferences,
+  RuntimeInfo,
   Scope,
   ScopeView,
 } from "./types.ts";
@@ -22,6 +23,7 @@ interface AppProps {
   busy: boolean;
   query: string;
   preferences: Preferences;
+  runtime: RuntimeInfo;
   onPickProject: () => void;
   onReload: () => void;
   onMove: (req: MoveRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
@@ -93,6 +95,8 @@ export function renderApp(root: HTMLElement, props: AppProps): void {
     lastRenderedProjectDir = props.projectDir;
   }
   root.appendChild(header(props));
+  const banner = sandboxBanner(props.runtime);
+  if (banner) root.appendChild(banner);
 
   if (!props.scopes) {
     const empty = document.createElement("div");
@@ -127,6 +131,32 @@ function restoreSearchFocus(
       // embedded webviews might not — fall through silently.
     }
   }
+}
+
+/**
+ * Sandbox banner shown when the user launched with `--home` /
+ * `CLAUDE_SCOPE_HOME` (or the project counterpart). Sits directly under
+ * the toolbar, full-width, persistent — the issue's acceptance criterion
+ * is "the user can't forget they're in scratch mode," so we deliberately
+ * don't make this dismissable.
+ */
+function sandboxBanner(runtime: RuntimeInfo): HTMLElement | null {
+  if (!runtime.home_override && !runtime.project_override) return null;
+  const banner = document.createElement("div");
+  banner.className = "sandbox-banner";
+  banner.setAttribute("role", "status");
+
+  const label = document.createElement("strong");
+  label.textContent = "Sandbox mode";
+  banner.appendChild(label);
+
+  const detail = document.createElement("span");
+  const parts: string[] = [];
+  if (runtime.home_override) parts.push(`home: ${runtime.home_override}`);
+  if (runtime.project_override) parts.push(`project: ${runtime.project_override}`);
+  detail.textContent = ` — ${parts.join(" · ")}`;
+  banner.appendChild(detail);
+  return banner;
 }
 
 function header(props: AppProps): HTMLElement {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -138,7 +138,7 @@ function restoreSearchFocus(
  * `CLAUDE_SCOPE_HOME` (or the project counterpart). Sits directly under
  * the toolbar, full-width, persistent — the issue's acceptance criterion
  * is "the user can't forget they're in scratch mode," so we deliberately
- * don't make this dismissable.
+ * don't make this dismissible.
  */
 function sandboxBanner(runtime: RuntimeInfo): HTMLElement | null {
   if (!runtime.home_override && !runtime.project_override) return null;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -144,7 +144,11 @@ function sandboxBanner(runtime: RuntimeInfo): HTMLElement | null {
   if (!runtime.home_override && !runtime.project_override) return null;
   const banner = document.createElement("div");
   banner.className = "sandbox-banner";
-  banner.setAttribute("role", "status");
+  // `role="note"` (not "status"): the banner is supplementary context,
+  // not a live status update. renderApp wipes the DOM on every keystroke,
+  // so a polite live region (which "status" implies) would re-announce
+  // the same scratch-mode message to screen readers on every render.
+  banner.setAttribute("role", "note");
 
   const label = document.createElement("strong");
   label.textContent = "Sandbox mode";


### PR DESCRIPTION
## Summary

- Adds launch-time `--home` / `--project` CLI flags and `CLAUDE_SCOPE_HOME` / `CLAUDE_SCOPE_PROJECT` env vars that redirect scope discovery away from the user's real `~/.claude/`. The `home` override applies to every scope resolution (so user/user-local writes always land in the sandbox); the `project` override only seeds the bootstrap project dir, so the front-end picker can still retarget Project/Local mid-session.
- Renders a yellow **Sandbox mode** banner under the toolbar, listing both active paths, so the user can't forget they're in scratch mode (acceptance criterion from #66).
- Ships `scripts/scratch-home.py`, a cross-platform Python helper that seeds a fresh tree across all four scopes (with a `.git` marker so `find_project_root` locks onto the right dir) and prints the launch commands for PowerShell, cmd, bash, and a built binary. Idempotent; `--force` wipes for a clean reseed.

## Why env vars are the documented dev-mode path

`npm run tauri dev -- --home X` doesn't work: `tauri-cli` forwards the trailing args as cargo flags, not binary flags, so `cargo run --home X --no-default-features …` errors out before the binary launches. Env vars sidestep the npm → tauri-cli → cargo chain entirely and are reliable across shells. CLI flags work fine against a built binary, so they're documented for that path.

## Scope

- Implements **option 1** from #66 (CLI flags + env var + scratch-home seeder + docs).
- **Option 2** (Windows Sandbox `.wsb` config) is out of scope here — option 1 is the day-to-day ergonomics fix; the throwaway-OS option can land as a follow-up if there's demand.

## Test plan

- [ ] `python scripts/scratch-home.py` prints the right launch commands for the active platform; the seeded tree exists at the printed path with all four `settings*.json` files plus `project/.git/HEAD`.
- [ ] Launch via env vars (`set CLAUDE_SCOPE_HOME=… && set CLAUDE_SCOPE_PROJECT=… && npm run tauri dev`). Yellow Sandbox banner sits under the toolbar showing both paths; all four scope columns populate from the seeded files.
- [ ] Move a rule from Project → User. The new entry lands in `<sandbox-home>/.claude/settings.json`, **not** `~/.claude/settings.json`. Real `~/.claude/` mtimes are unchanged after the session.
- [ ] Click **Open project…** under `--home`, pick a different dir. Project + Local retarget; banner still shows the original `home:` path; User + User-Local stay rooted in the sandbox.
- [ ] Built-binary launch works with the CLI flag form: `claude-scope --home <path> --project <path>`.
- [ ] `cargo test --lib` — new tests pass: 7 in `runtime::tests` (CLI/env precedence, equals form, unknown args, trailing flags, empty values, serialization), 1 in `scope::tests` (`resolve_with_home_redirects_user_scopes`).
- [ ] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `tsc --noEmit`, `vite build` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)