### PR TITLE
test(ui): scaffold vitest + initial renderApp coverage (#69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
       - name: Build frontend
         run: npm run build
 
+      # Renderer unit tests are Ubuntu-only for now: this layer is pure
+      # JSDOM-style work in happy-dom, so cross-OS coverage adds runtime
+      # without buying signal until something proves OS-specific. Issue #69.
+      - name: JS unit tests
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: npm run test:unit
+
       - name: Rust unit tests
         working-directory: src-tauri
         run: cargo test --lib --locked

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
         "@tauri-apps/cli": "^2.3.0",
+        "happy-dom": "^20.0.0",
         "typescript": "^6.0.3",
-        "vite": "^8.0.10"
+        "vite": "^8.0.10",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -215,6 +217,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -509,6 +517,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -756,6 +770,182 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -764,6 +954,42 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -797,6 +1023,23 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/lightningcss": {
@@ -1060,6 +1303,15 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1078,6 +1330,22 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ]
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1162,6 +1430,12 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1170,6 +1444,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1187,6 +1488,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1210,6 +1520,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true
     },
     "node_modules/vite": {
       "version": "8.0.10",
@@ -1285,6 +1601,141 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "lint": "biome check",
-    "format": "biome format --write"
+    "format": "biome format --write",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.3.0",
@@ -20,7 +21,9 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
     "@tauri-apps/cli": "^2.3.0",
+    "happy-dom": "^20.0.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.10"
+    "vite": "^8.0.10",
+    "vitest": "^4.1.0"
   }
 }

--- a/test/fixtures/loadedScopes.ts
+++ b/test/fixtures/loadedScopes.ts
@@ -1,0 +1,111 @@
+import type {
+  JsonValue,
+  LoadedScopes,
+  PermissionKind,
+  PermissionRuleOrigins,
+  PermissionRules,
+  Preferences,
+  RuntimeInfo,
+  Scope,
+  ScopeView,
+} from "../../src/types.ts";
+import { SCOPES } from "../../src/types.ts";
+
+/**
+ * Tiny fixture builders for the renderer tests. Mirrors the shape the Rust
+ * backend returns from `load_scopes` / `load_preferences` / `load_runtime_info`
+ * — built TS-side so unit tests stay fast and don't touch disk. Disk-backed
+ * `.claude/` fixtures (E2E) are out of scope for the first unit layer.
+ *
+ * All builders return fresh objects so tests can mutate the result without
+ * affecting other tests.
+ */
+
+interface ScopeViewOverrides {
+  scope: Scope;
+  path?: string | null;
+  exists?: boolean;
+  permissions?: Partial<PermissionRules>;
+  other_values?: { [key: string]: JsonValue };
+  parse_error?: string | null;
+}
+
+export function emptyPermissions(): PermissionRules {
+  return { allow: [], deny: [], ask: [] };
+}
+
+export function emptyOrigins(): PermissionRuleOrigins {
+  return { allow: [], deny: [], ask: [] };
+}
+
+export function buildScopeView(overrides: ScopeViewOverrides): ScopeView {
+  const permissions = { ...emptyPermissions(), ...(overrides.permissions ?? {}) };
+  return {
+    scope: overrides.scope,
+    path: overrides.path ?? `/fake/${overrides.scope}/settings.json`,
+    exists: overrides.exists ?? true,
+    permissions,
+    other_values: overrides.other_values ?? {},
+    parse_error: overrides.parse_error ?? null,
+  };
+}
+
+interface LoadedScopesOverrides {
+  project_dir?: string;
+  scopes?: ScopeViewOverrides[];
+  combined_permissions?: Partial<PermissionRules>;
+  combined_origins?: Partial<PermissionRuleOrigins>;
+}
+
+/**
+ * Builds a `LoadedScopes` payload for a given set of per-scope overrides.
+ * Any scope not listed gets a present-but-empty view so the renderer's
+ * "exists/no rules" branch is exercised by default. The combined panel
+ * is derived from the per-scope `allow`/`deny`/`ask` lists (origin lists
+ * point at the scopes that contributed each rule, in declaration order)
+ * unless the caller overrides.
+ */
+export function buildLoadedScopes(overrides: LoadedScopesOverrides = {}): LoadedScopes {
+  const overrideByScope = new Map(overrides.scopes?.map((s) => [s.scope, s]) ?? []);
+  const scopes: ScopeView[] = SCOPES.map((scope) =>
+    buildScopeView(overrideByScope.get(scope) ?? { scope, exists: false }),
+  );
+
+  const combined = emptyPermissions();
+  const origins = emptyOrigins();
+  const kinds: PermissionKind[] = ["allow", "deny", "ask"];
+  for (const kind of kinds) {
+    const seen = new Map<string, Scope[]>();
+    for (const view of scopes) {
+      for (const rule of view.permissions[kind]) {
+        const list = seen.get(rule);
+        if (list) list.push(view.scope);
+        else seen.set(rule, [view.scope]);
+      }
+    }
+    for (const [rule, scopesForRule] of seen) {
+      combined[kind].push(rule);
+      origins[kind].push(scopesForRule);
+    }
+  }
+
+  return {
+    project_dir: overrides.project_dir ?? "/fake/project",
+    scopes,
+    combined_permissions: { ...combined, ...(overrides.combined_permissions ?? {}) },
+    combined_origins: { ...origins, ...(overrides.combined_origins ?? {}) },
+  };
+}
+
+export function buildPreferences(overrides: Partial<Preferences> = {}): Preferences {
+  return {
+    visible_scopes: overrides.visible_scopes ?? [...SCOPES],
+  };
+}
+
+export function buildRuntimeInfo(overrides: Partial<RuntimeInfo> = {}): RuntimeInfo {
+  return {
+    home_override: overrides.home_override ?? null,
+    project_override: overrides.project_override ?? null,
+  };
+}

--- a/test/fixtures/loadedScopes.ts
+++ b/test/fixtures/loadedScopes.ts
@@ -59,11 +59,14 @@ interface LoadedScopesOverrides {
 
 /**
  * Builds a `LoadedScopes` payload for a given set of per-scope overrides.
- * Any scope not listed gets a present-but-empty view so the renderer's
- * "exists/no rules" branch is exercised by default. The combined panel
- * is derived from the per-scope `allow`/`deny`/`ask` lists (origin lists
- * point at the scopes that contributed each rule, in declaration order)
- * unless the caller overrides.
+ * Any scope not listed gets an `exists: false` view so the renderer's
+ * "(file not present)" branch is exercised by default — that's the
+ * realistic baseline for a project where most scope files don't exist.
+ * The combined panel is derived from the per-scope `allow`/`deny`/`ask`
+ * lists, mirroring the Rust backend in two ways: contributors are
+ * accumulated in precedence order (highest first — Local→Project→
+ * UserLocal→User), and a rule repeated within a single scope only
+ * counts that scope once. Caller can override either field directly.
  */
 export function buildLoadedScopes(overrides: LoadedScopesOverrides = {}): LoadedScopes {
   const overrideByScope = new Map(overrides.scopes?.map((s) => [s.scope, s]) ?? []);
@@ -71,21 +74,30 @@ export function buildLoadedScopes(overrides: LoadedScopesOverrides = {}): Loaded
     buildScopeView(overrideByScope.get(scope) ?? { scope, exists: false }),
   );
 
+  // SCOPES is UI order (broadest first); the backend iterates precedence
+  // order (highest first), which is the reverse. Walk that order so the
+  // origin lists match what the real `combined_permissions()` produces
+  // and what the scope-origin tooltip claims to show.
+  const precedenceOrder = [...scopes].reverse();
   const combined = emptyPermissions();
   const origins = emptyOrigins();
   const kinds: PermissionKind[] = ["allow", "deny", "ask"];
   for (const kind of kinds) {
-    const seen = new Map<string, Scope[]>();
-    for (const view of scopes) {
+    for (const view of precedenceOrder) {
       for (const rule of view.permissions[kind]) {
-        const list = seen.get(rule);
-        if (list) list.push(view.scope);
-        else seen.set(rule, [view.scope]);
+        const idx = combined[kind].indexOf(rule);
+        if (idx === -1) {
+          combined[kind].push(rule);
+          origins[kind].push([view.scope]);
+        } else if (!origins[kind][idx].includes(view.scope)) {
+          // Same rule listed twice inside one scope file is legal JSON
+          // (and easy to produce by hand-editing); the real backend
+          // dedupes the per-rule contributor list, so the fixture must
+          // too — otherwise the tooltip-order test would render
+          // "Local, Local" where the app shows "Local".
+          origins[kind][idx].push(view.scope);
+        }
       }
-    }
-    for (const [rule, scopesForRule] of seen) {
-      combined[kind].push(rule);
-      origins[kind].push(scopesForRule);
     }
   }
 

--- a/test/fixtures/loadedScopes.ts
+++ b/test/fixtures/loadedScopes.ts
@@ -40,9 +40,15 @@ export function emptyOrigins(): PermissionRuleOrigins {
 
 export function buildScopeView(overrides: ScopeViewOverrides): ScopeView {
   const permissions = { ...emptyPermissions(), ...(overrides.permissions ?? {}) };
+  // `path` is `string | null` on the wire — the Rust backend serializes
+  // null when it can't resolve a scope path. `??` would collapse a
+  // caller-supplied null into the default string, hiding that branch from
+  // tests, so check for `undefined` explicitly.
+  const path =
+    overrides.path !== undefined ? overrides.path : `/fake/${overrides.scope}/settings.json`;
   return {
     scope: overrides.scope,
-    path: overrides.path ?? `/fake/${overrides.scope}/settings.json`,
+    path,
     exists: overrides.exists ?? true,
     permissions,
     other_values: overrides.other_values ?? {},

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -26,9 +26,17 @@ interface PropsOverrides {
 }
 
 function makeProps(overrides: PropsOverrides = {}) {
+  const scopes = overrides.scopes ?? null;
+  // Default `projectDir` from the loaded scopes' `project_dir` so tests
+  // exercise the same render path the real app does (header text, the
+  // `lastRenderedProjectDir` reset that clears `openTreeNodes` when the
+  // project changes). Callers can still pass `projectDir: null` explicitly
+  // to cover the no-project branch.
+  const projectDir =
+    overrides.projectDir !== undefined ? overrides.projectDir : (scopes?.project_dir ?? null);
   return {
-    scopes: overrides.scopes ?? null,
-    projectDir: overrides.projectDir ?? null,
+    scopes,
+    projectDir,
     busy: overrides.busy ?? false,
     query: overrides.query ?? "",
     preferences: overrides.preferences ?? buildPreferences(),

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MoveOptions, MoveRequest, Scope } from "../../src/types.ts";
+import { SEARCH_INPUT_ID } from "../../src/types.ts";
+import { renderApp } from "../../src/ui.ts";
+import { buildLoadedScopes, buildPreferences, buildRuntimeInfo } from "../fixtures/loadedScopes.ts";
+
+function makeRoot(): HTMLElement {
+  const root = document.createElement("div");
+  root.id = "app";
+  document.body.appendChild(root);
+  return root;
+}
+
+function clearBody(): void {
+  while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+}
+
+interface PropsOverrides {
+  scopes?: ReturnType<typeof buildLoadedScopes> | null;
+  projectDir?: string | null;
+  busy?: boolean;
+  query?: string;
+  preferences?: ReturnType<typeof buildPreferences>;
+  runtime?: ReturnType<typeof buildRuntimeInfo>;
+  onMove?: (req: MoveRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
+}
+
+function makeProps(overrides: PropsOverrides = {}) {
+  return {
+    scopes: overrides.scopes ?? null,
+    projectDir: overrides.projectDir ?? null,
+    busy: overrides.busy ?? false,
+    query: overrides.query ?? "",
+    preferences: overrides.preferences ?? buildPreferences(),
+    runtime: overrides.runtime ?? buildRuntimeInfo(),
+    onPickProject: vi.fn(),
+    onReload: vi.fn(),
+    onMove: overrides.onMove ?? vi.fn(),
+    onMoveKey: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onQueryChange: vi.fn(),
+  };
+}
+
+describe("renderApp", () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
+
+  afterEach(() => {
+    clearBody();
+  });
+
+  it("shows the loading message when busy and no scopes are loaded", () => {
+    renderApp(root, makeProps({ busy: true }));
+    const empty = root.querySelector(".empty");
+    expect(empty?.textContent).toBe("Loading…");
+  });
+
+  it("shows the empty message when no scopes are loaded and not busy", () => {
+    renderApp(root, makeProps({ busy: false }));
+    const empty = root.querySelector(".empty");
+    expect(empty?.textContent).toBe("No settings loaded.");
+  });
+
+  it("renders the combined permissions panel with allow/deny/ask counts", () => {
+    const scopes = buildLoadedScopes({
+      scopes: [
+        {
+          scope: "project",
+          permissions: { allow: ["Bash(git status)", "Read(**)"], deny: ["Bash(rm -rf *)"] },
+        },
+        {
+          scope: "user",
+          permissions: { ask: ["WebFetch(domain:example.com)"] },
+        },
+      ],
+    });
+    renderApp(root, makeProps({ scopes }));
+    const labels = Array.from(root.querySelectorAll(".combo-label")).map((el) => el.textContent);
+    expect(labels).toEqual(["allow (2)", "deny (1)", "ask (1)"]);
+    const allowChips = root.querySelectorAll(".combo-allow .chip");
+    expect(Array.from(allowChips).map((c) => c.textContent)).toEqual([
+      "Bash(git status)",
+      "Read(**)",
+    ]);
+  });
+
+  it("renders matched/total counts when a query filters the combined panel", () => {
+    const scopes = buildLoadedScopes({
+      scopes: [
+        {
+          scope: "project",
+          permissions: { allow: ["Bash(git status)", "Read(**)", "Bash(npm test)"] },
+        },
+      ],
+    });
+    renderApp(root, makeProps({ scopes, query: "git" }));
+    const allowLabel = root.querySelector(".combo-allow .combo-label");
+    expect(allowLabel?.textContent).toBe("allow (1/3)");
+  });
+
+  it("preserves search input focus and caret across a re-render", () => {
+    const scopes = buildLoadedScopes({
+      scopes: [{ scope: "project", permissions: { allow: ["Bash(git status)"] } }],
+    });
+    renderApp(root, makeProps({ scopes }));
+    const input = document.getElementById(SEARCH_INPUT_ID) as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+    if (!input) return;
+    input.value = "git";
+    input.focus();
+    input.setSelectionRange(2, 2);
+    renderApp(root, makeProps({ scopes, query: "git" }));
+    const after = document.getElementById(SEARCH_INPUT_ID) as HTMLInputElement | null;
+    expect(document.activeElement).toBe(after);
+    expect(after?.selectionStart).toBe(2);
+    expect(after?.selectionEnd).toBe(2);
+  });
+
+  it("invokes onMove with the expected request when a per-scope move button is clicked", () => {
+    const onMove = vi.fn();
+    const scopes = buildLoadedScopes({
+      scopes: [{ scope: "project", permissions: { allow: ["Bash(git status)"] } }],
+    });
+    renderApp(root, makeProps({ scopes, onMove }));
+    // The project column has buttons targeting every other visible scope.
+    // Pick the one targeting "user" so the click is unambiguous.
+    const buttons = Array.from(
+      root.querySelectorAll<HTMLButtonElement>(".rule-group .rule-moves .move-btn"),
+    );
+    const toUser = buttons.find((b) => b.textContent === "→ User");
+    expect(toUser).toBeDefined();
+    toUser?.click();
+    expect(onMove).toHaveBeenCalledTimes(1);
+    const [req] = onMove.mock.calls[0];
+    expect(req).toEqual({
+      rule: "Bash(git status)",
+      kind: "allow",
+      from: "project",
+      to: "user",
+    });
+  });
+
+  it("renders a lint warning badge for a malformed rule", () => {
+    const scopes = buildLoadedScopes({
+      scopes: [{ scope: "project", permissions: { allow: ["bash(git status)"] } }],
+    });
+    renderApp(root, makeProps({ scopes }));
+    // Lower-case `bash` falls into the lint's "Unknown tool" branch and the
+    // badge is the only warning in the tree, so a single check across the
+    // whole root is enough.
+    const badges = root.querySelectorAll(".lint-warn");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+    expect(badges[0].textContent).toBe("⚠");
+  });
+
+  it("hides scope columns the user has marked invisible", () => {
+    const visible: Scope[] = ["project"];
+    const scopes = buildLoadedScopes({
+      scopes: [
+        { scope: "project", permissions: { allow: ["Bash(git status)"] } },
+        { scope: "user", permissions: { allow: ["Bash(ls)"] } },
+      ],
+    });
+    renderApp(
+      root,
+      makeProps({ scopes, preferences: buildPreferences({ visible_scopes: visible }) }),
+    );
+    const headings = Array.from(root.querySelectorAll(".col h3")).map((el) => el.textContent);
+    expect(headings).toEqual(["Project"]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src", "test", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    include: ["test/**/*.test.ts"],
+    css: false,
+  },
+});


### PR DESCRIPTION
## Summary

- Adds Vitest + happy-dom as the renderer-level unit-test layer (issue #69, milestone v0.4) with a fast, in-memory DOM the existing vanilla-TS UI can drive directly.
- Eight `renderApp` tests cover loading/empty branches, combined-permissions counts, filtered matched/total counts, search-input focus + caret restoration across re-render, `onMove` payload from a per-scope move button, lint warning badge on a malformed rule, and visible-scope preference column hiding.
- TS-side fixture builders under `test/fixtures/loadedScopes.ts` keep the layer disk-free; the later disk-backed E2E layer (out of scope here) can grow under `test/fixtures/projects/`.
- CI runs `npm run test:unit` on Ubuntu only — happy-dom is OS-agnostic so cross-OS fan-out adds runtime without buying signal until something proves OS-specific. Not wired into `.pre-commit-config.yaml` per the issue.

Closes #69.

## Test plan

- [x] `npm run test:unit` passes locally (8/8)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` still produces the same artefact
- [ ] CI green on Ubuntu / Windows / macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)