### PR TITLE
fix(ci): drop component prefix from release-please tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "draft": true,
   "force-tag-creation": true,
   "packages": {


### PR DESCRIPTION
## Summary

`release.yml` triggers on `tags: ["v*.*.*"]`, but release-please was tagging as `claude-scope-v0.3.0` because `include-component-in-tag` defaults to `true` in the action and our config didn't override it. The prefix mismatch is why merging #93 published a draft release with **no installers and no `SHA256SUMS.txt`** — only the GitHub-auto-generated source archives.

Set `include-component-in-tag: false` so the next release tags as `v0.4.0` and matches the existing trigger.

## What this does NOT fix

The current draft release at tag `claude-scope-v0.3.0` is still empty. Two options to populate it:

1. **`workflow_dispatch` `release.yml`** with `tag_name: claude-scope-v0.3.0` — builds installers + sums onto the existing draft. Tag stays `claude-scope-v0.3.0`.
2. **Delete the tag + draft release**, re-tag the same commit as `v0.3.0`, push — fires `release.yml` normally, clean tag history. Destructive (deletes the draft release object).

Either is fine; this PR is independent of which one you pick.

## Test plan

- [ ] Land this PR.
- [ ] Verify next release-please run picks up `include-component-in-tag: false` (tag will be `v<next>`).
- [ ] Resolve the v0.3.0 draft via option (1) or (2) above.