### PR TITLE
chore: enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Enforce LF line endings on checkout for all text files, regardless of the
+# user's core.autocrlf setting. See issue #92.
+* text=auto eol=lf
+
+# Tracked binaries — never normalize.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.ico  binary
+*.icns binary


### PR DESCRIPTION
## Summary

- Adds top-level `.gitattributes` with `* text=auto eol=lf` so new clones get an LF working tree regardless of `core.autocrlf` (Git for Windows defaults to `true`)
- Marks tracked image/icon binaries (`*.png`, `*.jpg`, `*.jpeg`, `*.ico`, `*.icns`) as `binary` so they're never normalized
- `git add --renormalize .` produced no diffs — pre-commit's `mixed-line-ending` hook has been keeping the index LF-only, so this just formalizes the invariant without a tree rewrite

## Verification

- `git check-attr -a -- src-tauri/Cargo.lock` → `text: auto`, `eol: lf` ✓
- `git check-attr -a -- src-tauri/icons/icon.png` → `binary: set`, `text: unset` ✓
- `git check-attr -a -- README.md` → `text: auto`, `eol: lf` ✓

## Test plan

- [ ] CI passes on Linux (existing checks should be unaffected)
- [ ] Fresh clone on Windows with `core.autocrlf=true` produces LF working tree (`git diff --check` clean)
- [ ] Pre-commit's `mixed-line-ending` hook stays in place as belt-and-suspenders (tracking removal as a separate decision per issue's acceptance criteria)

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)