### PR TITLE
docs: drop broken compare link in 0.3.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.3.0](https://github.com/bminier/claude-scope/compare/claude-scope-v0.2.0...claude-scope-v0.3.0) (2026-05-03)
+## 0.3.0 (2026-05-03)
 
 
 ### Features


### PR DESCRIPTION
## Summary

- The 0.3.0 entry in `CHANGELOG.md` linked to `compare/claude-scope-v0.2.0...claude-scope-v0.3.0`. Neither tag exists — release-please generated this before PR #94 dropped the component prefix, and there was never a v0.2.0 release tag (release-please used `bootstrap-sha` for the first release).
- Replaced the broken link with a plain version + date header. Future entries (0.3.0 → 0.4.0) will compare against the real `v0.3.0` tag and won't need intervention.

## Why this surfaced now

#76 (the weekly link-rot tracking issue) flagged the 404 on its first run after release-please landed. The `https://tauri.app/` "broken link" in the same report is a stuck cache entry from an earlier transient runner network failure — that needs a separate `gh cache delete` after this merges, then a `workflow_dispatch` re-run will close the issue.

## Test plan

- [x] `git diff CHANGELOG.md` shows only the heading line changes
- [ ] Post-merge: invalidate lychee cache (`lychee-Linux-2026-18`) and re-run `link-check.yml` on dev — confirm clean run auto-closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)