### PR TITLE
feat(ui): add light theme with auto/light/dark override (#38)

### DIFF
--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -44,7 +44,7 @@ pub struct Preferences {
     pub visible_scopes: Vec<Scope>,
     /// Color theme override. `Auto` defers to the OS at the JS layer;
     /// `Light`/`Dark` pin the palette regardless of OS preference.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_theme")]
     pub theme: Theme,
 }
 
@@ -85,6 +85,22 @@ where
 {
     let raw = Vec::<Scope>::deserialize(deserializer)?;
     Ok(normalize_visible_scopes(raw))
+}
+
+/// Deserialize a `Theme` value, falling back to `Auto` for any unrecognized
+/// string. Without this, an unknown variant (e.g. from a hand-edited config or
+/// a future version adding a new theme) would cause `serde_json::from_slice`
+/// to fail and `load()` to silently reset *all* preferences via `unwrap_or_default`.
+fn deserialize_theme<'de, D>(deserializer: D) -> Result<Theme, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer).unwrap_or_default();
+    Ok(match s.as_str() {
+        "light" => Theme::Light,
+        "dark" => Theme::Dark,
+        _ => Theme::Auto,
+    })
 }
 
 /// Resolve the on-disk path for the config file. `None` when the OS couldn't
@@ -223,6 +239,17 @@ mod tests {
             let parsed: Preferences = serde_json::from_str(&json).unwrap();
             assert_eq!(parsed.theme, theme);
         }
+    }
+
+    #[test]
+    fn unknown_theme_value_falls_back_to_auto_without_losing_other_fields() {
+        // A hand-edited config or a future schema with an unrecognized theme
+        // variant must degrade to Auto rather than failing the whole parse and
+        // resetting visible_scopes (and any other fields) via unwrap_or_default.
+        let prefs: Preferences =
+            serde_json::from_str(r#"{"visible_scopes":["project"],"theme":"sepia"}"#).unwrap();
+        assert_eq!(prefs.theme, Theme::Auto);
+        assert_eq!(prefs.visible_scopes, vec![Scope::Project]);
     }
 
     #[test]

--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -20,6 +20,16 @@ use crate::scope::Scope;
 /// Shape of the persisted config file. Every field carries a `#[serde(default)]`
 /// so unknown or missing keys degrade gracefully to sensible defaults — the
 /// schema can evolve without forcing a migration on every launch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Theme {
+    /// Follow the OS `prefers-color-scheme` value at runtime.
+    #[default]
+    Auto,
+    Light,
+    Dark,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Preferences {
     /// Scope columns the user wants visible. Defaults to all four. The
@@ -32,12 +42,17 @@ pub struct Preferences {
         deserialize_with = "deserialize_visible_scopes"
     )]
     pub visible_scopes: Vec<Scope>,
+    /// Color theme override. `Auto` defers to the OS at the JS layer;
+    /// `Light`/`Dark` pin the palette regardless of OS preference.
+    #[serde(default)]
+    pub theme: Theme,
 }
 
 impl Default for Preferences {
     fn default() -> Self {
         Self {
             visible_scopes: default_visible_scopes(),
+            theme: Theme::default(),
         }
     }
 }
@@ -176,10 +191,50 @@ mod tests {
     fn round_trips_through_json() {
         let prefs = Preferences {
             visible_scopes: vec![Scope::Local, Scope::Project],
+            theme: Theme::Light,
         };
         let json = serde_json::to_string(&prefs).unwrap();
         let parsed: Preferences = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, prefs);
+    }
+
+    #[test]
+    fn theme_defaults_to_auto() {
+        let prefs = Preferences::default();
+        assert_eq!(prefs.theme, Theme::Auto);
+    }
+
+    #[test]
+    fn deserializes_with_missing_theme_field() {
+        // Older configs predate the theme field; missing key must collapse
+        // to the default rather than fail the whole load.
+        let prefs: Preferences = serde_json::from_str(r#"{"visible_scopes":["project"]}"#).unwrap();
+        assert_eq!(prefs.theme, Theme::Auto);
+    }
+
+    #[test]
+    fn theme_round_trips_through_json_for_each_variant() {
+        for theme in [Theme::Auto, Theme::Light, Theme::Dark] {
+            let prefs = Preferences {
+                visible_scopes: default_visible_scopes(),
+                theme,
+            };
+            let json = serde_json::to_string(&prefs).unwrap();
+            let parsed: Preferences = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.theme, theme);
+        }
+    }
+
+    #[test]
+    fn theme_serializes_lowercase() {
+        let prefs = Preferences {
+            visible_scopes: default_visible_scopes(),
+            theme: Theme::Dark,
+        };
+        let json = serde_json::to_string(&prefs).unwrap();
+        // The JS side reads this string verbatim — pinning the casing
+        // here keeps the IPC contract from drifting silently.
+        assert!(json.contains(r#""theme":"dark""#));
     }
 
     /// Exercise the save path against a real filesystem so the
@@ -194,6 +249,7 @@ mod tests {
 
         let first = Preferences {
             visible_scopes: vec![Scope::Local],
+            theme: Theme::Auto,
         };
         let body = serde_json::to_vec_pretty(&first).unwrap();
         let parent = target.parent().unwrap();
@@ -207,6 +263,7 @@ mod tests {
         // alone would fail on Windows.
         let second = Preferences {
             visible_scopes: vec![Scope::Project, Scope::User],
+            theme: Theme::Dark,
         };
         let body2 = serde_json::to_vec_pretty(&second).unwrap();
         let mut tmpfile2 = tempfile::NamedTempFile::new_in(parent).unwrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import type {
   Preferences,
   RuntimeInfo,
   Scope,
+  Theme,
 } from "./types.ts";
 import { SCOPES, SEARCH_INPUT_ID } from "./types.ts";
 import { confirmMove, confirmMoveKey, openSettings, renderApp } from "./ui.ts";
@@ -23,6 +24,7 @@ import { confirmMove, confirmMoveKey, openSettings, renderApp } from "./ui.ts";
 // a new scope can't leave this list out of sync.
 const DEFAULT_PREFERENCES: Preferences = {
   visible_scopes: [...SCOPES],
+  theme: "auto",
 };
 
 const state: {
@@ -208,6 +210,47 @@ function setQuery(next: string): void {
   render();
 }
 
+// `prefers-color-scheme` listener used while the active theme is "auto".
+// We attach at most one — re-attaching on every render would either leak
+// listeners or require addEventListener-with-a-stable-reference contortions.
+// `null` means "no listener installed right now" (theme is light or dark).
+const prefersDarkMql =
+  typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-color-scheme: dark)")
+    : null;
+let autoThemeListener: ((evt: MediaQueryListEvent) => void) | null = null;
+
+function resolveTheme(theme: Theme): "light" | "dark" {
+  if (theme === "auto") {
+    return prefersDarkMql?.matches ? "dark" : "light";
+  }
+  return theme;
+}
+
+/**
+ * Apply the chosen theme to the document and (de)attach the OS-tracking
+ * listener. Safe to call repeatedly — the listener bookkeeping ensures we
+ * never end up with two listeners installed.
+ */
+function applyTheme(theme: Theme): void {
+  document.documentElement.setAttribute("data-theme", resolveTheme(theme));
+
+  if (!prefersDarkMql) return;
+  if (theme === "auto") {
+    if (autoThemeListener) return;
+    autoThemeListener = () => {
+      // The user's preference is still "auto" by construction (we only
+      // keep this listener attached while that's true), so re-resolve and
+      // repaint without touching state.preferences.
+      document.documentElement.setAttribute("data-theme", resolveTheme("auto"));
+    };
+    prefersDarkMql.addEventListener("change", autoThemeListener);
+  } else if (autoThemeListener) {
+    prefersDarkMql.removeEventListener("change", autoThemeListener);
+    autoThemeListener = null;
+  }
+}
+
 // Serialize preference saves: at most one in-flight call, with the latest
 // pending state always winning. Without this, rapid toggles could produce
 // overlapping `save_preferences` invokes whose completion order isn't
@@ -220,7 +263,11 @@ async function persistPreferences(next: Preferences): Promise<void> {
   // Update state + render immediately so the UI feels instant; persist in
   // the background. If the save fails, warn the user — stale in-memory
   // state is easier to reason about than a silent mismatch with disk.
+  const prev = state.preferences;
   state.preferences = next;
+  if (prev.theme !== next.theme) {
+    applyTheme(next.theme);
+  }
   render();
   pendingPreferencesSave = next;
   if (preferencesSaveInFlight) return;
@@ -249,11 +296,17 @@ function onToggleScopeVisibility(scope: Scope, visible: boolean): void {
   void persistPreferences({ ...state.preferences, visible_scopes: next });
 }
 
+function onChangeTheme(theme: Theme): void {
+  if (state.preferences.theme === theme) return;
+  void persistPreferences({ ...state.preferences, theme });
+}
+
 function onOpenSettings(trigger?: HTMLElement): void {
   void openSettings(
     {
       preferences: state.preferences,
       onToggleScopeVisibility,
+      onChangeTheme,
     },
     trigger,
   );
@@ -346,6 +399,11 @@ async function bootstrap(): Promise<void> {
   } else {
     console.warn("failed to load preferences, using defaults:", prefsResult.reason);
   }
+  // Apply theme as soon as we know it — before the scope load runs, so the
+  // load-busy spinner paints in the correct palette. The default `:root`
+  // CSS variables are dark, so this is also the moment any cold-start
+  // flash flips to light when the user has light selected.
+  applyTheme(state.preferences.theme);
   if (runtimeResult.status === "fulfilled") {
     state.runtime = runtimeResult.value;
   } else {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,16 @@
+/*
+ * Palette tokens. The default `:root` block is the dark palette — it's also
+ * what paints during the brief window between first paint and `applyTheme()`
+ * resolving on cold start, so a dark-flash on light-themed launches is the
+ * trade we accepted (vs. introducing a localStorage shadow). The
+ * `[data-theme="light"]` block overrides every token whose dark value would
+ * be wrong on a light background.
+ *
+ * Semantic tokens (--ring-focus, --shadow-modal, etc.) exist so component
+ * styles don't have to know whether they're rendering against a light or
+ * dark background — they always reference the same variable, and the
+ * variable resolves correctly in either palette.
+ */
 :root {
   --bg: #0f1115;
   --panel: #161a21;
@@ -10,6 +23,50 @@
   --deny: #e67e7e;
   --ask: #e8c374;
   --err: #ff6b6b;
+
+  --ring-focus: rgba(122, 162, 247, 0.25);
+  --shadow-modal: rgba(0, 0, 0, 0.5);
+  --backdrop: rgba(0, 0, 0, 0.55);
+  --drop-target-bg: rgba(122, 162, 247, 0.05);
+  --drop-target-border: rgba(122, 162, 247, 0.25);
+  --diff-add-bg: rgba(143, 201, 127, 0.15);
+  --diff-remove-bg: rgba(230, 126, 126, 0.12);
+  --lint-warn-bg: rgba(232, 195, 116, 0.12);
+  --lint-warn-ring: rgba(232, 195, 116, 0.35);
+  --popover-shadow: rgba(0, 0, 0, 0.45);
+  --sandbox-bg: #3a2e10;
+  --sandbox-text: #ffd479;
+  --sandbox-text-strong: #ffe2a0;
+  --sandbox-border: #5a4416;
+}
+
+:root[data-theme="light"] {
+  --bg: #f7f8fa;
+  --panel: #ffffff;
+  --panel-2: #eef0f4;
+  --border: #d4d8e0;
+  --text: #14161a;
+  --muted: #5b6472;
+  --accent: #3760c5;
+  --allow: #2f7a26;
+  --deny: #b3261e;
+  --ask: #8a6212;
+  --err: #b3261e;
+
+  --ring-focus: rgba(55, 96, 197, 0.25);
+  --shadow-modal: rgba(20, 22, 26, 0.18);
+  --backdrop: rgba(20, 22, 26, 0.35);
+  --drop-target-bg: rgba(55, 96, 197, 0.07);
+  --drop-target-border: rgba(55, 96, 197, 0.3);
+  --diff-add-bg: rgba(47, 122, 38, 0.1);
+  --diff-remove-bg: rgba(179, 38, 30, 0.08);
+  --lint-warn-bg: rgba(138, 98, 18, 0.1);
+  --lint-warn-ring: rgba(138, 98, 18, 0.3);
+  --popover-shadow: rgba(20, 22, 26, 0.22);
+  --sandbox-bg: #fff4d4;
+  --sandbox-text: #6a4c00;
+  --sandbox-text-strong: #4a3500;
+  --sandbox-border: #e0c373;
 }
 
 * {
@@ -47,9 +104,9 @@ body {
  * equivalent) is set at launch. Amber on dark amber to read as a warning
  * without escalating to an error red. */
 .sandbox-banner {
-  background: #3a2e10;
-  color: #ffd479;
-  border-bottom: 1px solid #5a4416;
+  background: var(--sandbox-bg);
+  color: var(--sandbox-text);
+  border-bottom: 1px solid var(--sandbox-border);
   padding: 8px 16px;
   font-size: 13px;
   display: flex;
@@ -64,7 +121,7 @@ body {
 }
 
 .sandbox-banner strong {
-  color: #ffe2a0;
+  color: var(--sandbox-text-strong);
 }
 
 .search {
@@ -96,7 +153,7 @@ body {
   border-color: var(--accent);
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  box-shadow: 0 0 0 2px rgba(122, 162, 247, 0.25);
+  box-shadow: 0 0 0 2px var(--ring-focus);
 }
 
 .search-input:disabled {
@@ -302,8 +359,8 @@ button:disabled {
    consistently across mouse and keyboard input. */
 .col-drop-active {
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(122, 162, 247, 0.25);
-  background: rgba(122, 162, 247, 0.05);
+  box-shadow: 0 0 0 2px var(--drop-target-border);
+  background: var(--drop-target-bg);
 }
 
 /* Grab cursors on the actual drag handles. Only applied when JS marks the
@@ -507,7 +564,7 @@ button:disabled {
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.55);
+  background: var(--backdrop);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -523,7 +580,7 @@ button:disabled {
   width: min(900px, 100%);
   max-height: 90vh;
   overflow: auto;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 20px 60px var(--shadow-modal);
 }
 
 .modal-title {
@@ -655,13 +712,13 @@ button:disabled {
 }
 
 .modal-diff-list .diff-removed {
-  background: rgba(230, 126, 126, 0.12);
+  background: var(--diff-remove-bg);
   color: var(--deny);
   text-decoration: line-through;
 }
 
 .modal-diff-list .diff-added {
-  background: rgba(143, 201, 127, 0.15);
+  background: var(--diff-add-bg);
   color: var(--allow);
 }
 
@@ -742,14 +799,14 @@ button:disabled {
      warning color explicitly so the badge stays in its lint palette. */
   color: var(--ask);
   border-color: var(--ask);
-  background: rgba(232, 195, 116, 0.12);
+  background: var(--lint-warn-bg);
 }
 
 .lint-warn:focus-visible {
   outline: none;
   color: var(--ask);
   border-color: var(--ask);
-  box-shadow: 0 0 0 2px rgba(232, 195, 116, 0.35);
+  box-shadow: 0 0 0 2px var(--lint-warn-ring);
 }
 
 .lint-warn-popover {
@@ -765,7 +822,7 @@ button:disabled {
   color: var(--text);
   border: 1px solid var(--border);
   border-radius: 6px;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 6px 18px var(--popover-shadow);
   font-size: 12px;
   line-height: 1.35;
   white-space: normal;
@@ -865,7 +922,7 @@ button:disabled {
   color: var(--text);
   border: 1px solid var(--border);
   border-radius: 6px;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 6px 18px var(--popover-shadow);
   font-size: 12px;
   line-height: 1.35;
   white-space: normal;

--- a/src/styles.css
+++ b/src/styles.css
@@ -38,6 +38,8 @@
   --sandbox-text: #ffd479;
   --sandbox-text-strong: #ffe2a0;
   --sandbox-border: #5a4416;
+
+  color-scheme: dark;
 }
 
 :root[data-theme="light"] {
@@ -67,6 +69,8 @@
   --sandbox-text: #6a4c00;
   --sandbox-text-strong: #4a3500;
   --sandbox-border: #e0c373;
+
+  color-scheme: light;
 }
 
 * {

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,12 +125,21 @@ export interface MoveKeyPreview {
 export const SEARCH_INPUT_ID = "rule-search";
 
 /**
+ * Color theme override. `auto` defers to the OS `prefers-color-scheme`
+ * value at runtime; `light` / `dark` pin the palette regardless of OS
+ * preference. Keep the variants lowercase — the Rust side serializes via
+ * `serde(rename_all = "lowercase")` and these strings cross the IPC verbatim.
+ */
+export type Theme = "auto" | "light" | "dark";
+
+/**
  * User preferences persisted to the OS config dir. Schema mirrors the Rust
  * `Preferences` struct; the backend fills in defaults for missing fields,
  * so this is always complete as read from the IPC.
  */
 export interface Preferences {
   visible_scopes: Scope[];
+  theme: Theme;
 }
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1294,7 +1294,7 @@ function settingsThemeSection(props: SettingsProps): HTMLElement {
   // settings-checklist sibling already follows that pattern).
   const list = document.createElement("div");
   list.className = "settings-checklist";
-  list.setAttribute("role", "group");
+  list.setAttribute("role", "radiogroup");
   list.setAttribute("aria-labelledby", "settings-theme-heading");
   const groupName = "settings-theme";
   for (const opt of THEME_OPTIONS) {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -14,6 +14,7 @@ import type {
   RuntimeInfo,
   Scope,
   ScopeView,
+  Theme,
 } from "./types.ts";
 import { SCOPES, SEARCH_INPUT_ID } from "./types.ts";
 
@@ -1230,7 +1231,14 @@ function formatValue(v: JsonValue | undefined): string {
 interface SettingsProps {
   preferences: Preferences;
   onToggleScopeVisibility: (scope: Scope, visible: boolean) => void;
+  onChangeTheme: (theme: Theme) => void;
 }
+
+const THEME_OPTIONS: ReadonlyArray<{ value: Theme; label: string }> = [
+  { value: "auto", label: "Match system" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+];
 
 /**
  * Open the settings dialog. Changes persist as the user clicks — there's no
@@ -1245,9 +1253,13 @@ interface SettingsProps {
  * stray keypresses.
  */
 export function openSettings(props: SettingsProps, trigger?: HTMLElement | null): void {
+  const body = document.createElement("div");
+  body.appendChild(settingsThemeSection(props));
+  body.appendChild(settingsColumnsSection(props));
+
   openModal({
     titleText: "Settings",
-    body: settingsColumnsSection(props),
+    body,
     actions: [
       {
         label: "Close",
@@ -1259,6 +1271,48 @@ export function openSettings(props: SettingsProps, trigger?: HTMLElement | null)
     panelClassName: "modal-settings",
     trigger,
   });
+}
+
+function settingsThemeSection(props: SettingsProps): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "settings-section";
+
+  const heading = document.createElement("h3");
+  heading.className = "settings-heading";
+  heading.textContent = "Theme";
+  section.appendChild(heading);
+
+  const hint = document.createElement("p");
+  hint.className = "settings-hint";
+  hint.textContent = "Match the OS or pin a palette. Persists across launches.";
+  section.appendChild(hint);
+
+  // Shared `name` so the radios behave as a single group with arrow-key
+  // navigation. Keep the value local so subsequent re-renders within this
+  // dialog could read it back (today there are none, but the
+  // settings-checklist sibling already follows that pattern).
+  const list = document.createElement("div");
+  list.className = "settings-checklist";
+  const groupName = "settings-theme";
+  for (const opt of THEME_OPTIONS) {
+    const row = document.createElement("label");
+    row.className = "settings-check";
+    const input = document.createElement("input");
+    input.type = "radio";
+    input.name = groupName;
+    input.value = opt.value;
+    input.checked = props.preferences.theme === opt.value;
+    input.addEventListener("change", () => {
+      if (input.checked) props.onChangeTheme(opt.value);
+    });
+    row.appendChild(input);
+    const label = document.createElement("span");
+    label.textContent = opt.label;
+    row.appendChild(label);
+    list.appendChild(row);
+  }
+  section.appendChild(list);
+  return section;
 }
 
 function settingsColumnsSection(props: SettingsProps): HTMLElement {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1278,6 +1278,7 @@ function settingsThemeSection(props: SettingsProps): HTMLElement {
   section.className = "settings-section";
 
   const heading = document.createElement("h3");
+  heading.id = "settings-theme-heading";
   heading.className = "settings-heading";
   heading.textContent = "Theme";
   section.appendChild(heading);
@@ -1293,6 +1294,8 @@ function settingsThemeSection(props: SettingsProps): HTMLElement {
   // settings-checklist sibling already follows that pattern).
   const list = document.createElement("div");
   list.className = "settings-checklist";
+  list.setAttribute("role", "group");
+  list.setAttribute("aria-labelledby", "settings-theme-heading");
   const groupName = "settings-theme";
   for (const opt of THEME_OPTIONS) {
     const row = document.createElement("label");

--- a/test/fixtures/loadedScopes.ts
+++ b/test/fixtures/loadedScopes.ts
@@ -118,6 +118,7 @@ export function buildLoadedScopes(overrides: LoadedScopesOverrides = {}): Loaded
 export function buildPreferences(overrides: Partial<Preferences> = {}): Preferences {
   return {
     visible_scopes: overrides.visible_scopes ?? [...SCOPES],
+    theme: overrides.theme ?? "auto",
   };
 }
 

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { MoveOptions, MoveRequest, Scope } from "../../src/types.ts";
+import type { MoveOptions, MoveRequest, Scope, Theme } from "../../src/types.ts";
 import { SEARCH_INPUT_ID } from "../../src/types.ts";
-import { renderApp } from "../../src/ui.ts";
+import { openSettings, renderApp } from "../../src/ui.ts";
 import { buildLoadedScopes, buildPreferences, buildRuntimeInfo } from "../fixtures/loadedScopes.ts";
 
 function makeRoot(): HTMLElement {
@@ -179,5 +179,60 @@ describe("renderApp", () => {
     );
     const headings = Array.from(root.querySelectorAll(".col h3")).map((el) => el.textContent);
     expect(headings).toEqual(["Project"]);
+  });
+});
+
+describe("openSettings – theme radios", () => {
+  afterEach(() => {
+    clearBody();
+  });
+
+  function makeSettingsProps(theme: Theme = "auto", onChangeTheme = vi.fn()) {
+    return {
+      preferences: buildPreferences({ theme }),
+      onToggleScopeVisibility: vi.fn(),
+      onChangeTheme,
+    };
+  }
+
+  function getThemeRadios(): HTMLInputElement[] {
+    return Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[name="settings-theme"]'),
+    );
+  }
+
+  it("renders three theme radios (auto, light, dark)", () => {
+    openSettings(makeSettingsProps());
+    const radios = getThemeRadios();
+    expect(radios).toHaveLength(3);
+    expect(radios.map((r) => r.value)).toEqual(["auto", "light", "dark"]);
+  });
+
+  it("checks the radio matching the current theme preference", () => {
+    for (const theme of ["auto", "light", "dark"] as Theme[]) {
+      clearBody();
+      openSettings(makeSettingsProps(theme));
+      const checked = getThemeRadios().find((r) => r.checked);
+      expect(checked?.value).toBe(theme);
+    }
+  });
+
+  it("calls onChangeTheme with the selected value when a radio is changed", () => {
+    const onChangeTheme = vi.fn();
+    openSettings(makeSettingsProps("auto", onChangeTheme));
+    const darkRadio = getThemeRadios().find((r) => r.value === "dark");
+    expect(darkRadio).toBeDefined();
+    darkRadio!.checked = true;
+    darkRadio!.dispatchEvent(new Event("change"));
+    expect(onChangeTheme).toHaveBeenCalledTimes(1);
+    expect(onChangeTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("radio group has ARIA group role with label pointing to the heading", () => {
+    openSettings(makeSettingsProps());
+    const group = document.querySelector('[role="group"][aria-labelledby="settings-theme-heading"]');
+    expect(group).not.toBeNull();
+    const heading = document.getElementById("settings-theme-heading");
+    expect(heading?.textContent).toBe("Theme");
   });
 });

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -228,9 +228,9 @@ describe("openSettings – theme radios", () => {
     expect(onChangeTheme).toHaveBeenCalledWith("dark");
   });
 
-  it("radio group has ARIA group role with label pointing to the heading", () => {
+  it("radio group has ARIA radiogroup role with label pointing to the heading", () => {
     openSettings(makeSettingsProps());
-    const group = document.querySelector('[role="group"][aria-labelledby="settings-theme-heading"]');
+    const group = document.querySelector('[role="radiogroup"][aria-labelledby="settings-theme-heading"]');
     expect(group).not.toBeNull();
     const heading = document.getElementById("settings-theme-heading");
     expect(heading?.textContent).toBe("Theme");

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -196,9 +196,7 @@ describe("openSettings – theme radios", () => {
   }
 
   function getThemeRadios(): HTMLInputElement[] {
-    return Array.from(
-      document.querySelectorAll<HTMLInputElement>('input[name="settings-theme"]'),
-    );
+    return Array.from(document.querySelectorAll<HTMLInputElement>('input[name="settings-theme"]'));
   }
 
   it("renders three theme radios (auto, light, dark)", () => {
@@ -222,15 +220,18 @@ describe("openSettings – theme radios", () => {
     openSettings(makeSettingsProps("auto", onChangeTheme));
     const darkRadio = getThemeRadios().find((r) => r.value === "dark");
     expect(darkRadio).toBeDefined();
-    darkRadio!.checked = true;
-    darkRadio!.dispatchEvent(new Event("change"));
+    if (!darkRadio) return;
+    darkRadio.checked = true;
+    darkRadio.dispatchEvent(new Event("change"));
     expect(onChangeTheme).toHaveBeenCalledTimes(1);
     expect(onChangeTheme).toHaveBeenCalledWith("dark");
   });
 
   it("radio group has ARIA radiogroup role with label pointing to the heading", () => {
     openSettings(makeSettingsProps());
-    const group = document.querySelector('[role="radiogroup"][aria-labelledby="settings-theme-heading"]');
+    const group = document.querySelector(
+      '[role="radiogroup"][aria-labelledby="settings-theme-heading"]',
+    );
     expect(group).not.toBeNull();
     const heading = document.getElementById("settings-theme-heading");
     expect(heading?.textContent).toBe("Theme");


### PR DESCRIPTION
Closes #38.

## Summary

- Splits `src/styles.css` into a dark `:root` palette and a `:root[data-theme="light"]` override; tokenizes every previously-hardcoded rgba/hex (focus ring, drop-target highlight, modal backdrop/shadow, diff +/− rows, lint-warn chip bg/ring, popover shadow, sandbox banner) so theme-sensitive surfaces resolve against the active palette.
- Extends the persisted `Preferences` schema with a `theme` field (`auto` / `light` / `dark`) via a new `Theme` enum. `#[serde(default)]` keeps existing configs loadable as `Auto`. The IPC contract is the lowercase string used verbatim on both sides.
- Adds `applyTheme()` in `src/main.ts` with a single managed `matchMedia('(prefers-color-scheme: dark)')` listener — attached only while the user's choice is `auto`, so OS flips repaint live without lingering listeners after the user pins `light`/`dark`.
- Settings modal grows a "Theme" radio group ("Match system" / "Light" / "Dark") above the existing scope-columns section, reusing `.settings-section` / `.settings-checklist` chrome.

## Decisions

- **Cold-start flash:** apply theme inside `bootstrap()` after `load_preferences` resolves. Brief dark-flash on light-themed launches is accepted in exchange for not introducing a localStorage shadow as a second source of truth.
- **OS auto-track:** when `theme === "auto"`, a single `change` listener on `prefers-color-scheme` repaints without reload. Listener is detached when the user pins a non-auto choice.
- **Persistence absorbed into this slice:** the issue body parked persistence behind a separate "settings page" issue, but the existing `Preferences` round-trip (rust `preferences.rs` + TS `persistPreferences`) was already the right home, so adding a single field was lower-friction than splitting the work.

## Test plan

- [x] `cargo test -- --skip scope::` (115/115 pass; new tests cover `Theme` default, missing-key fallback, per-variant round-trip, lowercase serialization).
- [x] `npm run test:unit` (8/8 pass; `buildPreferences` fixture updated).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` (biome) clean.
- [x] `npm run tauri dev` boots cleanly.
- [ ] Manual: toggle Match system / Light / Dark from Settings — palette flips immediately.
- [ ] Manual: with "Match system" selected, change Windows Settings → Personalization → Colors → Light/Dark — app follows live.
- [ ] Manual: quit + relaunch — selection survives.
- [ ] Manual spot-check on light: focus ring, drop-target highlight, move-confirm modal (backdrop/shadow + diff rows), lint-warn chip hover/focus, sandbox banner (`--home <path>` to trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)