### PR TITLE
feat: unify permissions display + moves with path-based primitive (#67)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1017,10 +1017,12 @@ mod tests {
     #[test]
     fn move_leaf_permission_list_unions_into_destination() {
         // The new shape that wasn't expressible under the old IPCs: move the
-        // entire `permissions.allow` array. Array-union semantics, source
-        // ends up with an empty allow list (the array was removed, but the
-        // permissions key itself stays since deny / ask might still be there
-        // — though here they aren't).
+        // entire `permissions.allow` array. Array-union semantics on the
+        // destination; on the source `remove_at_path` deletes the `allow`
+        // key from the `permissions` object entirely (it doesn't leave an
+        // empty array behind), and the `permissions` key itself stays put
+        // because `deny` / `ask` may still be there — verified below by
+        // the surviving `deny: ["d"]`.
         let tmp = tempfile::tempdir().unwrap();
         let paths = paths_in(tmp.path());
         write(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 
 use crate::io_atomic::{self, BackupTracker};
-use crate::model::{key_policy, KeyPolicy, PermissionKind, PermissionRules, SettingsDoc};
+use crate::model::{
+    describe_path, key_policy, validate_movable_path, KeyPolicy, MovablePath, PathSeg,
+    PermissionKind, PermissionRules, SettingsDoc,
+};
 use crate::preferences::{self, Preferences};
 use crate::runtime::{RuntimeInfo, RuntimeOverrides};
 use crate::scope::{self, Scope, ScopePaths};
@@ -107,6 +110,70 @@ pub struct MoveKeyPreview {
     pub key: String,
     pub from: MoveKeySide,
     pub to: MoveKeySide,
+}
+
+/// Path-based move request. Replaces the per-rule `MoveRequest` and per-key
+/// `MoveKeyRequest` flows with a single primitive addressable by JSON path.
+/// `validate_movable_path` (in `model`) classifies each request into one of:
+/// whole top-level key, whole `permissions.<kind>` array, or a single rule
+/// under `permissions.<kind>`. Other intermediate sub-paths are explicitly
+/// rejected for v1; broader sub-key moves (e.g. `env.PATH`) are a follow-up
+/// to issue #67, not in scope for this primitive.
+#[derive(Debug, Deserialize)]
+pub struct MoveLeafRequest {
+    pub path: Vec<PathSeg>,
+    pub from: Scope,
+    pub to: Scope,
+}
+
+/// What kind of movable path a `MoveLeafPreview` describes. Surfaced on the
+/// preview so the frontend's diff modal can pick the right rendering — it
+/// would otherwise need to re-classify the path itself, which would mean a
+/// second source of truth for the rules in `validate_movable_path`.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MoveLeafKind {
+    TopLevelKey,
+    PermissionList,
+    PermissionRule,
+}
+
+impl MoveLeafKind {
+    fn from_movable(m: &MovablePath<'_>) -> Self {
+        match m {
+            MovablePath::TopLevelKey(_) => MoveLeafKind::TopLevelKey,
+            MovablePath::PermissionList(_) => MoveLeafKind::PermissionList,
+            MovablePath::PermissionRule(_, _) => MoveLeafKind::PermissionRule,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct MoveLeafPreview {
+    pub path: Vec<PathSeg>,
+    pub kind: MoveLeafKind,
+    pub from: MoveLeafSide,
+    pub to: MoveLeafSide,
+}
+
+/// One side of a `MoveLeafPreview`. The `key_before` / `key_after` pair is the
+/// **whole top-level key's value** (for a permission-rule move at
+/// `permissions.allow[2]`, that's the entire `permissions` object), so the
+/// frontend can drill into the path itself when rendering and avoid having
+/// the wire format duplicate parent/leaf pairs. Skip-on-`None` distinguishes
+/// "key absent" from "key explicitly set to JSON null", same as
+/// `MoveKeySide`.
+#[derive(Debug, Serialize)]
+pub struct MoveLeafSide {
+    pub scope: Scope,
+    pub file_path: String,
+    pub file_path_exists: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_before: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_after: Option<serde_json::Value>,
+    pub will_write: bool,
+    pub note: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -213,6 +280,29 @@ pub fn apply_move_key(
     let paths =
         resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
     apply_move_key_impl(&paths, &req, backups(), &watch).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn diff_move_leaf(
+    req: MoveLeafRequest,
+    project_dir: Option<String>,
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<MoveLeafPreview, String> {
+    let paths =
+        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
+    diff_move_leaf_impl(&paths, &req).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn apply_move_leaf(
+    req: MoveLeafRequest,
+    project_dir: Option<String>,
+    watch: State<'_, WatchState>,
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<(), String> {
+    let paths =
+        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
+    apply_move_leaf_impl(&paths, &req, backups(), &watch).map_err(|e| e.to_string())
 }
 
 /// Snapshot of the launch-time overrides — the front-end uses this to
@@ -651,6 +741,222 @@ fn apply_move_key_impl(
     }
     watch.note_self_write(&from_path);
     Ok(())
+}
+
+/// The top-level key affected by a movable path. Validation guarantees the
+/// first segment is always a `Key` for the three movable shapes, so this is
+/// infallible after `validate_movable_path` succeeds. Pulled out so the
+/// diff/apply flows can stay readable and the invariant is documented in
+/// exactly one place.
+fn path_top_level_key(path: &[PathSeg]) -> &str {
+    path.first()
+        .and_then(PathSeg::as_key)
+        .expect("validate_movable_path guarantees path[0] is a key")
+}
+
+fn diff_move_leaf_impl(
+    paths: &ScopePaths,
+    req: &MoveLeafRequest,
+) -> Result<MoveLeafPreview, Box<dyn std::error::Error>> {
+    if req.from == req.to {
+        return Err("source and destination scopes must differ".into());
+    }
+    let movable = validate_movable_path(&req.path)?;
+    let from_path = require_path(paths, req.from)?;
+    let to_path = require_path(paths, req.to)?;
+    let affected_key = path_top_level_key(&req.path);
+
+    let from_doc = match io_atomic::load(from_path)? {
+        Some(d) => d,
+        None => return Err(format!("source file {} does not exist", from_path.display()).into()),
+    };
+    let src_value =
+        from_doc
+            .get_at_path(&req.path)
+            .cloned()
+            .ok_or_else(|| -> Box<dyn std::error::Error> {
+                format!(
+                    "path `{}` not found in {} {}",
+                    describe_path(&req.path),
+                    req.from.label(),
+                    from_path.display()
+                )
+                .into()
+            })?;
+
+    // Source `key_before` / `key_after` describe the *top-level key* the move
+    // is acting through, not the leaf. The frontend already knows the leaf
+    // path from the request and drills in itself, so the wire format avoids
+    // duplicating parent + child copies of the same JSON.
+    let from_key_before = from_doc.get_top_level(affected_key).cloned();
+    let mut from_after_doc = from_doc.clone();
+    from_after_doc.remove_at_path(&req.path);
+    let from_key_after = from_after_doc.get_top_level(affected_key).cloned();
+
+    let to_path_exists = to_path.exists();
+    let to_doc_loaded = io_atomic::load(to_path)?.unwrap_or_else(SettingsDoc::empty);
+    let to_key_before = to_doc_loaded.get_top_level(affected_key).cloned();
+    let mut to_doc = to_doc_loaded.clone();
+    to_doc.merge_at_path(&req.path, src_value.clone())?;
+    let to_key_after = to_doc.get_top_level(affected_key).cloned();
+
+    let dest_unchanged = to_key_before == to_key_after;
+    let to_note = leaf_preview_note(
+        &movable,
+        dest_unchanged,
+        to_path_exists,
+        to_key_before.as_ref(),
+        &src_value,
+    );
+
+    Ok(MoveLeafPreview {
+        path: req.path.clone(),
+        kind: MoveLeafKind::from_movable(&movable),
+        from: MoveLeafSide {
+            scope: req.from,
+            file_path: from_path.display().to_string(),
+            file_path_exists: from_path.exists(),
+            key_before: from_key_before,
+            key_after: from_key_after,
+            will_write: true,
+            note: None,
+        },
+        to: MoveLeafSide {
+            scope: req.to,
+            file_path: to_path.display().to_string(),
+            file_path_exists: to_path_exists,
+            key_before: to_key_before,
+            key_after: to_key_after,
+            will_write: !dest_unchanged,
+            note: to_note,
+        },
+    })
+}
+
+fn apply_move_leaf_impl(
+    paths: &ScopePaths,
+    req: &MoveLeafRequest,
+    backups: &BackupTracker,
+    watch: &WatchState,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if req.from == req.to {
+        return Err("source and destination scopes must differ".into());
+    }
+    let _movable = validate_movable_path(&req.path)?;
+    let from_path = require_path(paths, req.from)?.to_path_buf();
+    let to_path = require_path(paths, req.to)?.to_path_buf();
+    let affected_key = path_top_level_key(&req.path);
+
+    let (from_doc_loaded, from_stamp) = io_atomic::load_with_stamp(&from_path)?;
+    let mut from_doc = match from_doc_loaded {
+        Some(d) => d,
+        None => return Err(format!("source file {} does not exist", from_path.display()).into()),
+    };
+    let src_value =
+        from_doc
+            .get_at_path(&req.path)
+            .cloned()
+            .ok_or_else(|| -> Box<dyn std::error::Error> {
+                format!(
+                    "path `{}` not found in {} {}",
+                    describe_path(&req.path),
+                    req.from.label(),
+                    from_path.display()
+                )
+                .into()
+            })?;
+
+    // Snapshot whether the destination file existed on disk before we
+    // touched it, so a later rollback can tell "restore the old contents"
+    // apart from "we created this file, so removing it is the rollback."
+    // Same rationale as `apply_move_key_impl` — derive existence from the
+    // load result rather than a separate `exists()` call to dodge a TOCTOU
+    // window where a third party creates the file mid-flight.
+    let (to_doc_loaded, to_stamp) = io_atomic::load_with_stamp(&to_path)?;
+    let to_existed_before = to_doc_loaded.is_some();
+    let to_doc_before = to_doc_loaded.unwrap_or_else(SettingsDoc::empty);
+    let to_key_before = to_doc_before.get_top_level(affected_key).cloned();
+    let mut to_doc = to_doc_before.clone();
+    to_doc.merge_at_path(&req.path, src_value.clone())?;
+    let to_key_after = to_doc.get_top_level(affected_key).cloned();
+    let dest_mutated = to_key_before != to_key_after;
+
+    let removed = from_doc.remove_at_path(&req.path);
+    if !removed {
+        // get_at_path saw the value but remove_at_path didn't — should be
+        // unreachable given the same path on the same `from_doc`, but error
+        // loudly so a future regression in `remove_at_path` can't silently
+        // duplicate the rule across both scopes.
+        return Err(format!(
+            "internal error: path `{}` resolved on read but failed to remove",
+            describe_path(&req.path)
+        )
+        .into());
+    }
+
+    // Destination first, then source — matching `apply_move_impl` /
+    // `apply_move_key_impl` so the rollback shape is identical. Stamp checks
+    // protect against an external writer landing between our load and our
+    // save; rollback writes pass `None` because we're the canonical writer of
+    // the destination at that point.
+    if dest_mutated {
+        io_atomic::save(&to_path, &to_doc, backups, Some(&to_stamp))?;
+        watch.note_self_write(&to_path);
+    }
+    if let Err(source_err) = io_atomic::save(&from_path, &from_doc, backups, Some(&from_stamp)) {
+        if dest_mutated {
+            let rollback_result: Result<(), Box<dyn std::error::Error>> = if to_existed_before {
+                io_atomic::save(&to_path, &to_doc_before, backups, None).map_err(Into::into)
+            } else {
+                std::fs::remove_file(&to_path).map_err(Into::into)
+            };
+            if let Err(rollback_err) = rollback_result {
+                return Err(format!(
+                    "source save failed: {source_err}; destination rollback also failed: {rollback_err}"
+                )
+                .into());
+            }
+            watch.note_self_write(&to_path);
+        }
+        return Err(
+            format!("source save failed and destination was rolled back: {source_err}").into(),
+        );
+    }
+    watch.note_self_write(&from_path);
+    Ok(())
+}
+
+/// Human-readable note shown on the destination side of a `MoveLeafPreview`.
+/// Mirrors `policy_preview_note` for top-level key moves and adds notes for
+/// the two permission shapes; centralized so the diff path keeps producing
+/// the same wording the user would see if the apply path had to fall back.
+fn leaf_preview_note(
+    movable: &MovablePath<'_>,
+    dest_unchanged: bool,
+    to_path_exists: bool,
+    to_key_before: Option<&serde_json::Value>,
+    src_value: &serde_json::Value,
+) -> Option<String> {
+    if dest_unchanged {
+        return Some(
+            "Destination already contains this value; source copy will simply be removed."
+                .to_string(),
+        );
+    }
+    if !to_path_exists {
+        return Some("Destination file will be created.".to_string());
+    }
+    match movable {
+        MovablePath::TopLevelKey(k) => to_key_before.map(|before| policy_preview_note(k, before, src_value)),
+        MovablePath::PermissionList(_) => Some(
+            "Permission rules are array-unioned: source entries are appended to the destination and deduplicated."
+                .to_string(),
+        ),
+        MovablePath::PermissionRule(_, _) => Some(
+            "Single permission rule will be added to the destination's list."
+                .to_string(),
+        ),
+    }
 }
 
 /// Human-readable note explaining how the destination's existing value will
@@ -1676,5 +1982,300 @@ mod tests {
                 }
             })
         );
+    }
+
+    // -- move_leaf parity tests --------------------------------------------
+    //
+    // The path-based primitive replaces today's per-rule + per-key flows. The
+    // tests below verify it produces the same end state as the legacy
+    // commands for the canonical cases users hit today, plus the new
+    // permission-list shape that wasn't expressible before. Existing per-rule
+    // and per-key tests (above) stay until the legacy IPCs are retired.
+
+    fn key(s: &str) -> PathSeg {
+        PathSeg::Key(s.to_string())
+    }
+
+    fn idx(i: usize) -> PathSeg {
+        PathSeg::Index(i)
+    }
+
+    #[test]
+    fn move_leaf_rule_matches_apply_move_for_canonical_rule_move() {
+        // Same input as `move_from_project_to_user_preserves_other_keys` but
+        // through the unified primitive — end state must be identical so the
+        // frontend cutover has a true behavioral regression test, not just a
+        // shape sanity check.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(
+            paths.project.as_ref().unwrap(),
+            r#"{
+  "theme": "dark",
+  "permissions": { "allow": ["Bash(git status)", "Read(**)"] }
+}"#,
+        );
+
+        apply_move_leaf_impl(
+            &paths,
+            &MoveLeafRequest {
+                path: vec![key("permissions"), key("allow"), idx(0)],
+                from: Scope::Project,
+                to: Scope::User,
+            },
+            &BackupTracker::new(),
+            &WatchState::default(),
+        )
+        .unwrap();
+
+        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            project_doc.permissions().allow,
+            vec!["Read(**)".to_string()]
+        );
+        assert!(project_doc.other_entries().contains_key("theme"));
+        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            user_doc.permissions().allow,
+            vec!["Bash(git status)".to_string()]
+        );
+    }
+
+    #[test]
+    fn move_leaf_rule_already_present_in_dest_still_removes_source() {
+        // Moving a rule the destination already has is the no-op-write case
+        // — destination is unchanged, but the source must still lose its
+        // copy. Matches `apply_move_impl`'s contract for the same shape.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(
+            paths.project.as_ref().unwrap(),
+            r#"{"permissions":{"allow":["Bash(git status)"]}}"#,
+        );
+        write(
+            paths.user.as_ref().unwrap(),
+            r#"{"permissions":{"allow":["Bash(git status)"]}}"#,
+        );
+
+        apply_move_leaf_impl(
+            &paths,
+            &MoveLeafRequest {
+                path: vec![key("permissions"), key("allow"), idx(0)],
+                from: Scope::Project,
+                to: Scope::User,
+            },
+            &BackupTracker::new(),
+            &WatchState::default(),
+        )
+        .unwrap();
+
+        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert!(project_doc.permissions().allow.is_empty());
+        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            user_doc.permissions().allow,
+            vec!["Bash(git status)".to_string()]
+        );
+    }
+
+    #[test]
+    fn move_leaf_top_level_key_matches_move_key_for_env() {
+        // env's KeyPolicy::DeepMerge must continue to apply through the
+        // unified primitive — same destination state as `apply_move_key_impl`
+        // for the same input.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(
+            paths.project.as_ref().unwrap(),
+            r#"{"env":{"PATH":"/proj","API_KEY":"xyz"}}"#,
+        );
+        write(
+            paths.user.as_ref().unwrap(),
+            r#"{"env":{"PATH":"/old","HOME":"/h"}}"#,
+        );
+
+        apply_move_leaf_impl(
+            &paths,
+            &MoveLeafRequest {
+                path: vec![key("env")],
+                from: Scope::Project,
+                to: Scope::User,
+            },
+            &BackupTracker::new(),
+            &WatchState::default(),
+        )
+        .unwrap();
+
+        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        // Source values win on conflict (PATH); destination-only keys (HOME)
+        // are preserved; source-only keys (API_KEY) are inserted.
+        assert_eq!(
+            user_doc.get_top_level("env").unwrap(),
+            &serde_json::json!({"PATH": "/proj", "HOME": "/h", "API_KEY": "xyz"})
+        );
+        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        // Source key was removed wholesale.
+        assert!(project_doc.get_top_level("env").is_none());
+    }
+
+    #[test]
+    fn move_leaf_permission_list_unions_into_destination() {
+        // The new shape that wasn't expressible under the old IPCs: move the
+        // entire `permissions.allow` array. Array-union semantics, source
+        // ends up with an empty allow list (the array was removed, but the
+        // permissions key itself stays since deny / ask might still be there
+        // — though here they aren't).
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(
+            paths.project.as_ref().unwrap(),
+            r#"{"permissions":{"allow":["a","b"],"deny":["d"]}}"#,
+        );
+        write(
+            paths.user.as_ref().unwrap(),
+            r#"{"permissions":{"allow":["b","c"]}}"#,
+        );
+
+        apply_move_leaf_impl(
+            &paths,
+            &MoveLeafRequest {
+                path: vec![key("permissions"), key("allow")],
+                from: Scope::Project,
+                to: Scope::User,
+            },
+            &BackupTracker::new(),
+            &WatchState::default(),
+        )
+        .unwrap();
+
+        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            *user_doc.get_top_level("permissions").unwrap(),
+            serde_json::json!({"allow": ["b", "c", "a"]})
+        );
+        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        // The source's allow array was removed; deny survives untouched.
+        assert_eq!(
+            *project_doc.get_top_level("permissions").unwrap(),
+            serde_json::json!({"deny": ["d"]})
+        );
+    }
+
+    #[test]
+    fn diff_move_leaf_classifies_kind_and_describes_top_level_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(
+            paths.project.as_ref().unwrap(),
+            r#"{"permissions":{"allow":["Bash(git status)"]}}"#,
+        );
+
+        let preview = diff_move_leaf_impl(
+            &paths,
+            &MoveLeafRequest {
+                path: vec![key("permissions"), key("allow"), idx(0)],
+                from: Scope::Project,
+                to: Scope::User,
+            },
+        )
+        .unwrap();
+        assert!(matches!(preview.kind, MoveLeafKind::PermissionRule));
+        // from.key_before / from.key_after describe the *whole permissions
+        // object* on the source; the leaf was removed.
+        assert_eq!(
+            preview.from.key_before.unwrap(),
+            serde_json::json!({"allow": ["Bash(git status)"]})
+        );
+        assert_eq!(
+            preview.from.key_after.unwrap(),
+            serde_json::json!({"allow": []})
+        );
+        // Destination didn't have permissions at all yet — key_before is None
+        // (skipped on the wire), key_after contains the merged result.
+        assert!(preview.to.key_before.is_none());
+        assert_eq!(
+            preview.to.key_after.unwrap(),
+            serde_json::json!({"allow": ["Bash(git status)"]})
+        );
+        assert!(preview.to.will_write);
+    }
+
+    #[test]
+    fn move_leaf_rejects_bare_permissions_path() {
+        // Defense in depth — even if a buggy frontend skipped the leaf
+        // affordance and asked to move `permissions` whole, the backend
+        // refuses with the validation error from `validate_movable_path`.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(
+            paths.project.as_ref().unwrap(),
+            r#"{"permissions":{"allow":["x"]}}"#,
+        );
+        let err = apply_move_leaf_impl(
+            &paths,
+            &MoveLeafRequest {
+                path: vec![key("permissions")],
+                from: Scope::Project,
+                to: Scope::User,
+            },
+            &BackupTracker::new(),
+            &WatchState::default(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("permissions key is not movable"));
+    }
+
+    #[test]
+    fn move_leaf_rejects_same_scope_source_and_destination() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(paths.project.as_ref().unwrap(), r#"{"theme":"dark"}"#);
+        let err = apply_move_leaf_impl(
+            &paths,
+            &MoveLeafRequest {
+                path: vec![key("theme")],
+                from: Scope::Project,
+                to: Scope::Project,
+            },
+            &BackupTracker::new(),
+            &WatchState::default(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("must differ"));
+    }
+
+    #[test]
+    fn move_leaf_rejects_when_source_path_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(paths.project.as_ref().unwrap(), r#"{"permissions":{}}"#);
+        let err = apply_move_leaf_impl(
+            &paths,
+            &MoveLeafRequest {
+                path: vec![key("permissions"), key("allow"), idx(0)],
+                from: Scope::Project,
+                to: Scope::User,
+            },
+            &BackupTracker::new(),
+            &WatchState::default(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("not found"));
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -632,9 +632,12 @@ mod tests {
 
     /// Build a synthetic `ScopeView` for the combined-panel tests below,
     /// going through the new `values` map shape — `permissions_from_values`
-    /// pulls the rules back out, mirroring the load_scopes path. Empty
-    /// allow/deny/ask lists still produce a `permissions` entry so the
-    /// extractor sees the canonical shape rather than a missing key.
+    /// pulls the rules back out, mirroring the load_scopes path. Triplets
+    /// of empty lists are emitted as a missing `permissions` entry; the
+    /// extractor degrades gracefully there (returns empty
+    /// `PermissionRules`), and "no rules" matching "no key" makes the
+    /// fixture closest to the realistic on-disk shape for a settings file
+    /// without any permission rules.
     fn make_view(
         scope: Scope,
         exists: bool,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -348,6 +348,83 @@ fn path_top_level_key(path: &[PathSeg]) -> &str {
         .expect("validate_movable_path guarantees path[0] is a key")
 }
 
+/// Remove the source side of a move, dispatched by `MovablePath` so the
+/// semantics match the legacy IPCs the move-leaf primitive replaced.
+///
+/// For `PermissionRule`, every occurrence of the rule string is removed
+/// from `permissions.<kind>` (not just the indexed entry). The legacy
+/// `apply_move_impl` did this via `SettingsDoc::remove_rule`, and dropping
+/// it would silently leave duplicates behind in hand-edited files: the
+/// destination's array-union dedupes, so the user would see "moved" while
+/// a stray copy survives in the source. For `PermissionList` and
+/// `TopLevelKey`, an index-based `remove_at_path` is correct (whole array
+/// or whole key). Returns true iff the document was mutated; the apply
+/// path treats `false` as an internal-error guard since `get_at_path`
+/// already succeeded just above.
+fn remove_movable_source(
+    doc: &mut SettingsDoc,
+    movable: &MovablePath<'_>,
+    src_value: &serde_json::Value,
+    path: &[PathSeg],
+) -> bool {
+    match movable {
+        MovablePath::PermissionRule(kind, _) => match src_value.as_str() {
+            // `validate_movable_path` only classifies a path as
+            // `PermissionRule` when its index segment is in-range syntactically;
+            // the actual leaf shape is checked here at use time so a
+            // hand-edited array with a non-string at the index still has the
+            // index removed via the slower `remove_at_path` fallback.
+            Some(rule) => remove_all_rule_occurrences(doc, *kind, rule),
+            None => doc.remove_at_path(path),
+        },
+        MovablePath::PermissionList(_) | MovablePath::TopLevelKey(_) => doc.remove_at_path(path),
+    }
+}
+
+/// Remove every occurrence of `rule` from `permissions.<kind>`. Resurrects
+/// the legacy `SettingsDoc::remove_rule` semantics specifically for the
+/// move-leaf source side; see `remove_movable_source` for why a hand-edited
+/// duplicate would otherwise strand. Returns true iff at least one entry
+/// was removed.
+///
+/// Implementation: locate the next matching index, remove it, repeat. The
+/// re-locate per iteration is fine since rule arrays are tiny in practice
+/// (tens of entries, not thousands), and using the existing
+/// `remove_at_path` keeps the mutation API surface on `SettingsDoc`
+/// minimal.
+fn remove_all_rule_occurrences(doc: &mut SettingsDoc, kind: PermissionKind, rule: &str) -> bool {
+    let mut removed = false;
+    while let Some(idx) = find_rule_index(doc, kind, rule) {
+        let did_remove = doc.remove_at_path(&[
+            PathSeg::Key("permissions".into()),
+            PathSeg::Key(kind.key().into()),
+            PathSeg::Index(idx),
+        ]);
+        if !did_remove {
+            // Defensive: `find_rule_index` saw the value at `idx`, so the
+            // remove ought to succeed. Bail out of the loop rather than
+            // spin forever if some future refactor breaks that invariant.
+            break;
+        }
+        removed = true;
+    }
+    removed
+}
+
+/// Locate the first index in `permissions.<kind>` that matches `rule`, or
+/// `None` if no entry matches. Used by `remove_all_rule_occurrences` to
+/// drive its index-by-index removal loop without introducing a second
+/// public mutation API on `SettingsDoc`.
+fn find_rule_index(doc: &SettingsDoc, kind: PermissionKind, rule: &str) -> Option<usize> {
+    let arr = doc.get_at_path(&[
+        PathSeg::Key("permissions".into()),
+        PathSeg::Key(kind.key().into()),
+    ])?;
+    arr.as_array()?
+        .iter()
+        .position(|v| v.as_str() == Some(rule))
+}
+
 fn diff_move_leaf_impl(
     paths: &ScopePaths,
     req: &MoveLeafRequest,
@@ -381,16 +458,37 @@ fn diff_move_leaf_impl(
     // Source `key_before` / `key_after` describe the *top-level key* the move
     // is acting through, not the leaf. The frontend already knows the leaf
     // path from the request and drills in itself, so the wire format avoids
-    // duplicating parent + child copies of the same JSON.
+    // duplicating parent + child copies of the same JSON. Removal goes
+    // through `remove_movable_source` so the preview reflects the same
+    // legacy-parity semantics the apply path uses (notably: every copy of
+    // a duplicated rule string disappears, not just the indexed one).
     let from_key_before = from_doc.get_top_level(affected_key).cloned();
     let mut from_after_doc = from_doc.clone();
-    from_after_doc.remove_at_path(&req.path);
+    if !remove_movable_source(&mut from_after_doc, &movable, &src_value, &req.path) {
+        // get_at_path saw the value but the removal helper didn't take it.
+        // Same invariant the apply path enforces (a few lines below in
+        // `apply_move_leaf_impl`); surfacing the same error here keeps the
+        // diff and apply paths from drifting on what counts as a valid
+        // move request.
+        return Err(format!(
+            "internal error: path `{}` resolved on read but failed to remove",
+            describe_path(&req.path)
+        )
+        .into());
+    }
     let from_key_after = from_after_doc.get_top_level(affected_key).cloned();
 
-    let to_path_exists = to_path.exists();
-    let to_doc_loaded = io_atomic::load(to_path)?.unwrap_or_else(SettingsDoc::empty);
-    let to_key_before = to_doc_loaded.get_top_level(affected_key).cloned();
-    let mut to_doc = to_doc_loaded.clone();
+    // Derive existence from the load result rather than a separate
+    // `to_path.exists()` call to avoid a TOCTOU window where a third party
+    // creates / deletes the destination between the two checks. Mirrors
+    // `apply_move_leaf_impl`'s `to_existed_before` shape so the preview
+    // and apply paths agree on what "destination file will be created"
+    // means.
+    let to_doc_loaded = io_atomic::load(to_path)?;
+    let to_path_exists = to_doc_loaded.is_some();
+    let to_doc_before = to_doc_loaded.unwrap_or_else(SettingsDoc::empty);
+    let to_key_before = to_doc_before.get_top_level(affected_key).cloned();
+    let mut to_doc = to_doc_before.clone();
     to_doc.merge_at_path(&req.path, src_value.clone())?;
     let to_key_after = to_doc.get_top_level(affected_key).cloned();
 
@@ -436,7 +534,7 @@ fn apply_move_leaf_impl(
     if req.from == req.to {
         return Err("source and destination scopes must differ".into());
     }
-    let _movable = validate_movable_path(&req.path)?;
+    let movable = validate_movable_path(&req.path)?;
     let from_path = require_path(paths, req.from)?.to_path_buf();
     let to_path = require_path(paths, req.to)?.to_path_buf();
     let affected_key = path_top_level_key(&req.path);
@@ -475,12 +573,17 @@ fn apply_move_leaf_impl(
     let to_key_after = to_doc.get_top_level(affected_key).cloned();
     let dest_mutated = to_key_before != to_key_after;
 
-    let removed = from_doc.remove_at_path(&req.path);
+    // Source-side removal goes through `remove_movable_source` so a
+    // PermissionRule move drops every copy of the rule string (matching
+    // the legacy `remove_rule` behavior), not just the indexed entry —
+    // otherwise hand-edited duplicates would survive in the source while
+    // the destination's array-union dedupes, leaving a stale copy behind.
+    let removed = remove_movable_source(&mut from_doc, &movable, &src_value, &req.path);
     if !removed {
-        // get_at_path saw the value but remove_at_path didn't — should be
-        // unreachable given the same path on the same `from_doc`, but error
-        // loudly so a future regression in `remove_at_path` can't silently
-        // duplicate the rule across both scopes.
+        // get_at_path saw the value but the helper didn't take it — should
+        // be unreachable for any path that just resolved, but error loudly
+        // so a future regression can't silently duplicate the rule across
+        // both scopes.
         return Err(format!(
             "internal error: path `{}` resolved on read but failed to remove",
             describe_path(&req.path)
@@ -964,6 +1067,52 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(project_doc.permissions().allow.is_empty());
+        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            user_doc.permissions().allow,
+            vec!["Bash(git status)".to_string()]
+        );
+    }
+
+    #[test]
+    fn move_leaf_permission_rule_strips_all_copies_of_duplicated_string() {
+        // Hand-edited settings.json can list the same rule string twice in
+        // `permissions.allow`. The legacy `apply_move_impl` removed *all*
+        // matching strings from the source (via `arr.retain(...)`); the
+        // path-based primitive now matches that semantics through
+        // `remove_movable_source`. Without this fix, removing index 0
+        // would leave the duplicate at index 1 behind in the source while
+        // the destination's array-union dedupes — the user would think
+        // the rule moved while a stale copy lived on.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(
+            paths.project.as_ref().unwrap(),
+            r#"{"permissions":{"allow":["Bash(git status)","Bash(git status)","Read(**)"]}}"#,
+        );
+
+        apply_move_leaf_impl(
+            &paths,
+            &MoveLeafRequest {
+                path: vec![key("permissions"), key("allow"), idx(0)],
+                from: Scope::Project,
+                to: Scope::User,
+            },
+            &BackupTracker::new(),
+            &WatchState::default(),
+        )
+        .unwrap();
+
+        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            project_doc.permissions().allow,
+            vec!["Read(**)".to_string()],
+            "both Bash(git status) copies must be stripped from the source"
+        );
         let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
             .unwrap()
             .unwrap();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -29,11 +29,12 @@ pub struct ScopeView {
     pub scope: Scope,
     pub path: Option<String>,
     pub exists: bool,
-    pub permissions: PermissionRules,
-    /// Non-permission top-level keys with their raw JSON values, in the
-    /// order they appear on disk. Drives the UI tree view for `env`,
-    /// `hooks`, `theme`, etc.
-    pub other_values: serde_json::Map<String, serde_json::Value>,
+    /// Every top-level key on disk in source order, including `permissions`.
+    /// Drives the unified tree view in the UI: `env`, `hooks`, `theme`, and
+    /// `permissions` all render through the same renderer with leaf-level
+    /// move affordances at backend-marked movable paths
+    /// (`validate_movable_path`).
+    pub values: serde_json::Map<String, serde_json::Value>,
     pub parse_error: Option<String>,
 }
 
@@ -59,66 +60,12 @@ pub struct PermissionRuleOrigins {
     pub ask: Vec<Vec<Scope>>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct MoveRequest {
-    pub rule: String,
-    pub kind: PermissionKind,
-    pub from: Scope,
-    pub to: Scope,
-}
-
-/// Structured preview of a pending move, built so the front-end can render a
-/// real before/after diff instead of a plain-text confirmation dialog.
-#[derive(Debug, Serialize)]
-pub struct MovePreview {
-    pub rule: String,
-    pub kind: PermissionKind,
-    pub from: MoveSide,
-    pub to: MoveSide,
-}
-
-#[derive(Debug, Serialize)]
-pub struct MoveSide {
-    pub scope: Scope,
-    pub path: String,
-    pub path_exists: bool,
-    pub rules_before: Vec<String>,
-    pub rules_after: Vec<String>,
-    /// True when `apply_move` will actually write this side's file. False on
-    /// the destination when the rule is already present (no-op), and always
-    /// true on the source (we need to remove the rule).
-    pub will_write: bool,
-    /// Optional human-readable note (e.g. "destination file will be created"
-    /// or "already present; source copy will simply be removed").
-    pub note: Option<String>,
-}
-
-/// Moves a top-level non-permission key (`env`, `hooks`, `theme`, …) between
-/// scopes. Companion to `MoveRequest`, which handles individual permission
-/// rules; the key-move flow uses its own type because the payload is a raw
-/// JSON value rather than a rule string, and the merge semantics differ by
-/// value shape (see `SettingsDoc::merge_top_level`).
-#[derive(Debug, Deserialize)]
-pub struct MoveKeyRequest {
-    pub key: String,
-    pub from: Scope,
-    pub to: Scope,
-}
-
-#[derive(Debug, Serialize)]
-pub struct MoveKeyPreview {
-    pub key: String,
-    pub from: MoveKeySide,
-    pub to: MoveKeySide,
-}
-
-/// Path-based move request. Replaces the per-rule `MoveRequest` and per-key
-/// `MoveKeyRequest` flows with a single primitive addressable by JSON path.
-/// `validate_movable_path` (in `model`) classifies each request into one of:
-/// whole top-level key, whole `permissions.<kind>` array, or a single rule
-/// under `permissions.<kind>`. Other intermediate sub-paths are explicitly
-/// rejected for v1; broader sub-key moves (e.g. `env.PATH`) are a follow-up
-/// to issue #67, not in scope for this primitive.
+/// Path-based move request. The single primitive backing every move on the
+/// frontend, addressable by JSON path. `validate_movable_path` (in `model`)
+/// classifies each request into one of: whole top-level key, whole
+/// `permissions.<kind>` array, or a single rule under `permissions.<kind>`.
+/// Other intermediate sub-paths are explicitly rejected for v1; broader
+/// sub-key moves (e.g. `env.PATH`) are a follow-up to issue #67.
 #[derive(Debug, Deserialize)]
 pub struct MoveLeafRequest {
     pub path: Vec<PathSeg>,
@@ -176,26 +123,6 @@ pub struct MoveLeafSide {
     pub note: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
-pub struct MoveKeySide {
-    pub scope: Scope,
-    pub path: String,
-    pub path_exists: bool,
-    /// The raw JSON value stored at this key before the move. Omitted from
-    /// the serialized payload when the key isn't present — distinguishing
-    /// absence from a key explicitly set to JSON `null`, which is a valid
-    /// value and would otherwise collide at the wire level.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value_before: Option<serde_json::Value>,
-    /// The JSON value this side will have after the move is applied. `None`
-    /// on the source (the key is removed); same absence-vs-null skip as
-    /// `value_before`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value_after: Option<serde_json::Value>,
-    pub will_write: bool,
-    pub note: Option<String>,
-}
-
 /// Resolve scope paths honoring the launch-time overrides. The `home`
 /// override is always applied so user / user-local lookups stay redirected for
 /// the whole session. The `project` override only kicks in when the
@@ -234,52 +161,6 @@ pub fn load_scopes(
         let _ = app.emit("watcher-error", err);
     }
     Ok(loaded)
-}
-
-#[tauri::command]
-pub fn diff_move(
-    req: MoveRequest,
-    project_dir: Option<String>,
-    overrides: State<'_, RuntimeOverrides>,
-) -> Result<MovePreview, String> {
-    let paths =
-        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
-    diff_move_impl(&paths, &req).map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-pub fn apply_move(
-    req: MoveRequest,
-    project_dir: Option<String>,
-    watch: State<'_, WatchState>,
-    overrides: State<'_, RuntimeOverrides>,
-) -> Result<(), String> {
-    let paths =
-        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
-    apply_move_impl(&paths, &req, backups(), &watch).map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-pub fn diff_move_key(
-    req: MoveKeyRequest,
-    project_dir: Option<String>,
-    overrides: State<'_, RuntimeOverrides>,
-) -> Result<MoveKeyPreview, String> {
-    let paths =
-        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
-    diff_move_key_impl(&paths, &req).map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-pub fn apply_move_key(
-    req: MoveKeyRequest,
-    project_dir: Option<String>,
-    watch: State<'_, WatchState>,
-    overrides: State<'_, RuntimeOverrides>,
-) -> Result<(), String> {
-    let paths =
-        resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
-    apply_move_key_impl(&paths, &req, backups(), &watch).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -351,8 +232,7 @@ fn load_scope_view(scope: Scope, path: Option<&Path>) -> ScopeView {
         scope,
         path: path.map(|p| p.display().to_string()),
         exists: false,
-        permissions: PermissionRules::default(),
-        other_values: serde_json::Map::new(),
+        values: serde_json::Map::new(),
         parse_error: None,
     };
     let Some(p) = path else {
@@ -361,8 +241,7 @@ fn load_scope_view(scope: Scope, path: Option<&Path>) -> ScopeView {
     match io_atomic::load(p) {
         Ok(Some(doc)) => {
             view.exists = true;
-            view.permissions = doc.permissions();
-            view.other_values = doc.other_entries();
+            view.values = doc.all_entries();
         }
         Ok(None) => {}
         Err(e) => {
@@ -392,26 +271,48 @@ fn combined_permissions(views: &[ScopeView]) -> (PermissionRules, PermissionRule
     // order naturally lists contributing scopes highest-first too — matching
     // the tooltip's documented order.
     for view in views {
+        let perms = permissions_from_values(&view.values);
         accumulate(
-            &view.permissions.allow,
+            &perms.allow,
             view.scope,
             &mut rules.allow,
             &mut origins.allow,
         );
-        accumulate(
-            &view.permissions.deny,
-            view.scope,
-            &mut rules.deny,
-            &mut origins.deny,
-        );
-        accumulate(
-            &view.permissions.ask,
-            view.scope,
-            &mut rules.ask,
-            &mut origins.ask,
-        );
+        accumulate(&perms.deny, view.scope, &mut rules.deny, &mut origins.deny);
+        accumulate(&perms.ask, view.scope, &mut rules.ask, &mut origins.ask);
     }
     (rules, origins)
+}
+
+/// Pull a `PermissionRules` snapshot out of a `ScopeView::values` map.
+/// Mirrors `SettingsDoc::permissions` for the case where the caller already
+/// has the deserialized top-level value-map in hand instead of a SettingsDoc
+/// — used by `combined_permissions` so the union walk doesn't need a second
+/// disk load. Missing or malformed shapes degrade to empty lists rather
+/// than panic, matching the "partial corruption shouldn't break the UI"
+/// stance everywhere else.
+fn permissions_from_values(values: &serde_json::Map<String, serde_json::Value>) -> PermissionRules {
+    let mut out = PermissionRules::default();
+    let Some(perms) = values
+        .get("permissions")
+        .and_then(serde_json::Value::as_object)
+    else {
+        return out;
+    };
+    for kind in PermissionKind::ALL {
+        if let Some(serde_json::Value::Array(items)) = perms.get(kind.key()) {
+            let strs = items
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            match kind {
+                PermissionKind::Allow => out.allow = strs,
+                PermissionKind::Deny => out.deny = strs,
+                PermissionKind::Ask => out.ask = strs,
+            }
+        }
+    }
+    out
 }
 
 fn accumulate(
@@ -434,313 +335,6 @@ fn accumulate(
             out_origins.push(vec![scope]);
         }
     }
-}
-
-fn diff_move_impl(
-    paths: &ScopePaths,
-    req: &MoveRequest,
-) -> Result<MovePreview, Box<dyn std::error::Error>> {
-    if req.from == req.to {
-        return Err("source and destination scopes must differ".into());
-    }
-    let from_path = require_path(paths, req.from)?;
-    let to_path = require_path(paths, req.to)?;
-
-    // Source side: file must exist and the rule must currently be there.
-    // Match apply_move_impl's error wording so the preview path doesn't
-    // produce a different message than the one the user would see if they
-    // somehow skipped the preview.
-    let from_doc = match io_atomic::load(from_path)? {
-        Some(d) => d,
-        None => {
-            return Err(format!("source file {} does not exist", from_path.display()).into());
-        }
-    };
-    let from_before = from_doc.permissions().get(req.kind).to_vec();
-    if !from_before.iter().any(|r| r == &req.rule) {
-        return Err(format!(
-            "rule `{}` not found in {} {}",
-            req.rule,
-            req.from.label(),
-            from_path.display()
-        )
-        .into());
-    }
-    let from_after: Vec<String> = from_before
-        .iter()
-        .filter(|r| r.as_str() != req.rule)
-        .cloned()
-        .collect();
-
-    // Destination side: may or may not already have it.
-    let to_path_exists = to_path.exists();
-    let to_doc = io_atomic::load(to_path)?.unwrap_or_else(SettingsDoc::empty);
-    let to_before = to_doc.permissions().get(req.kind).to_vec();
-    let already_present = to_before.iter().any(|r| r == &req.rule);
-    let to_after: Vec<String> = if already_present {
-        to_before.clone()
-    } else {
-        let mut v = to_before.clone();
-        v.push(req.rule.clone());
-        v
-    };
-
-    let to_note = if already_present {
-        Some("Already present; source copy will simply be removed.".to_string())
-    } else if !to_path_exists {
-        Some("Destination file will be created.".to_string())
-    } else {
-        None
-    };
-
-    Ok(MovePreview {
-        rule: req.rule.clone(),
-        kind: req.kind,
-        from: MoveSide {
-            scope: req.from,
-            path: from_path.display().to_string(),
-            path_exists: from_path.exists(),
-            rules_before: from_before,
-            rules_after: from_after,
-            will_write: true,
-            note: None,
-        },
-        to: MoveSide {
-            scope: req.to,
-            path: to_path.display().to_string(),
-            path_exists: to_path_exists,
-            rules_before: to_before,
-            rules_after: to_after,
-            will_write: !already_present,
-            note: to_note,
-        },
-    })
-}
-
-fn apply_move_impl(
-    paths: &ScopePaths,
-    req: &MoveRequest,
-    backups: &BackupTracker,
-    watch: &WatchState,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if req.from == req.to {
-        return Err("source and destination scopes must differ".into());
-    }
-    let from_path = require_path(paths, req.from)?.to_path_buf();
-    let to_path = require_path(paths, req.to)?.to_path_buf();
-
-    let (to_doc_loaded, to_stamp) = io_atomic::load_with_stamp(&to_path)?;
-    let mut to_doc = to_doc_loaded.unwrap_or_else(SettingsDoc::empty);
-    let dest_mutated = to_doc.add_rule(req.kind, &req.rule);
-
-    let (from_doc_loaded, from_stamp) = io_atomic::load_with_stamp(&from_path)?;
-    let mut from_doc = match from_doc_loaded {
-        Some(d) => d,
-        None => return Err(format!("source file {} does not exist", from_path.display()).into()),
-    };
-    let removed = from_doc.remove_rule(req.kind, &req.rule);
-    if !removed {
-        return Err(format!(
-            "rule `{}` not found in {} {}",
-            req.rule,
-            req.from.label(),
-            from_path.display()
-        )
-        .into());
-    }
-
-    // Destination first, then source. If the destination already had the rule
-    // there's nothing to write there; skipping the save also avoids creating
-    // a spurious `.bak` for a file we aren't actually changing.
-    //
-    // `note_self_write` is called *after* each successful save, not before:
-    // a failed save means no filesystem event will arrive, so suppressing a
-    // would-be-legitimate external change would leave the UI stale for no
-    // reason. Suppression is path-scoped, so we pass the exact path each
-    // save touched.
-    //
-    // Each save passes the stamp captured at load time. A third party that
-    // edited the file between our load and our save aborts with
-    // `ConcurrentModification` rather than getting silently overwritten.
-    if dest_mutated {
-        io_atomic::save(&to_path, &to_doc, backups, Some(&to_stamp))?;
-        watch.note_self_write(&to_path);
-    }
-    // If the source write fails after the destination was updated, roll back
-    // the destination so the rule doesn't end up duplicated in both scopes.
-    if let Err(source_err) = io_atomic::save(&from_path, &from_doc, backups, Some(&from_stamp)) {
-        if dest_mutated {
-            to_doc.remove_rule(req.kind, &req.rule);
-            // Rollback skips the stamp check: we are the canonical writer of
-            // the destination at this point, and the stamp we'd want is the
-            // one our own successful write just produced.
-            if let Err(rollback_err) = io_atomic::save(&to_path, &to_doc, backups, None) {
-                return Err(format!(
-                    "source save failed: {source_err}; destination rollback also failed: {rollback_err}"
-                )
-                .into());
-            }
-            watch.note_self_write(&to_path);
-        }
-        return Err(
-            format!("source save failed and destination was rolled back: {source_err}").into(),
-        );
-    }
-    watch.note_self_write(&from_path);
-    Ok(())
-}
-
-fn diff_move_key_impl(
-    paths: &ScopePaths,
-    req: &MoveKeyRequest,
-) -> Result<MoveKeyPreview, Box<dyn std::error::Error>> {
-    validate_move_key(req)?;
-    let from_path = require_path(paths, req.from)?;
-    let to_path = require_path(paths, req.to)?;
-
-    let from_doc = match io_atomic::load(from_path)? {
-        Some(d) => d,
-        None => {
-            return Err(format!("source file {} does not exist", from_path.display()).into());
-        }
-    };
-    let src_value = from_doc.get_top_level(&req.key).cloned().ok_or_else(
-        || -> Box<dyn std::error::Error> {
-            format!(
-                "key `{}` not found in {} {}",
-                req.key,
-                req.from.label(),
-                from_path.display()
-            )
-            .into()
-        },
-    )?;
-
-    let to_path_exists = to_path.exists();
-    let mut to_doc = io_atomic::load(to_path)?.unwrap_or_else(SettingsDoc::empty);
-    let to_before = to_doc.get_top_level(&req.key).cloned();
-    to_doc.merge_top_level(&req.key, src_value.clone());
-    let to_after = to_doc.get_top_level(&req.key).cloned();
-
-    let dest_unchanged = to_before == to_after;
-    let to_note = if dest_unchanged {
-        Some(
-            "Destination already contains this value; source copy will simply be removed."
-                .to_string(),
-        )
-    } else if !to_path_exists {
-        Some("Destination file will be created.".to_string())
-    } else {
-        to_before
-            .as_ref()
-            .map(|before| policy_preview_note(&req.key, before, &src_value))
-    };
-
-    Ok(MoveKeyPreview {
-        key: req.key.clone(),
-        from: MoveKeySide {
-            scope: req.from,
-            path: from_path.display().to_string(),
-            path_exists: from_path.exists(),
-            value_before: Some(src_value),
-            value_after: None,
-            will_write: true,
-            note: None,
-        },
-        to: MoveKeySide {
-            scope: req.to,
-            path: to_path.display().to_string(),
-            path_exists: to_path_exists,
-            value_before: to_before,
-            value_after: to_after,
-            will_write: !dest_unchanged,
-            note: to_note,
-        },
-    })
-}
-
-fn apply_move_key_impl(
-    paths: &ScopePaths,
-    req: &MoveKeyRequest,
-    backups: &BackupTracker,
-    watch: &WatchState,
-) -> Result<(), Box<dyn std::error::Error>> {
-    validate_move_key(req)?;
-    let from_path = require_path(paths, req.from)?.to_path_buf();
-    let to_path = require_path(paths, req.to)?.to_path_buf();
-
-    let (from_doc_loaded, from_stamp) = io_atomic::load_with_stamp(&from_path)?;
-    let mut from_doc = match from_doc_loaded {
-        Some(d) => d,
-        None => return Err(format!("source file {} does not exist", from_path.display()).into()),
-    };
-    let src_value = from_doc.get_top_level(&req.key).cloned().ok_or_else(
-        || -> Box<dyn std::error::Error> {
-            format!(
-                "key `{}` not found in {} {}",
-                req.key,
-                req.from.label(),
-                from_path.display()
-            )
-            .into()
-        },
-    )?;
-
-    // Snapshot whether the destination file existed on disk before we
-    // touched it, so a later rollback can tell "restore the old contents"
-    // apart from "we created this file, so removing it is the rollback."
-    // Derive the existence flag from the load result rather than a separate
-    // `exists()` call: a third party that creates the file between our
-    // `exists()` and our `load_with_stamp` would otherwise leave us with
-    // `to_existed_before = false` plus a present stamp, and on rollback
-    // we'd `remove_file` a file we never created.
-    let (to_doc_loaded, to_stamp) = io_atomic::load_with_stamp(&to_path)?;
-    let to_existed_before = to_doc_loaded.is_some();
-    let to_doc_before = to_doc_loaded.unwrap_or_else(SettingsDoc::empty);
-    let to_before = to_doc_before.get_top_level(&req.key).cloned();
-    let mut to_doc = to_doc_before.clone();
-    to_doc.merge_top_level(&req.key, src_value.clone());
-    let to_after = to_doc.get_top_level(&req.key).cloned();
-    let dest_mutated = to_before != to_after;
-
-    from_doc.remove_top_level(&req.key);
-
-    // Destination first, then source — same ordering + rollback shape as
-    // apply_move_impl. Skipping the destination save when nothing changed
-    // avoids writing a .bak for a file we aren't actually touching.
-    //
-    // Stamp checks: each save passes the stamp captured at load. Rollback
-    // saves pass `None` because we are the canonical writer at that point
-    // (see apply_move_impl for the same reasoning).
-    if dest_mutated {
-        io_atomic::save(&to_path, &to_doc, backups, Some(&to_stamp))?;
-        watch.note_self_write(&to_path);
-    }
-    if let Err(source_err) = io_atomic::save(&from_path, &from_doc, backups, Some(&from_stamp)) {
-        if dest_mutated {
-            // Roll back the destination. If the file already existed before
-            // we wrote to it, restore the pre-merge snapshot. If the save
-            // newly created the file, delete it outright — re-saving the
-            // empty snapshot would leave a stray `{}` file behind.
-            let rollback_result: Result<(), Box<dyn std::error::Error>> = if to_existed_before {
-                io_atomic::save(&to_path, &to_doc_before, backups, None).map_err(Into::into)
-            } else {
-                std::fs::remove_file(&to_path).map_err(Into::into)
-            };
-            if let Err(rollback_err) = rollback_result {
-                return Err(format!(
-                    "source save failed: {source_err}; destination rollback also failed: {rollback_err}"
-                )
-                .into());
-            }
-            watch.note_self_write(&to_path);
-        }
-        return Err(
-            format!("source save failed and destination was rolled back: {source_err}").into(),
-        );
-    }
-    watch.note_self_write(&from_path);
-    Ok(())
 }
 
 /// The top-level key affected by a movable path. Validation guarantees the
@@ -1002,20 +596,6 @@ fn policy_preview_note(
     }
 }
 
-fn validate_move_key(req: &MoveKeyRequest) -> Result<(), Box<dyn std::error::Error>> {
-    if req.from == req.to {
-        return Err("source and destination scopes must differ".into());
-    }
-    if req.key == "permissions" {
-        return Err(
-            "use the permission move action for individual permission rules; \
-             the permissions key is not movable as a whole"
-                .into(),
-        );
-    }
-    Ok(())
-}
-
 fn require_path(paths: &ScopePaths, scope: Scope) -> Result<&Path, Box<dyn std::error::Error>> {
     paths.path_for(scope).ok_or_else(|| {
         format!(
@@ -1050,399 +630,50 @@ mod tests {
         }
     }
 
-    #[test]
-    fn move_from_project_to_user_preserves_other_keys() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{
-  "theme": "dark",
-  "permissions": { "allow": ["Bash(git status)", "Read(**)"] }
-}"#,
-        );
-
-        let backups = BackupTracker::new();
-        apply_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "Bash(git status)".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::Project,
-                to: Scope::User,
-            },
-            &backups,
-            &WatchState::default(),
-        )
-        .unwrap();
-
-        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            project_doc.permissions().allow,
-            vec!["Read(**)".to_string()]
-        );
-        assert!(project_doc.other_entries().contains_key("theme"));
-
-        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            user_doc.permissions().allow,
-            vec!["Bash(git status)".to_string()]
-        );
-    }
-
-    #[test]
-    fn diff_move_builds_structured_preview() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{"permissions":{"allow":["Bash(git status)","Read(**)"]}}"#,
-        );
-        let preview = diff_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "Bash(git status)".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::Project,
-                to: Scope::User,
-            },
-        )
-        .unwrap();
-        assert_eq!(preview.rule, "Bash(git status)");
-        assert_eq!(preview.from.rules_before.len(), 2);
-        assert_eq!(preview.from.rules_after, vec!["Read(**)".to_string()]);
-        assert!(preview.from.will_write);
-        // User file doesn't exist yet.
-        assert!(!preview.to.path_exists);
-        assert!(preview.to.will_write);
-        assert_eq!(preview.to.rules_after, vec!["Bash(git status)".to_string()]);
-        assert!(preview.to.note.as_deref() == Some("Destination file will be created."));
-    }
-
-    #[test]
-    fn diff_move_flags_already_present_destination() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{"permissions":{"allow":["Bash(git status)"]}}"#,
-        );
-        write(
-            paths.user.as_ref().unwrap(),
-            r#"{"permissions":{"allow":["Bash(git status)"]}}"#,
-        );
-        let preview = diff_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "Bash(git status)".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::Project,
-                to: Scope::User,
-            },
-        )
-        .unwrap();
-        assert!(
-            !preview.to.will_write,
-            "dest doesn't need a write when rule already there"
-        );
-        assert_eq!(preview.to.rules_before, preview.to.rules_after);
-        assert!(preview
-            .to
-            .note
-            .as_deref()
-            .unwrap()
-            .contains("Already present"));
-    }
-
-    #[test]
-    fn diff_move_errors_when_source_file_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        // Source file intentionally never written.
-        let err = diff_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "Bash(git status)".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::Project,
-                to: Scope::User,
-            },
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("does not exist"));
-    }
-
-    #[test]
-    fn diff_move_errors_when_source_lacks_rule() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{"permissions":{"allow":[]}}"#,
-        );
-        let err = diff_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "Bash(nope)".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::Project,
-                to: Scope::User,
-            },
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("not found"));
-    }
-
-    #[test]
-    fn move_creates_destination_file() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{ "permissions": { "deny": ["WebFetch(domain:evil.example)"] } }"#,
-        );
-        assert!(!paths.local.as_ref().unwrap().exists());
-
-        let backups = BackupTracker::new();
-        apply_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "WebFetch(domain:evil.example)".into(),
-                kind: PermissionKind::Deny,
-                from: Scope::Project,
-                to: Scope::Local,
-            },
-            &backups,
-            &WatchState::default(),
-        )
-        .unwrap();
-
-        let local_doc = io_atomic::load(paths.local.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            local_doc.permissions().deny,
-            vec!["WebFetch(domain:evil.example)".to_string()]
-        );
-        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert!(project_doc.permissions().deny.is_empty());
-    }
-
-    #[test]
-    fn diff_and_move_round_trip_through_user_local() {
-        // Regression for #23: UserLocal participates end-to-end — both as a
-        // destination that needs creating from scratch and as a source for a
-        // subsequent promotion. Covers diff_move_impl preview shape plus
-        // apply_move_impl backup + creation semantics for the new scope.
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.user.as_ref().unwrap(),
-            r#"{"permissions":{"allow":["Bash(git status)","Read(**)"]}}"#,
-        );
-        // user_local file does not exist yet — first move should create it.
-        assert!(!paths.user_local.as_ref().unwrap().exists());
-
-        // Preview: User → UserLocal.
-        let preview = diff_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "Bash(git status)".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::User,
-                to: Scope::UserLocal,
-            },
-        )
-        .unwrap();
-        assert_eq!(preview.from.scope, Scope::User);
-        assert_eq!(preview.to.scope, Scope::UserLocal);
-        assert!(!preview.to.path_exists);
-        assert!(preview.to.will_write);
-        assert_eq!(preview.to.rules_after, vec!["Bash(git status)".to_string()]);
-
-        let backups = BackupTracker::new();
-        apply_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "Bash(git status)".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::User,
-                to: Scope::UserLocal,
-            },
-            &backups,
-            &WatchState::default(),
-        )
-        .unwrap();
-
-        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(user_doc.permissions().allow, vec!["Read(**)".to_string()]);
-
-        let user_local_doc = io_atomic::load(paths.user_local.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            user_local_doc.permissions().allow,
-            vec!["Bash(git status)".to_string()]
-        );
-
-        // Now promote it outward: UserLocal → Project.
-        apply_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "Bash(git status)".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::UserLocal,
-                to: Scope::Project,
-            },
-            &backups,
-            &WatchState::default(),
-        )
-        .unwrap();
-
-        let user_local_doc = io_atomic::load(paths.user_local.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert!(user_local_doc.permissions().allow.is_empty());
-
-        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            project_doc.permissions().allow,
-            vec!["Bash(git status)".to_string()]
-        );
-    }
-
-    #[test]
-    fn move_same_scope_errors() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        let err = apply_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "x".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::Project,
-                to: Scope::Project,
-            },
-            &BackupTracker::new(),
-            &WatchState::default(),
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("must differ"));
-    }
-
-    #[test]
-    fn move_when_destination_already_has_rule_skips_dest_write() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{"permissions":{"allow":["Bash(git status)"]}}"#,
-        );
-        write(
-            paths.user.as_ref().unwrap(),
-            r#"{"permissions":{"allow":["Bash(git status)"]}}"#,
-        );
-        let user_bak = paths
-            .user
-            .as_ref()
-            .unwrap()
-            .with_file_name("settings.json.bak");
-        assert!(!user_bak.exists());
-
-        let backups = BackupTracker::new();
-        apply_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "Bash(git status)".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::Project,
-                to: Scope::User,
-            },
-            &backups,
-            &WatchState::default(),
-        )
-        .unwrap();
-
-        // Source still loses the rule.
-        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert!(project_doc.permissions().allow.is_empty());
-        // Destination was not rewritten, so no .bak should have been created.
-        assert!(
-            !user_bak.exists(),
-            "destination .bak should not be created when rule was already present"
-        );
-    }
-
-    #[test]
-    fn move_missing_rule_errors() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{"permissions":{"allow":[]}}"#,
-        );
-        let err = apply_move_impl(
-            &paths,
-            &MoveRequest {
-                rule: "Bash(nope)".into(),
-                kind: PermissionKind::Allow,
-                from: Scope::Project,
-                to: Scope::User,
-            },
-            &BackupTracker::new(),
-            &WatchState::default(),
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("not found"));
+    /// Build a synthetic `ScopeView` for the combined-panel tests below,
+    /// going through the new `values` map shape — `permissions_from_values`
+    /// pulls the rules back out, mirroring the load_scopes path. Empty
+    /// allow/deny/ask lists still produce a `permissions` entry so the
+    /// extractor sees the canonical shape rather than a missing key.
+    fn make_view(
+        scope: Scope,
+        exists: bool,
+        allow: &[&str],
+        deny: &[&str],
+        ask: &[&str],
+    ) -> ScopeView {
+        let mut values = serde_json::Map::new();
+        if !allow.is_empty() || !deny.is_empty() || !ask.is_empty() {
+            values.insert(
+                "permissions".into(),
+                serde_json::json!({
+                    "allow": allow,
+                    "deny": deny,
+                    "ask": ask,
+                }),
+            );
+        }
+        ScopeView {
+            scope,
+            path: None,
+            exists,
+            values,
+            parse_error: None,
+        }
     }
 
     #[test]
     fn combined_unions_across_scopes() {
         let views = vec![
-            ScopeView {
-                scope: Scope::Local,
-                path: None,
-                exists: true,
-                permissions: PermissionRules {
-                    allow: vec!["Bash(git status)".into()],
-                    deny: vec![],
-                    ask: vec![],
-                },
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
-            ScopeView {
-                scope: Scope::Project,
-                path: None,
-                exists: true,
-                permissions: PermissionRules {
-                    allow: vec!["Bash(git status)".into(), "Read(**)".into()],
-                    deny: vec!["WebFetch(domain:evil.example)".into()],
-                    ask: vec![],
-                },
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
-            ScopeView {
-                scope: Scope::User,
-                path: None,
-                exists: false,
-                permissions: PermissionRules::default(),
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
+            make_view(Scope::Local, true, &["Bash(git status)"], &[], &[]),
+            make_view(
+                Scope::Project,
+                true,
+                &["Bash(git status)", "Read(**)"],
+                &["WebFetch(domain:evil.example)"],
+                &[],
+            ),
+            make_view(Scope::User, false, &[], &[], &[]),
         ];
         let (combined, _origins) = combined_permissions(&views);
         assert_eq!(combined.allow, vec!["Bash(git status)", "Read(**)"]);
@@ -1459,30 +690,8 @@ mod tests {
     #[test]
     fn combined_surfaces_allow_deny_overlap_without_resolving() {
         let views = vec![
-            ScopeView {
-                scope: Scope::Local,
-                path: None,
-                exists: true,
-                permissions: PermissionRules {
-                    allow: vec!["Bash(git push)".into()],
-                    deny: vec![],
-                    ask: vec![],
-                },
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
-            ScopeView {
-                scope: Scope::Project,
-                path: None,
-                exists: true,
-                permissions: PermissionRules {
-                    allow: vec![],
-                    deny: vec!["Bash(git push)".into()],
-                    ask: vec![],
-                },
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
+            make_view(Scope::Local, true, &["Bash(git push)"], &[], &[]),
+            make_view(Scope::Project, true, &[], &["Bash(git push)"], &[]),
         ];
         let (combined, _origins) = combined_permissions(&views);
         assert_eq!(combined.allow, vec!["Bash(git push)"]);
@@ -1498,64 +707,33 @@ mod tests {
         // that scope. Locks down the contract the front-end tooltip relies
         // on.
         let views = vec![
-            ScopeView {
-                scope: Scope::Local,
-                path: None,
-                exists: true,
-                permissions: PermissionRules {
-                    allow: vec!["Bash(git status)".into(), "Read(**)".into()],
-                    deny: vec![],
-                    ask: vec![],
-                },
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
-            ScopeView {
-                scope: Scope::Project,
-                path: None,
-                exists: true,
-                permissions: PermissionRules::default(),
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
-            ScopeView {
-                scope: Scope::UserLocal,
-                path: None,
-                exists: true,
-                permissions: PermissionRules {
-                    allow: vec!["Bash(git status)".into()],
-                    deny: vec![],
-                    ask: vec![],
-                },
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
-            ScopeView {
-                scope: Scope::User,
-                path: None,
-                exists: true,
-                permissions: PermissionRules {
-                    allow: vec!["Bash(git status)".into(), "Bash(ls)".into()],
-                    deny: vec![],
-                    ask: vec![],
-                },
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
+            make_view(
+                Scope::Local,
+                true,
+                &["Bash(git status)", "Read(**)"],
+                &[],
+                &[],
+            ),
+            make_view(Scope::Project, true, &[], &[], &[]),
+            make_view(Scope::UserLocal, true, &["Bash(git status)"], &[], &[]),
+            make_view(
+                Scope::User,
+                true,
+                &["Bash(git status)", "Bash(ls)"],
+                &[],
+                &[],
+            ),
         ];
         let (combined, origins) = combined_permissions(&views);
         assert_eq!(
             combined.allow,
             vec!["Bash(git status)", "Read(**)", "Bash(ls)"]
         );
-        // Same rule across Local + UserLocal + User, in precedence order.
         assert_eq!(
             origins.allow[0],
             vec![Scope::Local, Scope::UserLocal, Scope::User]
         );
-        // Rule only in Local.
         assert_eq!(origins.allow[1], vec![Scope::Local]);
-        // Rule only in User.
         assert_eq!(origins.allow[2], vec![Scope::User]);
         assert!(origins.deny.is_empty());
         assert!(origins.ask.is_empty());
@@ -1569,221 +747,18 @@ mod tests {
         // origins list must also collapse same-scope repeats so the
         // tooltip doesn't render "Local, Local, User".
         let views = vec![
-            ScopeView {
-                scope: Scope::Local,
-                path: None,
-                exists: true,
-                permissions: PermissionRules {
-                    allow: vec!["Bash(git status)".into(), "Bash(git status)".into()],
-                    deny: vec![],
-                    ask: vec![],
-                },
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
-            ScopeView {
-                scope: Scope::User,
-                path: None,
-                exists: true,
-                permissions: PermissionRules {
-                    allow: vec!["Bash(git status)".into()],
-                    deny: vec![],
-                    ask: vec![],
-                },
-                other_values: serde_json::Map::new(),
-                parse_error: None,
-            },
+            make_view(
+                Scope::Local,
+                true,
+                &["Bash(git status)", "Bash(git status)"],
+                &[],
+                &[],
+            ),
+            make_view(Scope::User, true, &["Bash(git status)"], &[], &[]),
         ];
         let (combined, origins) = combined_permissions(&views);
         assert_eq!(combined.allow, vec!["Bash(git status)"]);
         assert_eq!(origins.allow[0], vec![Scope::Local, Scope::User]);
-    }
-
-    #[test]
-    fn move_key_merges_env_object_into_destination() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{"env": {"PATH": "/src", "HOME": "/home/a"}}"#,
-        );
-        write(
-            paths.user.as_ref().unwrap(),
-            r#"{"env": {"PATH": "/dst", "SHELL": "/bin/zsh"}}"#,
-        );
-
-        let req = MoveKeyRequest {
-            key: "env".to_string(),
-            from: Scope::Project,
-            to: Scope::User,
-        };
-        apply_move_key_impl(&paths, &req, &BackupTracker::new(), &WatchState::default()).unwrap();
-
-        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert!(
-            project_doc.get_top_level("env").is_none(),
-            "source env removed"
-        );
-
-        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        let env = user_doc.get_top_level("env").unwrap();
-        // New keys from source win on conflict; destination-only keys kept.
-        assert_eq!(env["PATH"], "/src");
-        assert_eq!(env["HOME"], "/home/a");
-        assert_eq!(env["SHELL"], "/bin/zsh");
-    }
-
-    #[test]
-    fn move_key_creates_destination_file() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(paths.project.as_ref().unwrap(), r#"{"theme": "dark"}"#);
-        assert!(!paths.user.as_ref().unwrap().exists());
-
-        let req = MoveKeyRequest {
-            key: "theme".to_string(),
-            from: Scope::Project,
-            to: Scope::User,
-        };
-        apply_move_key_impl(&paths, &req, &BackupTracker::new(), &WatchState::default()).unwrap();
-
-        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert!(project_doc.get_top_level("theme").is_none());
-        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            user_doc.get_top_level("theme").unwrap(),
-            &serde_json::json!("dark")
-        );
-    }
-
-    #[test]
-    fn diff_move_key_flags_merge_note_when_destination_has_key() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(paths.project.as_ref().unwrap(), r#"{"env": {"A": "1"}}"#);
-        write(paths.user.as_ref().unwrap(), r#"{"env": {"B": "2"}}"#);
-
-        let preview = diff_move_key_impl(
-            &paths,
-            &MoveKeyRequest {
-                key: "env".to_string(),
-                from: Scope::Project,
-                to: Scope::User,
-            },
-        )
-        .unwrap();
-
-        assert_eq!(preview.key, "env");
-        assert!(preview.from.will_write);
-        assert!(preview.to.will_write);
-        assert!(preview
-            .to
-            .note
-            .as_deref()
-            .is_some_and(|n| n.contains("merged")));
-        assert_eq!(
-            preview.to.value_after.as_ref().unwrap(),
-            &serde_json::json!({"B": "2", "A": "1"})
-        );
-    }
-
-    #[test]
-    fn move_key_refuses_permissions_key() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        let err = diff_move_key_impl(
-            &paths,
-            &MoveKeyRequest {
-                key: "permissions".to_string(),
-                from: Scope::Project,
-                to: Scope::User,
-            },
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("permissions key is not movable"));
-    }
-
-    #[test]
-    fn move_key_same_scope_errors() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        let err = apply_move_key_impl(
-            &paths,
-            &MoveKeyRequest {
-                key: "env".to_string(),
-                from: Scope::Project,
-                to: Scope::Project,
-            },
-            &BackupTracker::new(),
-            &WatchState::default(),
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("must differ"));
-    }
-
-    #[test]
-    fn move_key_errors_when_source_lacks_key() {
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(paths.project.as_ref().unwrap(), r#"{}"#);
-        let err = diff_move_key_impl(
-            &paths,
-            &MoveKeyRequest {
-                key: "theme".to_string(),
-                from: Scope::Project,
-                to: Scope::User,
-            },
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("not found"));
-    }
-
-    #[test]
-    fn move_key_dedupes_array_union_keys() {
-        // allowedHttpHookUrls is a documented array-union key: entries from
-        // every scope are concatenated and deduplicated. Moving from project
-        // into user with overlap should yield the destination's entries
-        // followed by the source's, with the duplicate dropped.
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{"allowedHttpHookUrls": ["https://a.example", "https://b.example"]}"#,
-        );
-        write(
-            paths.user.as_ref().unwrap(),
-            r#"{"allowedHttpHookUrls": ["https://b.example", "https://c.example"]}"#,
-        );
-        apply_move_key_impl(
-            &paths,
-            &MoveKeyRequest {
-                key: "allowedHttpHookUrls".to_string(),
-                from: Scope::Project,
-                to: Scope::User,
-            },
-            &BackupTracker::new(),
-            &WatchState::default(),
-        )
-        .unwrap();
-        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            user_doc.get_top_level("allowedHttpHookUrls").unwrap(),
-            &serde_json::json!([
-                "https://b.example",
-                "https://c.example",
-                "https://a.example"
-            ])
-        );
     }
 
     #[test]
@@ -1891,97 +866,6 @@ mod tests {
         );
         assert!(note.contains("Unknown key"));
         assert!(note.contains("replaced"));
-    }
-
-    #[test]
-    fn move_key_replaces_override_only_hooks() {
-        // hooks is override-only per Claude Code's docs: the highest-precedence
-        // scope wins, scopes are not merged. Moving hooks from project into
-        // user must overwrite the destination's existing hooks block, not
-        // merge into it.
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{"hooks": {"PreToolUse": [{"command": "from-project"}]}}"#,
-        );
-        write(
-            paths.user.as_ref().unwrap(),
-            r#"{"hooks": {"PostToolUse": [{"command": "from-user"}]}}"#,
-        );
-        apply_move_key_impl(
-            &paths,
-            &MoveKeyRequest {
-                key: "hooks".to_string(),
-                from: Scope::Project,
-                to: Scope::User,
-            },
-            &BackupTracker::new(),
-            &WatchState::default(),
-        )
-        .unwrap();
-        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            user_doc.get_top_level("hooks").unwrap(),
-            &serde_json::json!({"PreToolUse": [{"command": "from-project"}]})
-        );
-    }
-
-    #[test]
-    fn move_key_applies_structured_sandbox_merge() {
-        // End-to-end check that the structured sandbox merge survives
-        // serialization through apply_move_key_impl: array leaves under
-        // filesystem.* and network.* union, scalar leaves replace,
-        // dest-only leaves survive.
-        let tmp = tempfile::tempdir().unwrap();
-        let paths = paths_in(tmp.path());
-        write(
-            paths.project.as_ref().unwrap(),
-            r#"{
-  "sandbox": {
-    "enabled": true,
-    "filesystem": {"allowWrite": ["/proj"]},
-    "network": {"allowedDomains": ["*.npmjs.org"]}
-  }
-}"#,
-        );
-        write(
-            paths.user.as_ref().unwrap(),
-            r#"{
-  "sandbox": {
-    "enabled": false,
-    "filesystem": {"allowWrite": ["/user"]},
-    "network": {"allowedDomains": ["github.com"], "httpProxyPort": 8080}
-  }
-}"#,
-        );
-        apply_move_key_impl(
-            &paths,
-            &MoveKeyRequest {
-                key: "sandbox".to_string(),
-                from: Scope::Project,
-                to: Scope::User,
-            },
-            &BackupTracker::new(),
-            &WatchState::default(),
-        )
-        .unwrap();
-        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            user_doc.get_top_level("sandbox").unwrap(),
-            &serde_json::json!({
-                "enabled": true,
-                "filesystem": {"allowWrite": ["/user", "/proj"]},
-                "network": {
-                    "allowedDomains": ["github.com", "*.npmjs.org"],
-                    "httpProxyPort": 8080
-                }
-            })
-        );
     }
 
     // -- move_leaf parity tests --------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,10 +31,6 @@ pub fn run() {
         .manage(overrides)
         .invoke_handler(tauri::generate_handler![
             commands::load_scopes,
-            commands::diff_move,
-            commands::apply_move,
-            commands::diff_move_key,
-            commands::apply_move_key,
             commands::diff_move_leaf,
             commands::apply_move_leaf,
             commands::load_preferences,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,8 @@ pub fn run() {
             commands::apply_move,
             commands::diff_move_key,
             commands::apply_move_key,
+            commands::diff_move_leaf,
+            commands::apply_move_leaf,
             commands::load_preferences,
             commands::save_preferences,
             commands::load_runtime_info,

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -348,10 +348,7 @@ impl SettingsDoc {
                 // overwrite (its documented shape-mismatch path), which for
                 // a permission move means propagating a malformed
                 // `permissions.<kind>` (a string, scalar, object) into the
-                // destination scope. The frontend already suppresses move
-                // affordances for malformed permission lists, but defense
-                // in depth at the IPC boundary keeps a hand-crafted
-                // request from corrupting the destination file.
+                // destination scope.
                 if !value.is_array() {
                     return Err(format!(
                         "permission list at `permissions.{}` must be a JSON array, got {}",
@@ -359,8 +356,30 @@ impl SettingsDoc {
                         json_type_name(&value)
                     ));
                 }
-                let arr = ensure_permission_list(&mut self.root, kind);
-                array_union_in_place(arr, value);
+                // Refuse to move when any entry isn't a string. The
+                // renderer, combined panel, count helpers, and confirm
+                // modal all treat permission lists as string-rules-only
+                // (non-strings are filtered silently) — unioning a number
+                // or object would write data the UI never shows on the
+                // dest. Filtering them out on the wire would silently
+                // drop the user's data without telling them; the
+                // explicit error gives them a chance to fix the file
+                // before retrying. Defense in depth: the frontend
+                // suppresses the affordance too, but a hand-crafted IPC
+                // would otherwise corrupt the destination.
+                let arr = value.as_array().expect("value.is_array()");
+                if let Some((idx, bad)) = arr.iter().enumerate().find(|(_, v)| !v.is_string()) {
+                    return Err(format!(
+                        "permission list at `permissions.{}` contains a non-string entry \
+                         at index {} ({}); ClaudeScope only treats string entries as rules \
+                         — fix the file before moving the list",
+                        kind.key(),
+                        idx,
+                        json_type_name(bad)
+                    ));
+                }
+                let arr_slot = ensure_permission_list(&mut self.root, kind);
+                array_union_in_place(arr_slot, value);
                 Ok(())
             }
             MovablePath::PermissionRule(kind, _) => {
@@ -1462,6 +1481,32 @@ mod tests {
             )
             .unwrap_err();
         assert!(err.contains("must be a JSON array"));
+        // Destination unchanged.
+        assert_eq!(
+            *doc.get_top_level("permissions").unwrap(),
+            serde_json::json!({"allow": ["a"]})
+        );
+    }
+
+    #[test]
+    fn merge_at_path_rejects_permission_list_with_non_string_entry() {
+        // Source array contains a number — the rest of the codebase treats
+        // permission lists as string-rules-only (renderer + combined panel
+        // + count helpers all filter), so a permission-list move must
+        // refuse rather than silently union an entry the UI never shows on
+        // the dest. The error names the bad index so the user can find it.
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"permissions": {"allow": ["a"]}}),
+            Indent::Spaces(2),
+        );
+        let err = doc
+            .merge_at_path(
+                &[key("permissions"), key("allow")],
+                serde_json::json!(["valid", 42, "another"]),
+            )
+            .unwrap_err();
+        assert!(err.contains("non-string entry"));
+        assert!(err.contains("index 1"));
         // Destination unchanged.
         assert_eq!(
             *doc.get_top_level("permissions").unwrap(),

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -151,16 +151,6 @@ pub struct PermissionRules {
     pub ask: Vec<String>,
 }
 
-impl PermissionRules {
-    pub fn get(&self, kind: PermissionKind) -> &[String] {
-        match kind {
-            PermissionKind::Allow => &self.allow,
-            PermissionKind::Deny => &self.deny,
-            PermissionKind::Ask => &self.ask,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct SettingsDoc {
     root: Value,
@@ -179,9 +169,12 @@ impl SettingsDoc {
         Self { root, indent }
     }
 
-    /// Top-level non-permission entries (key + value) in the order they were
-    /// written on disk. Used by the UI tree-view so it can show what's in
-    /// `env`, `hooks`, `theme`, and any future keys — not just their names.
+    /// Top-level non-permission entries (key + value) in on-disk order.
+    /// The UI consumes `all_entries` instead since the migration in #67
+    /// rendered `permissions` inline with the other top-level keys; this
+    /// accessor is kept under `#[cfg(test)]` so unit tests can still make
+    /// "permissions vs everything else" assertions compactly.
+    #[cfg(test)]
     pub fn other_entries(&self) -> Map<String, Value> {
         let Some(obj) = self.root.as_object() else {
             return Map::new();
@@ -192,9 +185,22 @@ impl SettingsDoc {
             .collect()
     }
 
+    /// Every top-level key + value in on-disk order, including `permissions`.
+    /// Drives the unified scope-column tree on the frontend.
+    pub fn all_entries(&self) -> Map<String, Value> {
+        let Some(obj) = self.root.as_object() else {
+            return Map::new();
+        };
+        obj.clone()
+    }
+
     /// Read the permissions block as a `PermissionRules` snapshot. Missing or
     /// malformed shapes produce empty lists rather than failing; a partially
     /// corrupt settings file shouldn't stop the whole UI from loading.
+    /// Production code reaches permissions through the unified `values`
+    /// map (see `commands::permissions_from_values`); this accessor is
+    /// kept for test convenience.
+    #[cfg(test)]
     pub fn permissions(&self) -> PermissionRules {
         let mut out = PermissionRules::default();
         let Some(perms) = self.root.get("permissions").and_then(Value::as_object) else {
@@ -216,62 +222,11 @@ impl SettingsDoc {
         out
     }
 
-    /// Add a rule to the given list if it isn't already present. Ensures
-    /// `permissions.<kind>` exists as an array. Returns true if the document
-    /// was actually mutated (i.e. the rule wasn't already present).
-    pub fn add_rule(&mut self, kind: PermissionKind, rule: &str) -> bool {
-        let obj = ensure_object(&mut self.root);
-        let perms_entry = obj
-            .entry("permissions".to_string())
-            .or_insert_with(|| Value::Object(Map::new()));
-        if !perms_entry.is_object() {
-            *perms_entry = Value::Object(Map::new());
-        }
-        let perms = perms_entry.as_object_mut().expect("permissions is object");
-        let list_entry = perms
-            .entry(kind.key().to_string())
-            .or_insert_with(|| Value::Array(Vec::new()));
-        if !list_entry.is_array() {
-            *list_entry = Value::Array(Vec::new());
-        }
-        let arr = list_entry.as_array_mut().expect("rule list is array");
-        if arr.iter().any(|v| v.as_str() == Some(rule)) {
-            return false;
-        }
-        arr.push(Value::String(rule.to_string()));
-        true
-    }
-
-    /// Remove every occurrence of `rule` from `permissions.<kind>`. Returns
-    /// true if at least one entry was removed.
-    pub fn remove_rule(&mut self, kind: PermissionKind, rule: &str) -> bool {
-        let Some(perms) = self
-            .root
-            .get_mut("permissions")
-            .and_then(Value::as_object_mut)
-        else {
-            return false;
-        };
-        let Some(Value::Array(arr)) = perms.get_mut(kind.key()) else {
-            return false;
-        };
-        let before = arr.len();
-        arr.retain(|v| v.as_str() != Some(rule));
-        before != arr.len()
-    }
-
-    /// Read a single top-level key (any type). Used by the key-move flow to
-    /// inspect the raw JSON value before applying a merge.
+    /// Read a single top-level key (any type). Tests and the move-leaf
+    /// diff/apply use it for one-shot reads; production callers that need
+    /// path-based access go through `get_at_path`.
     pub fn get_top_level(&self, key: &str) -> Option<&Value> {
         self.root.get(key)
-    }
-
-    /// Remove a top-level key. Returns true if the key was present.
-    pub fn remove_top_level(&mut self, key: &str) -> bool {
-        self.root
-            .as_object_mut()
-            .and_then(|o| o.remove(key))
-            .is_some()
     }
 
     /// Merge `value` into the top-level `key` using the documented Claude
@@ -853,26 +808,6 @@ mod tests {
     }
 
     #[test]
-    fn add_then_remove_roundtrip() {
-        let mut doc = SettingsDoc::empty();
-        doc.add_rule(PermissionKind::Allow, "Bash(git status)");
-        assert!(doc
-            .permissions()
-            .allow
-            .contains(&"Bash(git status)".to_string()));
-        assert!(doc.remove_rule(PermissionKind::Allow, "Bash(git status)"));
-        assert!(doc.permissions().allow.is_empty());
-    }
-
-    #[test]
-    fn add_rule_is_idempotent_and_reports_mutation() {
-        let mut doc = SettingsDoc::empty();
-        assert!(doc.add_rule(PermissionKind::Deny, "Bash(rm -rf /)"));
-        assert!(!doc.add_rule(PermissionKind::Deny, "Bash(rm -rf /)"));
-        assert_eq!(doc.permissions().deny.len(), 1);
-    }
-
-    #[test]
     fn render_preserves_key_order_and_indent() {
         let doc = SettingsDoc::from_value(
             serde_json::from_str(r#"{"theme":"dark","permissions":{"allow":["a"],"deny":[]}}"#)
@@ -903,12 +838,6 @@ mod tests {
         let doc = SettingsDoc::empty();
         let out = doc.render();
         assert_eq!(out.trim_end(), "{}");
-    }
-
-    #[test]
-    fn remove_rule_on_missing_is_noop() {
-        let mut doc = SettingsDoc::empty();
-        assert!(!doc.remove_rule(PermissionKind::Allow, "nope"));
     }
 
     #[test]
@@ -1241,18 +1170,6 @@ mod tests {
             *doc.get_top_level("allowedHttpHookUrls").unwrap(),
             serde_json::json!(["https://a.example"])
         );
-    }
-
-    #[test]
-    fn remove_top_level_reports_presence() {
-        let mut doc = SettingsDoc::from_value(
-            serde_json::json!({"env": {"A": "1"}, "theme": "dark"}),
-            Indent::Spaces(2),
-        );
-        assert!(doc.remove_top_level("theme"));
-        assert!(!doc.remove_top_level("theme"));
-        assert!(doc.get_top_level("theme").is_none());
-        assert!(doc.get_top_level("env").is_some());
     }
 
     fn key(s: &str) -> PathSeg {

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -19,6 +19,115 @@ pub enum PermissionKind {
     Ask,
 }
 
+/// One segment of a JSON path. The frontend ships paths as mixed arrays of
+/// strings and numbers (`["permissions", "allow", 2]`), so an untagged enum
+/// over `String` / `usize` keeps the wire format identical to JSON Pointer
+/// shape without forcing every caller to escape numeric indices.
+///
+/// `Key` is tried first by serde, which is the right preference: object keys
+/// are strings on the wire even when they happen to look numeric, and
+/// `serde_json` only feeds the `usize` arm an actual JSON number.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PathSeg {
+    Key(String),
+    Index(usize),
+}
+
+impl PathSeg {
+    /// Borrow the key segment if this is one. Used by the diff/apply flows
+    /// to pull the affected top-level key off a validated path; index
+    /// segments don't appear at index 0 of any movable shape.
+    pub fn as_key(&self) -> Option<&str> {
+        match self {
+            PathSeg::Key(s) => Some(s.as_str()),
+            PathSeg::Index(_) => None,
+        }
+    }
+}
+
+/// Shape of a path the move-leaf primitive accepts. `validate_movable_path`
+/// classifies every incoming request into one of these so the diff/apply
+/// impls can dispatch on a small, exhaustive enum instead of scrutinizing the
+/// path slice in three places. The set deliberately mirrors today's two-IPC
+/// capabilities (whole top-level key, whole permission kind array, single
+/// permission rule) — broader sub-path moves into other keys (`env.PATH`,
+/// `hooks.PreToolUse[0]`, etc.) are explicitly rejected for v1; they're a
+/// natural follow-up but out of scope for issue #67.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MovablePath<'a> {
+    /// Whole top-level key. Mirrors the old key-move flow.
+    TopLevelKey(&'a str),
+    /// Whole `permissions.<kind>` array (allow / deny / ask). Array-union into
+    /// the destination's matching array.
+    PermissionList(PermissionKind),
+    /// Single rule entry under `permissions.<kind>`. Array-union into the
+    /// destination's matching array (push if not already present).
+    PermissionRule(PermissionKind, usize),
+}
+
+/// Classify a wire-level path into a `MovablePath`, or reject it with a
+/// descriptive error. Centralizing the rules here keeps the diff path, apply
+/// path, and any future caller in lockstep — a path that's invalid at
+/// validation time is impossible at the dispatch site.
+pub fn validate_movable_path(path: &[PathSeg]) -> Result<MovablePath<'_>, String> {
+    match path {
+        [PathSeg::Key(k)] if k == "permissions" => Err(
+            "the permissions key is not movable as a whole; move a specific rule list \
+             (allow / deny / ask) or a single rule"
+                .into(),
+        ),
+        [PathSeg::Key(k)] => Ok(MovablePath::TopLevelKey(k.as_str())),
+        [PathSeg::Key(perm), PathSeg::Key(kind)] if perm == "permissions" => {
+            permission_kind_from_str(kind).map(MovablePath::PermissionList)
+        }
+        [PathSeg::Key(perm), PathSeg::Key(kind), PathSeg::Index(i)] if perm == "permissions" => {
+            permission_kind_from_str(kind).map(|k| MovablePath::PermissionRule(k, *i))
+        }
+        [] => Err("path is empty; move requires a target".into()),
+        _ => Err(format!(
+            "path is not movable in this version: {}",
+            describe_path(path)
+        )),
+    }
+}
+
+fn permission_kind_from_str(s: &str) -> Result<PermissionKind, String> {
+    match s {
+        "allow" => Ok(PermissionKind::Allow),
+        "deny" => Ok(PermissionKind::Deny),
+        "ask" => Ok(PermissionKind::Ask),
+        other => Err(format!(
+            "unknown permission kind `{other}`: expected allow / deny / ask"
+        )),
+    }
+}
+
+/// Render a path slice in JSON-Pointer-ish form for error messages. Uses dot
+/// separators for keys and bracketed indices for array entries (e.g.
+/// `permissions.allow[2]`) — readable in error toasts without needing the
+/// caller to construct the string themselves.
+pub fn describe_path(path: &[PathSeg]) -> String {
+    let mut out = String::new();
+    for seg in path {
+        match seg {
+            PathSeg::Key(k) => {
+                if !out.is_empty() {
+                    out.push('.');
+                }
+                out.push_str(k);
+            }
+            PathSeg::Index(i) => {
+                out.push_str(&format!("[{i}]"));
+            }
+        }
+    }
+    if out.is_empty() {
+        out.push_str("(root)");
+    }
+    out
+}
+
 impl PermissionKind {
     pub const ALL: [PermissionKind; 3] = [
         PermissionKind::Allow,
@@ -208,6 +317,100 @@ impl SettingsDoc {
         }
     }
 
+    /// Read the JSON value at `path` if every segment resolves. Object keys
+    /// are matched verbatim; array indices must be in-bounds. Returns `None`
+    /// when any segment misses, which the move flow distinguishes from
+    /// `Some(Value::Null)` (a real null value at that path).
+    pub fn get_at_path(&self, path: &[PathSeg]) -> Option<&Value> {
+        let mut cur = &self.root;
+        for seg in path {
+            cur = match (cur, seg) {
+                (Value::Object(obj), PathSeg::Key(k)) => obj.get(k)?,
+                (Value::Array(arr), PathSeg::Index(i)) => arr.get(*i)?,
+                _ => return None,
+            };
+        }
+        Some(cur)
+    }
+
+    /// Remove the value at `path`. Mirrors `get_at_path`'s navigation but
+    /// removes the trailing segment instead of returning the value: keys are
+    /// removed from their parent object, array indices are spliced out (which
+    /// shifts later indices). Returns true iff a removal happened — a missing
+    /// path is a no-op `false` so callers can detect a stale request.
+    pub fn remove_at_path(&mut self, path: &[PathSeg]) -> bool {
+        let Some((last, parents)) = path.split_last() else {
+            return false;
+        };
+        let mut cur = &mut self.root;
+        for seg in parents {
+            cur = match (cur, seg) {
+                (Value::Object(obj), PathSeg::Key(k)) => match obj.get_mut(k) {
+                    Some(v) => v,
+                    None => return false,
+                },
+                (Value::Array(arr), PathSeg::Index(i)) => match arr.get_mut(*i) {
+                    Some(v) => v,
+                    None => return false,
+                },
+                _ => return false,
+            };
+        }
+        match (cur, last) {
+            (Value::Object(obj), PathSeg::Key(k)) => obj.remove(k).is_some(),
+            (Value::Array(arr), PathSeg::Index(i)) if *i < arr.len() => {
+                arr.remove(*i);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Merge `value` into the destination using the move-leaf semantics
+    /// classified by `validate_movable_path`. The caller is expected to have
+    /// already validated `path`; passing an invalid path here is a bug, so
+    /// this returns an error rather than silently dropping the write.
+    ///
+    /// - `MovablePath::TopLevelKey(k)` defers to `merge_top_level` so the
+    ///   existing per-key policy table (Replace / DeepMerge / ArrayUnion /
+    ///   Sandbox / ReplaceUnknown) governs the merge.
+    /// - `MovablePath::PermissionList(kind)` array-unions the incoming list
+    ///   into `permissions.<kind>`. Non-array sources fall back to overwrite,
+    ///   matching `array_union_in_place`'s shape-mismatch contract.
+    /// - `MovablePath::PermissionRule(kind, _)` ignores the source index (the
+    ///   destination's array order is independent) and pushes the rule string
+    ///   into `permissions.<kind>` if not already present.
+    pub fn merge_at_path(&mut self, path: &[PathSeg], value: Value) -> Result<(), String> {
+        let movable = validate_movable_path(path)?;
+        match movable {
+            MovablePath::TopLevelKey(k) => {
+                self.merge_top_level(k, value);
+                Ok(())
+            }
+            MovablePath::PermissionList(kind) => {
+                let arr = ensure_permission_list(&mut self.root, kind);
+                array_union_in_place(arr, value);
+                Ok(())
+            }
+            MovablePath::PermissionRule(kind, _) => {
+                let Some(rule) = value.as_str() else {
+                    return Err(format!(
+                        "permission rule must be a JSON string, got {}",
+                        json_type_name(&value)
+                    ));
+                };
+                let arr_value = ensure_permission_list(&mut self.root, kind);
+                let arr = arr_value
+                    .as_array_mut()
+                    .expect("ensure_permission_list returns array");
+                if !arr.iter().any(|v| v.as_str() == Some(rule)) {
+                    arr.push(Value::String(rule.to_string()));
+                }
+                Ok(())
+            }
+        }
+    }
+
     /// Render to JSON using the detected indentation. We intentionally avoid
     /// serde_json's pretty printer configuration because it doesn't support
     /// tab indents; hand-rolling keeps our options open.
@@ -229,6 +432,43 @@ fn ensure_object(value: &mut Value) -> &mut Map<String, Value> {
         *value = Value::Object(Map::new());
     }
     value.as_object_mut().expect("just made it an object")
+}
+
+/// Resolve `root.permissions.<kind>` to a mutable array slot, creating any
+/// missing intermediates. If `permissions` exists but is the wrong shape
+/// (e.g. a hand-edited file where `permissions` ended up as a string), the
+/// non-object value is replaced with a fresh map — matching the conservative
+/// "rather create than fail" stance of `add_rule`. Returns the array slot as
+/// a `&mut Value` so callers can hand it straight to `array_union_in_place`.
+fn ensure_permission_list(root: &mut Value, kind: PermissionKind) -> &mut Value {
+    let obj = ensure_object(root);
+    let perms_entry = obj
+        .entry("permissions".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !perms_entry.is_object() {
+        *perms_entry = Value::Object(Map::new());
+    }
+    let perms = perms_entry.as_object_mut().expect("permissions is object");
+    let list_entry = perms
+        .entry(kind.key().to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if !list_entry.is_array() {
+        *list_entry = Value::Array(Vec::new());
+    }
+    list_entry
+}
+
+/// Human-readable name for a JSON value's runtime shape, used in error
+/// messages. Lifted to a helper so the move-leaf API can stay terse.
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
 }
 
 /// How a top-level settings key should be combined when its value is moved
@@ -1013,5 +1253,287 @@ mod tests {
         assert!(!doc.remove_top_level("theme"));
         assert!(doc.get_top_level("theme").is_none());
         assert!(doc.get_top_level("env").is_some());
+    }
+
+    fn key(s: &str) -> PathSeg {
+        PathSeg::Key(s.to_string())
+    }
+
+    fn idx(i: usize) -> PathSeg {
+        PathSeg::Index(i)
+    }
+
+    #[test]
+    fn validate_movable_path_classifies_top_level_key() {
+        assert_eq!(
+            validate_movable_path(&[key("env")]).unwrap(),
+            MovablePath::TopLevelKey("env")
+        );
+    }
+
+    #[test]
+    fn validate_movable_path_classifies_permission_list() {
+        assert_eq!(
+            validate_movable_path(&[key("permissions"), key("allow")]).unwrap(),
+            MovablePath::PermissionList(PermissionKind::Allow)
+        );
+        assert_eq!(
+            validate_movable_path(&[key("permissions"), key("deny")]).unwrap(),
+            MovablePath::PermissionList(PermissionKind::Deny)
+        );
+    }
+
+    #[test]
+    fn validate_movable_path_classifies_permission_rule() {
+        assert_eq!(
+            validate_movable_path(&[key("permissions"), key("ask"), idx(3)]).unwrap(),
+            MovablePath::PermissionRule(PermissionKind::Ask, 3)
+        );
+    }
+
+    #[test]
+    fn validate_movable_path_rejects_bare_permissions_key() {
+        // Whole-block permissions moves bypass the per-rule policy and would
+        // surprise users — reject so the UI never offers the gesture.
+        assert!(validate_movable_path(&[key("permissions")]).is_err());
+    }
+
+    #[test]
+    fn validate_movable_path_rejects_unknown_permission_kind() {
+        assert!(validate_movable_path(&[key("permissions"), key("maybe")]).is_err());
+    }
+
+    #[test]
+    fn validate_movable_path_rejects_intermediate_subkeys() {
+        // v1 only carries today's two-IPC capabilities forward; sub-path moves
+        // into other keys (`env.PATH`, `hooks.PreToolUse[0]`) are explicitly
+        // out of scope until a follow-up issue.
+        assert!(validate_movable_path(&[key("env"), key("PATH")]).is_err());
+        assert!(validate_movable_path(&[key("hooks"), key("PreToolUse"), idx(0)]).is_err());
+    }
+
+    #[test]
+    fn validate_movable_path_rejects_empty() {
+        assert!(validate_movable_path(&[]).is_err());
+    }
+
+    #[test]
+    fn describe_path_renders_dot_and_brackets() {
+        assert_eq!(
+            describe_path(&[key("permissions"), key("allow"), idx(2)]),
+            "permissions.allow[2]"
+        );
+        assert_eq!(describe_path(&[key("env")]), "env");
+        assert_eq!(describe_path(&[]), "(root)");
+    }
+
+    #[test]
+    fn get_at_path_navigates_object_and_array() {
+        let doc = SettingsDoc::from_value(
+            serde_json::json!({
+                "permissions": {"allow": ["Bash(git status)", "Read(**)"]},
+                "env": {"PATH": "/bin"}
+            }),
+            Indent::Spaces(2),
+        );
+        assert_eq!(
+            doc.get_at_path(&[key("permissions"), key("allow"), idx(1)])
+                .unwrap(),
+            &serde_json::json!("Read(**)")
+        );
+        assert_eq!(
+            doc.get_at_path(&[key("env"), key("PATH")]).unwrap(),
+            &serde_json::json!("/bin")
+        );
+    }
+
+    #[test]
+    fn get_at_path_returns_none_on_miss() {
+        let doc = SettingsDoc::from_value(
+            serde_json::json!({"permissions": {"allow": ["x"]}}),
+            Indent::Spaces(2),
+        );
+        // Index out of bounds.
+        assert!(doc
+            .get_at_path(&[key("permissions"), key("allow"), idx(7)])
+            .is_none());
+        // Wrong segment kind for the runtime shape.
+        assert!(doc.get_at_path(&[key("permissions"), idx(0)]).is_none());
+        // Missing key.
+        assert!(doc.get_at_path(&[key("nope")]).is_none());
+    }
+
+    #[test]
+    fn get_at_path_distinguishes_null_value_from_absence() {
+        // Real `null` round-trips as `Some(Value::Null)`; absence is `None`.
+        // The move flow keys off this distinction (skip_serializing_if).
+        let doc = SettingsDoc::from_value(serde_json::json!({"theme": null}), Indent::Spaces(2));
+        assert_eq!(doc.get_at_path(&[key("theme")]), Some(&Value::Null));
+        assert_eq!(doc.get_at_path(&[key("missing")]), None);
+    }
+
+    #[test]
+    fn remove_at_path_removes_top_level_key() {
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"theme": "dark", "env": {"A": "1"}}),
+            Indent::Spaces(2),
+        );
+        assert!(doc.remove_at_path(&[key("theme")]));
+        assert!(doc.get_top_level("theme").is_none());
+        assert!(doc.get_top_level("env").is_some());
+    }
+
+    #[test]
+    fn remove_at_path_splices_array_element_and_shifts() {
+        // Removing an element shifts later indices left — caller responsibility
+        // to re-fetch by value, not by stale index.
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"permissions": {"allow": ["a", "b", "c"]}}),
+            Indent::Spaces(2),
+        );
+        assert!(doc.remove_at_path(&[key("permissions"), key("allow"), idx(1)]));
+        assert_eq!(
+            doc.get_at_path(&[key("permissions"), key("allow")])
+                .unwrap(),
+            &serde_json::json!(["a", "c"])
+        );
+    }
+
+    #[test]
+    fn remove_at_path_returns_false_on_miss() {
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"permissions": {"allow": ["x"]}}),
+            Indent::Spaces(2),
+        );
+        assert!(!doc.remove_at_path(&[key("permissions"), key("allow"), idx(7)]));
+        assert!(!doc.remove_at_path(&[key("permissions"), key("deny"), idx(0)]));
+        assert!(!doc.remove_at_path(&[key("nope")]));
+        assert!(!doc.remove_at_path(&[]));
+    }
+
+    #[test]
+    fn merge_at_path_top_level_key_dispatches_to_existing_policy() {
+        // env's KeyPolicy::DeepMerge must apply through merge_at_path so the
+        // unified primitive doesn't change semantics for keys that already had
+        // a policy under merge_top_level.
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"env": {"PATH": "/old", "HOME": "/h"}}),
+            Indent::Spaces(2),
+        );
+        doc.merge_at_path(&[key("env")], serde_json::json!({"PATH": "/new", "X": "1"}))
+            .unwrap();
+        assert_eq!(
+            *doc.get_top_level("env").unwrap(),
+            serde_json::json!({"PATH": "/new", "HOME": "/h", "X": "1"})
+        );
+    }
+
+    #[test]
+    fn merge_at_path_permission_list_unions_array() {
+        // Whole-list move: array-union into the destination's matching kind,
+        // matching the rule-move semantics rather than a wholesale replace.
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"permissions": {"allow": ["a", "b"]}}),
+            Indent::Spaces(2),
+        );
+        doc.merge_at_path(
+            &[key("permissions"), key("allow")],
+            serde_json::json!(["b", "c"]),
+        )
+        .unwrap();
+        assert_eq!(
+            *doc.get_top_level("permissions").unwrap(),
+            serde_json::json!({"allow": ["a", "b", "c"]})
+        );
+    }
+
+    #[test]
+    fn merge_at_path_permission_rule_pushes_when_absent() {
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"permissions": {"allow": ["a"]}}),
+            Indent::Spaces(2),
+        );
+        doc.merge_at_path(
+            &[key("permissions"), key("allow"), idx(0)],
+            serde_json::json!("b"),
+        )
+        .unwrap();
+        assert_eq!(
+            *doc.get_top_level("permissions").unwrap(),
+            serde_json::json!({"allow": ["a", "b"]})
+        );
+    }
+
+    #[test]
+    fn merge_at_path_permission_rule_is_idempotent() {
+        // Existing rule already in the destination is a no-op merge; the
+        // source-removal half of the move flow handles the cleanup.
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"permissions": {"allow": ["a"]}}),
+            Indent::Spaces(2),
+        );
+        doc.merge_at_path(
+            &[key("permissions"), key("allow"), idx(0)],
+            serde_json::json!("a"),
+        )
+        .unwrap();
+        assert_eq!(
+            *doc.get_top_level("permissions").unwrap(),
+            serde_json::json!({"allow": ["a"]})
+        );
+    }
+
+    #[test]
+    fn merge_at_path_permission_rule_creates_missing_kind_array() {
+        // Destination has no `deny` array yet — the helper should create it
+        // and insert, mirroring `add_rule`'s self-bootstrapping behavior.
+        let mut doc = SettingsDoc::empty();
+        doc.merge_at_path(
+            &[key("permissions"), key("deny"), idx(0)],
+            serde_json::json!("WebFetch(domain:evil.example)"),
+        )
+        .unwrap();
+        assert_eq!(
+            *doc.get_top_level("permissions").unwrap(),
+            serde_json::json!({"deny": ["WebFetch(domain:evil.example)"]})
+        );
+    }
+
+    #[test]
+    fn merge_at_path_rejects_non_string_permission_rule() {
+        let mut doc = SettingsDoc::empty();
+        let err = doc
+            .merge_at_path(
+                &[key("permissions"), key("allow"), idx(0)],
+                serde_json::json!(42),
+            )
+            .unwrap_err();
+        assert!(err.contains("must be a JSON string"));
+    }
+
+    #[test]
+    fn merge_at_path_rejects_invalid_path() {
+        let mut doc = SettingsDoc::empty();
+        // Bare permissions key — same rejection as validate_movable_path.
+        assert!(doc
+            .merge_at_path(&[key("permissions")], serde_json::json!({}))
+            .is_err());
+        // Sub-key under env not yet supported.
+        assert!(doc
+            .merge_at_path(&[key("env"), key("PATH")], serde_json::json!("/bin"))
+            .is_err());
+    }
+
+    #[test]
+    fn path_seg_serde_roundtrip_matches_wire_format() {
+        // Frontend ships paths as JSON arrays of strings + numbers. The
+        // untagged enum has to preserve that shape exactly so the IPC wire
+        // format never needs an escape hatch.
+        let path: Vec<PathSeg> =
+            serde_json::from_value(serde_json::json!(["permissions", "allow", 2])).unwrap();
+        assert_eq!(path, vec![key("permissions"), key("allow"), idx(2)]);
+
+        let back = serde_json::to_value(&path).unwrap();
+        assert_eq!(back, serde_json::json!(["permissions", "allow", 2]));
     }
 }

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -343,6 +343,22 @@ impl SettingsDoc {
                 Ok(())
             }
             MovablePath::PermissionList(kind) => {
+                // Reject up front when the source value isn't an array.
+                // `array_union_in_place` would otherwise fall back to an
+                // overwrite (its documented shape-mismatch path), which for
+                // a permission move means propagating a malformed
+                // `permissions.<kind>` (a string, scalar, object) into the
+                // destination scope. The frontend already suppresses move
+                // affordances for malformed permission lists, but defense
+                // in depth at the IPC boundary keeps a hand-crafted
+                // request from corrupting the destination file.
+                if !value.is_array() {
+                    return Err(format!(
+                        "permission list at `permissions.{}` must be a JSON array, got {}",
+                        kind.key(),
+                        json_type_name(&value)
+                    ));
+                }
                 let arr = ensure_permission_list(&mut self.root, kind);
                 array_union_in_place(arr, value);
                 Ok(())
@@ -1426,6 +1442,31 @@ mod tests {
             )
             .unwrap_err();
         assert!(err.contains("must be a JSON string"));
+    }
+
+    #[test]
+    fn merge_at_path_rejects_non_array_permission_list() {
+        // Hand-edited file where `permissions.allow` ended up as a string
+        // (or any non-array). Without this guard, `array_union_in_place`
+        // would fall back to overwrite and propagate the malformed shape
+        // into the destination scope. The frontend already suppresses the
+        // affordance, but the IPC must refuse a hand-crafted request too.
+        let mut doc = SettingsDoc::from_value(
+            serde_json::json!({"permissions": {"allow": ["a"]}}),
+            Indent::Spaces(2),
+        );
+        let err = doc
+            .merge_at_path(
+                &[key("permissions"), key("allow")],
+                serde_json::json!("not-an-array"),
+            )
+            .unwrap_err();
+        assert!(err.contains("must be a JSON array"));
+        // Destination unchanged.
+        assert_eq!(
+            *doc.get_top_level("permissions").unwrap(),
+            serde_json::json!({"allow": ["a"]})
+        );
     }
 
     #[test]

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,18 +5,16 @@ import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import "./styles.css";
 import type {
   LoadedScopes,
-  MoveKeyPreview,
-  MoveKeyRequest,
+  MoveLeafPreview,
+  MoveLeafRequest,
   MoveOptions,
-  MovePreview,
-  MoveRequest,
   Preferences,
   RuntimeInfo,
   Scope,
   Theme,
 } from "./types.ts";
 import { SCOPES, SEARCH_INPUT_ID } from "./types.ts";
-import { confirmMove, confirmMoveKey, openSettings, renderApp } from "./ui.ts";
+import { confirmMoveLeaf, openSettings, renderApp } from "./ui.ts";
 
 // Mirror of the Rust `Preferences::default()` — used until the real payload
 // arrives from the backend so renders before load_preferences() resolves
@@ -105,8 +103,8 @@ async function reload(): Promise<void> {
   await load(state.projectDir);
 }
 
-async function moveRule(
-  req: MoveRequest,
+async function moveLeaf(
+  req: MoveLeafRequest,
   trigger?: HTMLElement,
   opts?: MoveOptions,
 ): Promise<void> {
@@ -119,26 +117,29 @@ async function moveRule(
     // becomes friction (#70). Click-to-move stays gated on the modal as
     // the safer default for the less-explicit click gesture.
     if (!opts?.skipConfirm) {
-      // Intentionally *don't* flip state.busy / re-render before diff_move:
-      // it's fast, the modal itself blocks interaction once open, and keeping
-      // the triggering button alive lets confirmMove restore focus to it on
-      // Cancel/Esc.
-      let preview: MovePreview;
+      // Intentionally *don't* flip state.busy / re-render before
+      // diff_move_leaf: it's fast, the modal itself blocks interaction once
+      // open, and keeping the triggering button alive lets confirmMoveLeaf
+      // restore focus to it on Cancel/Esc.
+      let preview: MoveLeafPreview;
       try {
-        preview = await invoke<MovePreview>("diff_move", { req, project_dir: projectDir });
+        preview = await invoke<MoveLeafPreview>("diff_move_leaf", {
+          req,
+          project_dir: projectDir,
+        });
       } catch (err) {
         alert(`Move failed: ${err}`);
         return;
       }
 
-      const apply = await confirmMove(preview, trigger);
+      const apply = await confirmMoveLeaf(preview, trigger);
       if (!apply) return;
     }
 
     state.busy = true;
     render();
     try {
-      await invoke("apply_move", { req, project_dir: projectDir });
+      await invoke("apply_move_leaf", { req, project_dir: projectDir });
       // load() owns busy cleanup + final render on success — don't
       // duplicate that work in a finally block.
       await load(projectDir);
@@ -154,49 +155,6 @@ async function moveRule(
     // were in the middle of a move). Drain it here so an external edit
     // during the confirm step still gets picked up after the modal
     // closes. load()'s finally does the same thing for the load case.
-    if (externalReloadPending && !state.busy) {
-      externalReloadPending = false;
-      void load(state.projectDir);
-    }
-  }
-}
-
-async function moveKey(
-  req: MoveKeyRequest,
-  trigger?: HTMLElement,
-  opts?: MoveOptions,
-): Promise<void> {
-  if (moveInFlight) return;
-  moveInFlight = true;
-  try {
-    const projectDir = state.projectDir;
-    // Same skip-confirm contract as moveRule (#70): drops bypass the
-    // diff/confirm modal because dragging already expresses intent.
-    if (!opts?.skipConfirm) {
-      let preview: MoveKeyPreview;
-      try {
-        preview = await invoke<MoveKeyPreview>("diff_move_key", { req, project_dir: projectDir });
-      } catch (err) {
-        alert(`Move failed: ${err}`);
-        return;
-      }
-
-      const apply = await confirmMoveKey(preview, trigger);
-      if (!apply) return;
-    }
-
-    state.busy = true;
-    render();
-    try {
-      await invoke("apply_move_key", { req, project_dir: projectDir });
-      await load(projectDir);
-    } catch (err) {
-      alert(`Move failed: ${err}`);
-      state.busy = false;
-      render();
-    }
-  } finally {
-    moveInFlight = false;
     if (externalReloadPending && !state.busy) {
       externalReloadPending = false;
       void load(state.projectDir);
@@ -324,8 +282,7 @@ function render(): void {
     runtime: state.runtime,
     onPickProject: pickProject,
     onReload: reload,
-    onMove: moveRule,
-    onMoveKey: moveKey,
+    onMoveLeaf: moveLeaf,
     onOpenSettings,
     onQueryChange: setQuery,
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,18 +16,23 @@ export type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue };
 
+/**
+ * One segment of a JSON path. Mirrors Rust's `PathSeg` (untagged
+ * `String`/`usize`): object keys ride as strings, array indices ride as
+ * numbers. The unified `move_leaf` IPC carries paths in this shape.
+ */
+export type PathSeg = string | number;
+
 export interface ScopeView {
   scope: Scope;
   path: string | null;
   exists: boolean;
-  permissions: PermissionRules;
-  // Non-permission top-level keys with their raw JSON values. Rust preserves
-  // on-disk key order via serde_json's `preserve_order` feature; JS preserves
-  // insertion order too for string keys, *except* it shuffles integer-like
-  // keys ("0", "1", …) to the front. For Claude Code's settings shape
-  // (env var names, hook event names, theme scalar) that's a non-issue —
-  // none of the realistic top-level or nested keys are integer-like.
-  other_values: { [key: string]: JsonValue };
+  // Every top-level key on disk in source order, including `permissions`.
+  // Rust preserves on-disk key order via serde_json's `preserve_order`
+  // feature; JS preserves insertion order too for string keys, *except* it
+  // shuffles integer-like keys ("0", "1", …) to the front. Realistic Claude
+  // Code settings keys are non-integer-like, so this is a non-issue.
+  values: { [key: string]: JsonValue };
   parse_error: string | null;
 }
 
@@ -55,66 +60,56 @@ export interface LoadedScopes {
   combined_origins: PermissionRuleOrigins;
 }
 
-export interface MoveRequest {
-  rule: string;
-  kind: PermissionKind;
+/**
+ * Path-based move request. Replaces the per-rule `MoveRequest` and per-key
+ * `MoveKeyRequest` shapes with a single primitive: any movable JSON path
+ * (whole top-level key, whole `permissions.<kind>` array, or a single rule
+ * under `permissions.<kind>`) plus source / destination scopes.
+ */
+export interface MoveLeafRequest {
+  path: PathSeg[];
   from: Scope;
   to: Scope;
 }
 
 /**
- * Caller hints for `onMove` / `onMoveKey`. Drop handlers pass
- * `skipConfirm: true` because dragging onto a target column already
- * expresses intent — the diff/confirm modal is friction at that point.
- * Click-to-move keeps the modal as the safer default for less explicit
- * gestures. Recovery on accidental drops still falls back to the
- * per-write `.bak` files until an audit log / undo lands (#19).
+ * Caller hints for `onMoveLeaf`. Drop handlers pass `skipConfirm: true`
+ * because dragging onto a target column already expresses intent — the
+ * diff/confirm modal is friction at that point. Click-to-move keeps the
+ * modal as the safer default for less explicit gestures. Recovery on
+ * accidental drops still falls back to the per-write `.bak` files until an
+ * audit log / undo lands (#19).
  */
 export interface MoveOptions {
   skipConfirm?: boolean;
 }
 
-export interface MoveSide {
+/**
+ * What kind of movable path the preview describes. Mirrors Rust's
+ * `MoveLeafKind` (snake_case on the wire) so the diff modal can branch on a
+ * compact discriminator instead of re-classifying the path itself.
+ */
+export type MoveLeafKind = "top_level_key" | "permission_list" | "permission_rule";
+
+export interface MoveLeafSide {
   scope: Scope;
-  path: string;
-  path_exists: boolean;
-  rules_before: string[];
-  rules_after: string[];
+  file_path: string;
+  file_path_exists: boolean;
+  // The Rust side omits these fields entirely when the affected top-level
+  // key is absent (see `#[serde(skip_serializing_if = "Option::is_none")]`),
+  // so `undefined` means "key absent" while `null` is a real JSON null
+  // value. The diff modal keys off that distinction when rendering.
+  key_before?: JsonValue;
+  key_after?: JsonValue;
   will_write: boolean;
   note: string | null;
 }
 
-export interface MovePreview {
-  rule: string;
-  kind: PermissionKind;
-  from: MoveSide;
-  to: MoveSide;
-}
-
-export interface MoveKeyRequest {
-  key: string;
-  from: Scope;
-  to: Scope;
-}
-
-export interface MoveKeySide {
-  scope: Scope;
-  path: string;
-  path_exists: boolean;
-  // The Rust side omits `value_before` / `value_after` entirely when the key
-  // is absent (see `#[serde(skip_serializing_if = "Option::is_none")]`), so
-  // `undefined` means "absent" while `null` is a real JSON null value. The
-  // UI relies on that distinction when rendering verdicts and values.
-  value_before?: JsonValue;
-  value_after?: JsonValue;
-  will_write: boolean;
-  note: string | null;
-}
-
-export interface MoveKeyPreview {
-  key: string;
-  from: MoveKeySide;
-  to: MoveKeySide;
+export interface MoveLeafPreview {
+  path: PathSeg[];
+  kind: MoveLeafKind;
+  from: MoveLeafSide;
+  to: MoveLeafSide;
 }
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -155,6 +155,20 @@ export function renderApp(root: HTMLElement, props: AppProps): void {
     return;
   }
 
+  // Seed `openTreeNodes` with the default-open permission branches once per
+  // project, on the first render that has scopes available. Done here
+  // (rather than inside `treeBranch`'s own auto-open clause) so a manual
+  // collapse via `<details>.toggle` is *authoritative* — without this,
+  // any subsequent render after a move or filter change would reopen the
+  // branch and the collapsed state would be impossible to persist.
+  // `lastSeededProjectDir` decouples the seed from `lastRenderedProjectDir`
+  // because scopes can lag a project change by one render (busy=true,
+  // scopes=null first; scopes arrive on the next render).
+  if (lastSeededProjectDir !== props.projectDir) {
+    lastSeededProjectDir = props.projectDir;
+    seedDefaultOpenPermissions(props.scopes);
+  }
+
   // Lowercase the query once per render instead of per rule; scopeGrid/
   // combinedPanel push this down into every filter call.
   const lowerQuery = props.query.toLowerCase();
@@ -535,6 +549,35 @@ const openTreeNodes = new Set<string>();
 // in a different project that happens to share scope+path strings.
 let lastRenderedProjectDir: string | null = null;
 
+// Tracks the project directory we last seeded with default-open permission
+// branches. Distinct from `lastRenderedProjectDir` because the first render
+// after a project pick is usually `busy: true` with no scopes yet; the seed
+// has to wait for the second render where scopes are available.
+let lastSeededProjectDir: string | null = null;
+
+/**
+ * One-shot seed of `openTreeNodes` for the permission branches we want to
+ * default-open on a fresh project load: `permissions` itself plus each
+ * non-empty `permissions.<kind>` array. Mirrors the old single-pane
+ * visibility from before the unified-tree migration so the user lands on
+ * the same allow / deny / ask content without clicking. After this, the
+ * `<details>.toggle` listener in `treeBranch` is the only writer of
+ * `openTreeNodes`, so a manual collapse persists across re-renders.
+ */
+function seedDefaultOpenPermissions(loaded: LoadedScopes): void {
+  for (const view of loaded.scopes) {
+    const perms = view.values.permissions;
+    if (!perms || typeof perms !== "object" || Array.isArray(perms)) continue;
+    openTreeNodes.add(treeKey(view.scope, ["permissions"]));
+    const permsObj = perms as { [k: string]: JsonValue };
+    for (const kind of PERMISSION_KINDS) {
+      if (Array.isArray(permsObj[kind])) {
+        openTreeNodes.add(treeKey(view.scope, ["permissions", kind]));
+      }
+    }
+  }
+}
+
 // HTML5 drag-and-drop source state. Set by `dragstart` on a movable tree
 // node, cleared by `dragend` (or by renderApp on a re-render that tears
 // down the source mid-drag). Lives at module scope because `dragover` on
@@ -661,15 +704,13 @@ function treeBranch(
     }
   }
 
-  // Auto-expand permission branches under the unified tree (parent is "permissions")
-  // so the user doesn't need to click into the tree to see allow / deny / ask
-  // — that was the old single-pane visibility before the migration.
-  const isPermissionsChild = path.length === 2 && path[0] === "permissions";
-  const shouldAutoOpen =
-    openTreeNodes.has(key) ||
-    (path.length === 1 && path[0] === "permissions") ||
-    isPermissionsChild;
-  if (shouldAutoOpen) {
+  // `openTreeNodes` is the single source of truth for which branches are
+  // open. `seedDefaultOpenPermissions` (in `renderApp`) pre-populates it
+  // with `permissions` and each non-empty `permissions.<kind>` on the
+  // first render per project, so the unified tree starts in the same
+  // shape as the old single-pane view; subsequent renders defer to
+  // whatever the user toggled.
+  if (openTreeNodes.has(key)) {
     details.open = true;
     populate();
   }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2,6 +2,7 @@ import { lintRule } from "./lint.ts";
 import type {
   JsonValue,
   LoadedScopes,
+  MoveLeafKind,
   MoveLeafPreview,
   MoveLeafRequest,
   MoveLeafSide,
@@ -530,9 +531,9 @@ let lastRenderedProjectDir: string | null = null;
 // element, and the lifecycle is one short user gesture — same shape as
 // `openTreeNodes` / `lastRenderedProjectDir`.
 //
-// `path` mirrors the Rust `Vec<PathSeg>` wire shape. `dropEffectClass` is
-// purely cosmetic — applied to the destination column's hover style so a
-// permission-rule drop highlights the rule list, not the entire column.
+// `path` mirrors the Rust `Vec<PathSeg>` wire shape; `el` is the source
+// node, kept so the move flow can restore focus to it after a confirm
+// modal dismiss.
 interface DragSource {
   path: PathSeg[];
   from: Scope;
@@ -1065,23 +1066,16 @@ function leafDiffSide(preview: MoveLeafPreview, mode: "add" | "remove"): HTMLEle
     verdict.textContent = "(no change)";
     verdict.classList.add("muted");
   } else if (mode === "remove") {
-    verdict.textContent = preview.kind === "top_level_key" ? "key removed" : "rule removed";
+    verdict.textContent = removeVerdict(preview.kind);
     verdict.classList.add("removed");
   } else {
     // `key_before === undefined` is the absence sentinel (Rust skipped the
     // field). For permission shapes the affected key is `permissions`,
-    // which usually pre-exists with empty arrays, so "merged" is the more
-    // accurate verdict than "added" — only show "added" when the whole
-    // affected top-level key is being created from nothing.
+    // which usually pre-exists, so "merged" is the more accurate verdict
+    // than "added" — only show "added" when the whole affected top-level
+    // key is being created from nothing.
     const created = side.key_before === undefined;
-    verdict.textContent =
-      preview.kind === "top_level_key"
-        ? created
-          ? "key added"
-          : "key merged"
-        : created
-          ? "rules added"
-          : "rule added";
+    verdict.textContent = addVerdict(preview.kind, created);
     verdict.classList.add("added");
   }
   head.appendChild(verdict);
@@ -1113,10 +1107,13 @@ function leafDiffSide(preview: MoveLeafPreview, mode: "add" | "remove"): HTMLEle
 }
 
 /**
- * Chip-list before/after for permission moves. For a single-rule move the
- * affected rule is highlighted (struck-through on remove side, marked
- * added on the dest); for a whole-list move every rule is highlighted on
- * the dest side that wasn't already present.
+ * Chip-list before/after for permission moves. Highlights are driven by the
+ * delta between this side's `key_before` / `key_after`, not by membership
+ * in the source's list — for a `permission_list` move the destination may
+ * already share rules with the source, and those rules are *not* "added"
+ * (the array-union skips them). The remove side highlights rules that
+ * disappear (`before` minus `after`); the add side highlights rules that
+ * appear (`after` minus `before`).
  */
 function permissionListDiff(
   preview: MoveLeafPreview,
@@ -1133,27 +1130,19 @@ function permissionListDiff(
     list.appendChild(li);
     return list;
   }
-  const keyValue = mode === "remove" ? side.key_before : side.key_after;
-  const items = extractPermissionList(keyValue, kind);
-
-  // What's "the moving rule"? For a permission_rule move it's the source's
-  // current value at the leaf path — that's the rule being transferred.
-  // For a permission_list move there's no single rule, so highlight every
-  // rule that's in the source list (those are all moving).
-  const movingRules = movingRuleSet(preview);
+  const itemsBefore = extractPermissionList(side.key_before, kind);
+  const itemsAfter = extractPermissionList(side.key_after, kind);
+  const items = mode === "remove" ? itemsBefore : itemsAfter;
+  const beforeSet = new Set(itemsBefore);
+  const afterSet = new Set(itemsAfter);
 
   for (const rule of items) {
     const li = document.createElement("li");
     const code = document.createElement("code");
     code.textContent = rule;
-    if (movingRules.has(rule)) {
-      if (mode === "remove") {
-        li.className = "diff-removed";
-      } else if (side.will_write) {
-        // will_write=false means everything was already present on the
-        // dest; render neutrally so it doesn't look like a fresh addition.
-        li.className = "diff-added";
-      }
+    const isDelta = mode === "remove" ? !afterSet.has(rule) : !beforeSet.has(rule);
+    if (isDelta) {
+      li.className = mode === "remove" ? "diff-removed" : "diff-added";
     }
     li.appendChild(code);
     list.appendChild(li);
@@ -1167,6 +1156,30 @@ function permissionListDiff(
   return list;
 }
 
+function removeVerdict(kind: MoveLeafKind): string {
+  switch (kind) {
+    case "top_level_key":
+      return "key removed";
+    case "permission_list":
+      return "list removed";
+    case "permission_rule":
+      return "rule removed";
+  }
+}
+
+function addVerdict(kind: MoveLeafKind, created: boolean): string {
+  switch (kind) {
+    case "top_level_key":
+      return created ? "key added" : "key merged";
+    case "permission_list":
+      return created ? "list added" : "list merged";
+    case "permission_rule":
+      // Single-rule destination is always a list-append; the parent
+      // `permissions` map's pre-existence is irrelevant to the verdict.
+      return "rule added";
+  }
+}
+
 function extractPermissionList(
   keyValue: JsonValue | undefined,
   kind: PermissionKind,
@@ -1176,21 +1189,6 @@ function extractPermissionList(
   const arr = (keyValue as { [k: string]: JsonValue })[kind];
   if (!Array.isArray(arr)) return [];
   return arr.filter((v): v is string => typeof v === "string");
-}
-
-function movingRuleSet(preview: MoveLeafPreview): Set<string> {
-  const moving = new Set<string>();
-  if (preview.kind === "permission_rule") {
-    const v = leafValueAtPath(preview.from.key_before, preview.path);
-    if (typeof v === "string") moving.add(v);
-    return moving;
-  }
-  if (preview.kind === "permission_list") {
-    const kind = permissionKindForPath(preview.path);
-    if (!kind) return moving;
-    for (const rule of extractPermissionList(preview.from.key_before, kind)) moving.add(rule);
-  }
-  return moving;
 }
 
 function openConfirmModal(opts: {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -777,15 +777,21 @@ function treeLeaf(
     return row;
   }
 
-  // Permission entries that aren't strings are rare (they only show up in
-  // hand-edited settings.json) but they exist; the backend rejects a move
-  // for them at `merge_at_path`, so suppress the affordances here rather
-  // than offer an action that's guaranteed to fail. The path itself is
-  // still classified as movable by `isMovablePath` — the gate is on the
-  // value's runtime shape, which lives only at this leaf.
-  const isMalformedPermissionEntry =
+  // Permission paths can be malformed in hand-edited settings.json: a
+  // whole list at `permissions.<kind>` (length 2) might be a string or
+  // object instead of an array, and a single rule slot (length 3) might
+  // be a number / null instead of a string. The backend's `merge_at_path`
+  // rejects both of those at the IPC, so suppress the affordances here
+  // rather than offer an action that's guaranteed to fail.
+  //
+  // Reaching `treeLeaf` for a length-2 permissions path implies the value
+  // is non-array (otherwise `treeNode` would have routed to `treeBranch`),
+  // so any length-2 permissions leaf is by construction malformed.
+  const isMalformedPermissionList = permKind !== null && path.length === 2;
+  const isMalformedPermissionRule =
     permKind !== null && path.length === 3 && typeof value !== "string";
-  const offerMoveAffordance = !isMalformedPermissionEntry && isMovablePath(path);
+  const offerMoveAffordance =
+    !isMalformedPermissionList && !isMalformedPermissionRule && isMovablePath(path);
 
   const row = document.createElement("div");
   row.className = "tree-node tree-leaf";
@@ -896,6 +902,11 @@ function treeBranchPeek(
         total++;
         if (matchesLoweredQuery(item, lowerQuery)) matched++;
       }
+      // Fall back to plain `[N]` when there are no string entries to
+      // match — `[0/0]` next to a non-empty array of malformed items
+      // would suggest the branch is empty when expanding it would still
+      // show those entries.
+      if (total === 0) return `[${value.length}]`;
       return `[${matched}/${total}]`;
     }
     return `[${value.length}]`;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2,13 +2,11 @@ import { lintRule } from "./lint.ts";
 import type {
   JsonValue,
   LoadedScopes,
-  MoveKeyPreview,
-  MoveKeyRequest,
-  MoveKeySide,
+  MoveLeafPreview,
+  MoveLeafRequest,
+  MoveLeafSide,
   MoveOptions,
-  MovePreview,
-  MoveRequest,
-  MoveSide,
+  PathSeg,
   PermissionKind,
   Preferences,
   RuntimeInfo,
@@ -27,10 +25,47 @@ interface AppProps {
   runtime: RuntimeInfo;
   onPickProject: () => void;
   onReload: () => void;
-  onMove: (req: MoveRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
-  onMoveKey: (req: MoveKeyRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
+  onMoveLeaf: (req: MoveLeafRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
   onOpenSettings: (trigger?: HTMLElement) => void;
   onQueryChange: (next: string) => void;
+}
+
+const PERMISSION_KINDS: ReadonlyArray<PermissionKind> = ["allow", "deny", "ask"];
+
+/**
+ * Mirror of Rust's `validate_movable_path`: which JSON paths the move-leaf
+ * primitive accepts. Three shapes for v1:
+ *   1. `[<top-level-key>]` (any key except `permissions`)
+ *   2. `["permissions", "allow"|"deny"|"ask"]` — whole rule list
+ *   3. `["permissions", "allow"|"deny"|"ask", <index>]` — single rule
+ * Other intermediate sub-paths (e.g. `env.PATH`) are explicitly out of
+ * scope for issue #67 and a backend rejection would round-trip as a
+ * confusing error toast — better to gate the affordance here.
+ */
+function isMovablePath(path: PathSeg[]): boolean {
+  if (path.length === 1) return path[0] !== "permissions" && typeof path[0] === "string";
+  if (path[0] === "permissions") {
+    if (path.length === 2 && typeof path[1] === "string") {
+      return PERMISSION_KINDS.includes(path[1] as PermissionKind);
+    }
+    if (path.length === 3 && typeof path[1] === "string" && typeof path[2] === "number") {
+      return PERMISSION_KINDS.includes(path[1] as PermissionKind);
+    }
+  }
+  return false;
+}
+
+/**
+ * The kind under `permissions.<kind>...` for paths that target permission
+ * data, or `null` for any other path. Drives the allow/deny/ask styling on
+ * permission tree leaves and the chip-row diff in the confirm modal.
+ */
+function permissionKindForPath(path: PathSeg[]): PermissionKind | null {
+  if (path.length < 2 || path[0] !== "permissions") return null;
+  const kind = path[1];
+  if (typeof kind !== "string") return null;
+  if (PERMISSION_KINDS.includes(kind as PermissionKind)) return kind as PermissionKind;
+  return null;
 }
 
 function matchesLoweredQuery(rule: string, lowerQuery: string): boolean {
@@ -488,15 +523,21 @@ const openTreeNodes = new Set<string>();
 // in a different project that happens to share scope+path strings.
 let lastRenderedProjectDir: string | null = null;
 
-// HTML5 drag-and-drop source state. Set by `dragstart` on a chip or
-// top-level tree key, cleared by `dragend` (or by renderApp on a re-render
-// that tears down the source mid-drag). Lives at module scope because
-// `dragover` on drop targets needs to read the source scope without a
-// closure over the source element, and the lifecycle is one short user
-// gesture — same shape as `openTreeNodes` / `lastRenderedProjectDir`.
-type DragSource =
-  | { kind: "rule"; rule: string; ruleKind: PermissionKind; from: Scope; el: HTMLElement }
-  | { kind: "key"; key: string; from: Scope; el: HTMLElement };
+// HTML5 drag-and-drop source state. Set by `dragstart` on a movable tree
+// node, cleared by `dragend` (or by renderApp on a re-render that tears
+// down the source mid-drag). Lives at module scope because `dragover` on
+// drop targets needs to read the source without a closure over the source
+// element, and the lifecycle is one short user gesture — same shape as
+// `openTreeNodes` / `lastRenderedProjectDir`.
+//
+// `path` mirrors the Rust `Vec<PathSeg>` wire shape. `dropEffectClass` is
+// purely cosmetic — applied to the destination column's hover style so a
+// permission-rule drop highlights the rule list, not the entire column.
+interface DragSource {
+  path: PathSeg[];
+  from: Scope;
+  el: HTMLElement;
+}
 let dragSource: DragSource | null = null;
 
 function clearDragState(): void {
@@ -509,64 +550,55 @@ function clearDragState(): void {
   }
 }
 
-function setupRuleDragSource(
-  el: HTMLElement,
-  rule: string,
-  kind: PermissionKind,
-  scope: Scope,
-): void {
+function setupLeafDragSource(el: HTMLElement, scope: Scope, path: PathSeg[]): void {
   el.draggable = true;
   el.addEventListener("dragstart", (e) => {
-    dragSource = { kind: "rule", rule, ruleKind: kind, from: scope, el };
+    dragSource = { path, from: scope, el };
     if (e.dataTransfer) {
       // Custom MIME type used in dragover to reject foreign drags from other
       // apps or browser tabs before checking dragSource. The payload lives in
       // dragSource; the MIME value is just a discriminator.
-      e.dataTransfer.setData("application/x-claude-scope-move", "rule");
+      e.dataTransfer.setData("application/x-claude-scope-move", "leaf");
       e.dataTransfer.effectAllowed = "move";
     }
   });
   el.addEventListener("dragend", clearDragState);
 }
 
-function setupKeyDragSource(el: HTMLElement, scope: Scope, key: string): void {
-  el.draggable = true;
-  el.addEventListener("dragstart", (e) => {
-    dragSource = { kind: "key", key, from: scope, el };
-    if (e.dataTransfer) {
-      e.dataTransfer.setData("application/x-claude-scope-move", "key");
-      e.dataTransfer.effectAllowed = "move";
-    }
-  });
-  el.addEventListener("dragend", clearDragState);
-}
-
-function treeKey(scope: Scope, path: (string | number)[]): string {
+function treeKey(scope: Scope, path: PathSeg[]): string {
   return `${scope}:${JSON.stringify(path)}`;
 }
 
 function treeNode(
   scope: Scope,
-  path: (string | number)[],
+  path: PathSeg[],
   label: string,
   value: JsonValue,
   props?: AppProps,
+  lowerQuery = "",
 ): HTMLElement {
   if (value !== null && typeof value === "object") {
-    return treeBranch(scope, path, label, value, props);
+    return treeBranch(scope, path, label, value, props, lowerQuery);
   }
-  return treeLeaf(scope, path, label, value, props);
+  return treeLeaf(scope, path, label, value, props, lowerQuery);
 }
 
 function treeBranch(
   scope: Scope,
-  path: (string | number)[],
+  path: PathSeg[],
   label: string,
   value: JsonValue[] | { [key: string]: JsonValue },
   props: AppProps | undefined,
+  lowerQuery = "",
 ): HTMLElement {
   const details = document.createElement("details");
   details.className = "tree-node tree-branch";
+  // Permission lists wear the allow/deny/ask color class on both the branch
+  // summary and the children, so the leaves don't need to redo it
+  // individually. Path-driven so the rule of "permissions.<kind>...
+  // inherits the kind class" lives in one place.
+  const permKind = permissionKindForPath(path);
+  if (permKind) details.classList.add(`tree-perm-${permKind}`);
   const key = treeKey(scope, path);
 
   const summary = document.createElement("summary");
@@ -574,24 +606,20 @@ function treeBranch(
   const name = document.createElement("span");
   name.className = "tree-key";
   name.textContent = label;
-  // Make the key span (not the whole <summary>) the drag source for whole
-  // top-level keys: starting a drag on the inner span lets the browser
-  // suppress the `<details>` toggle that would otherwise fire on click,
-  // and isolates the affordance from nested key labels which never become
-  // drag sources.
-  if (path.length === 1 && props && !props.busy) {
-    setupKeyDragSource(name, scope, String(path[0]));
+  // Make the key span (not the whole <summary>) the drag source for movable
+  // branches: starting a drag on the inner span lets the browser suppress
+  // the `<details>` toggle that would otherwise fire on click, and isolates
+  // the affordance from nested key labels which aren't movable.
+  if (props && !props.busy && isMovablePath(path)) {
+    setupLeafDragSource(name, scope, path);
   }
   summary.appendChild(name);
   const peek = document.createElement("span");
   peek.className = "tree-peek";
   peek.textContent = Array.isArray(value) ? `[${value.length}]` : `{${Object.keys(value).length}}`;
   summary.appendChild(peek);
-  // Move-target buttons only make sense for whole top-level keys; nested
-  // subtree moves aren't in scope for this PR. props is only provided at
-  // the top level, which keeps the guard implicit and cheap.
-  if (path.length === 1 && props) {
-    summary.appendChild(keyMoveButtons(scope, String(path[0]), props));
+  if (props && isMovablePath(path)) {
+    summary.appendChild(leafMoveButtons(scope, path, props));
   }
   details.appendChild(summary);
 
@@ -609,16 +637,27 @@ function treeBranch(
     populated = true;
     if (Array.isArray(value)) {
       value.forEach((child, i) => {
-        children.appendChild(treeNode(scope, [...path, i], `[${i}]`, child));
+        // Permission rule arrays carry their kind via the parent path; child
+        // construction passes `props` and `lowerQuery` through so the leaf
+        // gets its move buttons + drag + lint badge + filter test.
+        children.appendChild(treeNode(scope, [...path, i], `[${i}]`, child, props, lowerQuery));
       });
     } else {
       for (const [k, v] of Object.entries(value)) {
-        children.appendChild(treeNode(scope, [...path, k], k, v));
+        children.appendChild(treeNode(scope, [...path, k], k, v, props, lowerQuery));
       }
     }
   }
 
-  if (openTreeNodes.has(key)) {
+  // Auto-expand permission branches under the unified tree (parent is "permissions")
+  // so the user doesn't need to click into the tree to see allow / deny / ask
+  // — that was the old single-pane visibility before the migration.
+  const isPermissionsChild = path.length === 2 && path[0] === "permissions";
+  const shouldAutoOpen =
+    openTreeNodes.has(key) ||
+    (path.length === 1 && path[0] === "permissions") ||
+    isPermissionsChild;
+  if (shouldAutoOpen) {
     details.open = true;
     populate();
   }
@@ -636,33 +675,70 @@ function treeBranch(
 
 function treeLeaf(
   scope: Scope,
-  path: (string | number)[],
+  path: PathSeg[],
   label: string,
   value: JsonValue,
   props?: AppProps,
+  lowerQuery = "",
 ): HTMLElement {
+  const permKind = permissionKindForPath(path);
+  const isPermissionRule = permKind !== null && path.length === 3 && typeof value === "string";
+
+  // Permission rule leaves under `permissions.<kind>` get the rule-chip
+  // styling, lint badge, origin tooltip, drag handle, and per-target move
+  // buttons that the old `ruleRow` used to render. Filter the row out
+  // entirely when the search query is active and doesn't match — keeps the
+  // "(m/n)" hint on the parent branch summary truthful.
+  if (isPermissionRule && permKind) {
+    const rule = value as string;
+    if (lowerQuery !== "" && !matchesLoweredQuery(rule, lowerQuery)) {
+      const skip = document.createElement("span");
+      skip.hidden = true;
+      return skip;
+    }
+    const row = document.createElement("div");
+    row.className = `tree-node tree-leaf rule rule-${permKind}`;
+    const code = document.createElement("code");
+    code.className = "rule-text";
+    code.textContent = rule;
+    if (props && !props.busy) {
+      setupLeafDragSource(code, scope, path);
+    }
+    // Per-scope rule rows share the same tooltip helper as the combined
+    // panel for consistency (issue #82). Origins is just `[scope]` here
+    // since the rule lives in exactly this scope's file.
+    row.appendChild(wrapWithOriginTooltip(code, [scope]));
+    const badge = lintBadge(rule);
+    if (badge) row.appendChild(badge);
+    if (props) {
+      row.appendChild(leafMoveButtons(scope, path, props));
+    }
+    return row;
+  }
+
   const row = document.createElement("div");
   row.className = "tree-node tree-leaf";
   const name = document.createElement("span");
   name.className = "tree-key";
   name.textContent = label;
-  if (path.length === 1 && props && !props.busy) {
-    setupKeyDragSource(name, scope, String(path[0]));
+  if (props && !props.busy && isMovablePath(path)) {
+    setupLeafDragSource(name, scope, path);
   }
   row.appendChild(name);
   const val = document.createElement("span");
   val.className = `tree-value tree-value-${leafType(value)}`;
   val.textContent = formatLeaf(value);
   row.appendChild(val);
-  if (path.length === 1 && props) {
-    row.appendChild(keyMoveButtons(scope, String(path[0]), props));
+  if (props && isMovablePath(path)) {
+    row.appendChild(leafMoveButtons(scope, path, props));
   }
   return row;
 }
 
-function keyMoveButtons(scope: Scope, key: string, props: AppProps): HTMLElement {
+function leafMoveButtons(scope: Scope, path: PathSeg[], props: AppProps): HTMLElement {
   const moveBtns = document.createElement("div");
   moveBtns.className = "rule-moves tree-key-moves";
+  const describe = describePath(path);
   for (const target of SCOPES) {
     if (target === scope) continue;
     // Mirror scopeGrid: don't offer moves into columns the user hid — the
@@ -674,7 +750,7 @@ function keyMoveButtons(scope: Scope, key: string, props: AppProps): HTMLElement
     btn.textContent = `→ ${SCOPE_LABELS[target]}`;
     btn.setAttribute(
       "aria-label",
-      `Move settings key ${key} from ${SCOPE_LABELS[scope]} to ${SCOPE_LABELS[target]}`,
+      `Move ${describe} from ${SCOPE_LABELS[scope]} to ${SCOPE_LABELS[target]}`,
     );
     btn.disabled = props.busy;
     btn.addEventListener("click", (e) => {
@@ -682,11 +758,28 @@ function keyMoveButtons(scope: Scope, key: string, props: AppProps): HTMLElement
       // the move action is a distinct intent, so swallow propagation.
       e.preventDefault();
       e.stopPropagation();
-      props.onMoveKey({ key, from: scope, to: target }, e.currentTarget as HTMLElement);
+      props.onMoveLeaf({ path, from: scope, to: target }, e.currentTarget as HTMLElement);
     });
     moveBtns.appendChild(btn);
   }
   return moveBtns;
+}
+
+/**
+ * Render a path slice as a human-readable label for ARIA + error messages.
+ * Mirrors Rust's `describe_path`: `permissions.allow[2]` for a rule, `env`
+ * for a top-level key, `permissions.allow` for a whole rule list.
+ */
+function describePath(path: PathSeg[]): string {
+  let out = "";
+  for (const seg of path) {
+    if (typeof seg === "number") {
+      out += `[${seg}]`;
+    } else {
+      out += out === "" ? seg : `.${seg}`;
+    }
+  }
+  return out || "(root)";
 }
 
 function leafType(value: JsonValue): string {
@@ -766,15 +859,7 @@ function scopeColumn(view: ScopeView, props: AppProps, lowerQuery: string): HTML
     // per-destination `.bak` is the recovery path until an audit log /
     // undo lands (#19).
     const opts: MoveOptions = { skipConfirm: true };
-    if (src.kind === "rule") {
-      props.onMove(
-        { rule: src.rule, kind: src.ruleKind, from: src.from, to: view.scope },
-        trigger,
-        opts,
-      );
-    } else {
-      props.onMoveKey({ key: src.key, from: src.from, to: view.scope }, trigger, opts);
-    }
+    props.onMoveLeaf({ path: src.path, from: src.from, to: view.scope }, trigger, opts);
   });
 
   const head = document.createElement("div");
@@ -797,114 +882,75 @@ function scopeColumn(view: ScopeView, props: AppProps, lowerQuery: string): HTML
     status.textContent = "(file not present)";
     status.classList.add("muted");
   } else {
-    const totals =
-      view.permissions.allow.length + view.permissions.deny.length + view.permissions.ask.length;
+    const totals = countPermissionRules(view.values);
     status.textContent = `${totals} permission rule${totals === 1 ? "" : "s"}`;
   }
   head.appendChild(status);
   col.appendChild(head);
 
-  const kinds: PermissionKind[] = ["allow", "deny", "ask"];
-  const isFiltering = lowerQuery !== "";
-  // Compute all the groups up front so we can decide between the per-kind
-  // view and the column-level "no matches" placeholder without re-filtering.
-  const groups = kinds.map((kind) => {
-    const rules = view.permissions[kind];
-    const matched = isFiltering ? rules.filter((r) => matchesLoweredQuery(r, lowerQuery)) : rules;
-    return { kind, rules, matched };
-  });
-  const totalAll = groups.reduce((s, g) => s + g.rules.length, 0);
-  const totalMatched = groups.reduce((s, g) => s + g.matched.length, 0);
-
-  if (isFiltering && totalAll > 0 && totalMatched === 0) {
-    // Nothing matched anywhere in this scope — replace the group headers with
-    // a single column-level placeholder so the user doesn't see three empty
-    // "(0/N)" headers stacked on top of each other.
-    const none = document.createElement("div");
-    none.className = "col-no-matches";
-    none.textContent = `No rules match “${props.query}”.`;
-    col.appendChild(none);
-  } else {
-    for (const { kind, rules, matched } of groups) {
-      // Skip empty kinds outright. When filtering, kinds that exist but
-      // have 0 matches still render a header so the m/n count makes the
-      // hidden rules visible to the user.
-      if (rules.length === 0) continue;
-      const section = document.createElement("div");
-      section.className = `rule-group rule-${kind}`;
-      const label = document.createElement("h4");
-      label.textContent = isFiltering
-        ? `${KIND_LABELS[kind]} (${matched.length}/${rules.length})`
-        : `${KIND_LABELS[kind]} (${rules.length})`;
-      section.appendChild(label);
-      for (const rule of matched) {
-        section.appendChild(ruleRow(view.scope, kind, rule, props));
-      }
-      col.appendChild(section);
+  // Render every top-level key — `permissions` included — through the
+  // shared tree walker. Permissions render with leaf-level move buttons
+  // and allow/deny/ask styling thanks to `permissionKindForPath` /
+  // `treeLeaf`'s rule-leaf branch; other keys keep today's whole-key move
+  // behavior.
+  const keys = Object.keys(view.values);
+  if (keys.length === 0) {
+    if (view.exists && !view.parse_error) {
+      const empty = document.createElement("div");
+      empty.className = "col-empty";
+      empty.textContent = "(empty)";
+      col.appendChild(empty);
     }
+    return col;
   }
 
-  const otherKeys = Object.keys(view.other_values);
-  if (otherKeys.length > 0) {
-    const tree = document.createElement("div");
-    tree.className = "other-tree";
-    const heading = document.createElement("h4");
-    heading.className = "other-tree-heading";
-    heading.textContent = "Other settings";
-    tree.appendChild(heading);
-    for (const key of otherKeys) {
-      tree.appendChild(treeNode(view.scope, [key], key, view.other_values[key], props));
+  const tree = document.createElement("div");
+  tree.className = "scope-tree";
+  for (const key of keys) {
+    tree.appendChild(treeNode(view.scope, [key], key, view.values[key], props, lowerQuery));
+  }
+  col.appendChild(tree);
+
+  // Filter feedback. The tree leaves filter themselves silently when the
+  // query doesn't match a rule string; surface a column-level placeholder
+  // when a permissions block exists but every rule was filtered out, so
+  // empty-looking columns aren't mysterious.
+  if (lowerQuery !== "") {
+    const totalRules = countPermissionRules(view.values);
+    if (totalRules > 0 && countMatchingRules(view.values, lowerQuery) === 0) {
+      const none = document.createElement("div");
+      none.className = "col-no-matches";
+      none.textContent = `No rules match “${props.query}”.`;
+      col.appendChild(none);
     }
-    col.appendChild(tree);
   }
 
   return col;
 }
 
-function ruleRow(scope: Scope, kind: PermissionKind, rule: string, props: AppProps): HTMLElement {
-  const row = document.createElement("div");
-  row.className = "rule";
-
-  const code = document.createElement("code");
-  code.className = "rule-text";
-  code.textContent = rule;
-  // Drag affordance lives on the chip itself, not the row, so the move
-  // buttons stay clickable and the row keeps its hover semantics intact.
-  // Disabled while a write is in flight, mirroring how `move-btn` is
-  // gated on `props.busy` further down.
-  if (!props.busy) {
-    setupRuleDragSource(code, rule, kind, scope);
+function countPermissionRules(values: { [key: string]: JsonValue }): number {
+  const perms = values.permissions;
+  if (!perms || typeof perms !== "object" || Array.isArray(perms)) return 0;
+  let total = 0;
+  for (const kind of PERMISSION_KINDS) {
+    const list = (perms as { [k: string]: JsonValue })[kind];
+    if (Array.isArray(list)) total += list.length;
   }
-  // Per-scope rule rows share the same tooltip helper as the combined
-  // panel for consistency (issue #82). Origins is just `[scope]` here
-  // since the rule lives in exactly this scope's file.
-  row.appendChild(wrapWithOriginTooltip(code, [scope]));
+  return total;
+}
 
-  const badge = lintBadge(rule);
-  if (badge) row.appendChild(badge);
-
-  const moveBtns = document.createElement("div");
-  moveBtns.className = "rule-moves";
-  for (const target of SCOPES) {
-    if (target === scope) continue;
-    // Same reasoning as `keyMoveButtons`: hidden columns can't be move
-    // targets, since the result would be immediately invisible.
-    if (!isScopeVisible(target)) continue;
-    const btn = document.createElement("button");
-    btn.className = "move-btn";
-    btn.textContent = `→ ${SCOPE_LABELS[target]}`;
-    btn.setAttribute(
-      "aria-label",
-      `Move ${KIND_LABELS[kind]} rule ${rule} from ${SCOPE_LABELS[scope]} to ${SCOPE_LABELS[target]}`,
-    );
-    btn.disabled = props.busy;
-    btn.onclick = (e) =>
-      props.onMove({ rule, kind, from: scope, to: target }, e.currentTarget as HTMLElement);
-    moveBtns.appendChild(btn);
+function countMatchingRules(values: { [key: string]: JsonValue }, lowerQuery: string): number {
+  const perms = values.permissions;
+  if (!perms || typeof perms !== "object" || Array.isArray(perms)) return 0;
+  let matched = 0;
+  for (const kind of PERMISSION_KINDS) {
+    const list = (perms as { [k: string]: JsonValue })[kind];
+    if (!Array.isArray(list)) continue;
+    for (const item of list) {
+      if (typeof item === "string" && matchesLoweredQuery(item, lowerQuery)) matched++;
+    }
   }
-  row.appendChild(moveBtns);
-
-  return row;
+  return matched;
 }
 
 /**
@@ -920,12 +966,15 @@ function ruleRow(scope: Scope, kind: PermissionKind, rule: string, props: AppPro
  * If `trigger` is passed and still live in the DOM when the dialog closes,
  * focus is returned to it.
  */
-export function confirmMove(preview: MovePreview, trigger?: HTMLElement | null): Promise<boolean> {
+export function confirmMoveLeaf(
+  preview: MoveLeafPreview,
+  trigger?: HTMLElement | null,
+): Promise<boolean> {
   const subtitle = document.createDocumentFragment();
-  const ruleCode = document.createElement("code");
-  ruleCode.className = "chip";
-  ruleCode.textContent = preview.rule;
-  subtitle.appendChild(ruleCode);
+  const target = document.createElement("code");
+  target.className = "chip";
+  target.textContent = leafSubtitleLabel(preview);
+  subtitle.appendChild(target);
   subtitle.appendChild(
     document.createTextNode(
       ` from ${SCOPE_LABELS[preview.from.scope]} to ${SCOPE_LABELS[preview.to.scope]}`,
@@ -934,43 +983,214 @@ export function confirmMove(preview: MovePreview, trigger?: HTMLElement | null):
 
   const diff = document.createElement("div");
   diff.className = "modal-diff";
-  diff.appendChild(diffSide(preview.from, "remove", preview.rule));
-  diff.appendChild(diffSide(preview.to, "add", preview.rule));
+  diff.appendChild(leafDiffSide(preview, "remove"));
+  diff.appendChild(leafDiffSide(preview, "add"));
 
   return openConfirmModal({
-    titleText: `Move ${KIND_LABELS[preview.kind]} rule`,
+    titleText: leafModalTitle(preview),
     subtitle,
     body: diff,
     trigger,
   });
 }
 
-export function confirmMoveKey(
-  preview: MoveKeyPreview,
-  trigger?: HTMLElement | null,
-): Promise<boolean> {
-  const subtitle = document.createDocumentFragment();
-  const keyCode = document.createElement("code");
-  keyCode.className = "chip";
-  keyCode.textContent = preview.key;
-  subtitle.appendChild(keyCode);
-  subtitle.appendChild(
-    document.createTextNode(
-      ` from ${SCOPE_LABELS[preview.from.scope]} to ${SCOPE_LABELS[preview.to.scope]}`,
-    ),
-  );
+function leafModalTitle(preview: MoveLeafPreview): string {
+  switch (preview.kind) {
+    case "permission_rule": {
+      const kind = permissionKindForPath(preview.path);
+      return `Move ${kind ? KIND_LABELS[kind] : ""} rule`.trim();
+    }
+    case "permission_list": {
+      const kind = permissionKindForPath(preview.path);
+      return `Move ${kind ? KIND_LABELS[kind] : ""} rule list`.trim();
+    }
+    case "top_level_key":
+      return "Move settings key";
+  }
+}
 
-  const diff = document.createElement("div");
-  diff.className = "modal-diff";
-  diff.appendChild(keyDiffSide(preview.from, "remove"));
-  diff.appendChild(keyDiffSide(preview.to, "add"));
+function leafSubtitleLabel(preview: MoveLeafPreview): string {
+  // For a single rule the subtitle chip carries the rule string itself; for
+  // a list or top-level key it's the path so the user reads "Move env from
+  // ..." or "Move permissions.allow from ...".
+  if (preview.kind === "permission_rule") {
+    const rule = leafValueAtPath(preview.from.key_before, preview.path);
+    if (typeof rule === "string") return rule;
+  }
+  return describePath(preview.path);
+}
 
-  return openConfirmModal({
-    titleText: "Move settings key",
-    subtitle,
-    body: diff,
-    trigger,
-  });
+/**
+ * Drill into a `key_before` / `key_after` value using the leaf path
+ * (segments after the affected top-level key). Returns the leaf value or
+ * `undefined` if any segment misses — same skip-on-absent contract as the
+ * IPC.
+ */
+function leafValueAtPath(keyValue: JsonValue | undefined, path: PathSeg[]): JsonValue | undefined {
+  if (keyValue === undefined) return undefined;
+  let cur: JsonValue | undefined = keyValue;
+  for (let i = 1; i < path.length; i++) {
+    const seg = path[i];
+    if (cur === null || cur === undefined) return undefined;
+    if (typeof seg === "number") {
+      if (!Array.isArray(cur)) return undefined;
+      cur = cur[seg];
+    } else {
+      if (typeof cur !== "object" || Array.isArray(cur)) return undefined;
+      cur = (cur as { [k: string]: JsonValue })[seg];
+    }
+  }
+  return cur;
+}
+
+function leafDiffSide(preview: MoveLeafPreview, mode: "add" | "remove"): HTMLElement {
+  const side = mode === "remove" ? preview.from : preview.to;
+  const col = document.createElement("div");
+  col.className = `modal-side modal-side-${mode}`;
+
+  const head = document.createElement("div");
+  head.className = "modal-side-head";
+  const label = document.createElement("h3");
+  label.textContent = SCOPE_LABELS[side.scope];
+  head.appendChild(label);
+
+  const filePath = document.createElement("div");
+  filePath.className = "modal-side-path";
+  filePath.textContent = side.file_path;
+  head.appendChild(filePath);
+
+  const verdict = document.createElement("div");
+  verdict.className = "modal-side-verdict";
+  if (!side.will_write) {
+    verdict.textContent = "(no change)";
+    verdict.classList.add("muted");
+  } else if (mode === "remove") {
+    verdict.textContent = preview.kind === "top_level_key" ? "key removed" : "rule removed";
+    verdict.classList.add("removed");
+  } else {
+    // `key_before === undefined` is the absence sentinel (Rust skipped the
+    // field). For permission shapes the affected key is `permissions`,
+    // which usually pre-exists with empty arrays, so "merged" is the more
+    // accurate verdict than "added" — only show "added" when the whole
+    // affected top-level key is being created from nothing.
+    const created = side.key_before === undefined;
+    verdict.textContent =
+      preview.kind === "top_level_key"
+        ? created
+          ? "key added"
+          : "key merged"
+        : created
+          ? "rules added"
+          : "rule added";
+    verdict.classList.add("added");
+  }
+  head.appendChild(verdict);
+  col.appendChild(head);
+
+  if (side.note) {
+    const note = document.createElement("div");
+    note.className = "modal-side-note";
+    note.textContent = side.note;
+    col.appendChild(note);
+  }
+
+  // Body: chip-list rendering for permission shapes (preserves today's
+  // confirmMove readability), JSON dump for top-level key moves
+  // (preserves today's confirmMoveKey shape).
+  const body = document.createElement("div");
+  body.className = "modal-side-value";
+  if (preview.kind === "top_level_key") {
+    const pre = document.createElement("pre");
+    pre.className = "modal-side-json";
+    pre.textContent = formatValue(mode === "remove" ? side.key_before : side.key_after);
+    body.appendChild(pre);
+  } else {
+    body.appendChild(permissionListDiff(preview, side, mode));
+  }
+  col.appendChild(body);
+
+  return col;
+}
+
+/**
+ * Chip-list before/after for permission moves. For a single-rule move the
+ * affected rule is highlighted (struck-through on remove side, marked
+ * added on the dest); for a whole-list move every rule is highlighted on
+ * the dest side that wasn't already present.
+ */
+function permissionListDiff(
+  preview: MoveLeafPreview,
+  side: MoveLeafSide,
+  mode: "add" | "remove",
+): HTMLElement {
+  const list = document.createElement("ul");
+  list.className = "modal-diff-list";
+  const kind = permissionKindForPath(preview.path);
+  if (!kind) {
+    const li = document.createElement("li");
+    li.className = "diff-empty";
+    li.textContent = "(unknown permission shape)";
+    list.appendChild(li);
+    return list;
+  }
+  const keyValue = mode === "remove" ? side.key_before : side.key_after;
+  const items = extractPermissionList(keyValue, kind);
+
+  // What's "the moving rule"? For a permission_rule move it's the source's
+  // current value at the leaf path — that's the rule being transferred.
+  // For a permission_list move there's no single rule, so highlight every
+  // rule that's in the source list (those are all moving).
+  const movingRules = movingRuleSet(preview);
+
+  for (const rule of items) {
+    const li = document.createElement("li");
+    const code = document.createElement("code");
+    code.textContent = rule;
+    if (movingRules.has(rule)) {
+      if (mode === "remove") {
+        li.className = "diff-removed";
+      } else if (side.will_write) {
+        // will_write=false means everything was already present on the
+        // dest; render neutrally so it doesn't look like a fresh addition.
+        li.className = "diff-added";
+      }
+    }
+    li.appendChild(code);
+    list.appendChild(li);
+  }
+  if (list.children.length === 0) {
+    const li = document.createElement("li");
+    li.className = "diff-empty";
+    li.textContent = "(empty)";
+    list.appendChild(li);
+  }
+  return list;
+}
+
+function extractPermissionList(
+  keyValue: JsonValue | undefined,
+  kind: PermissionKind,
+): readonly string[] {
+  if (keyValue === undefined || keyValue === null) return [];
+  if (typeof keyValue !== "object" || Array.isArray(keyValue)) return [];
+  const arr = (keyValue as { [k: string]: JsonValue })[kind];
+  if (!Array.isArray(arr)) return [];
+  return arr.filter((v): v is string => typeof v === "string");
+}
+
+function movingRuleSet(preview: MoveLeafPreview): Set<string> {
+  const moving = new Set<string>();
+  if (preview.kind === "permission_rule") {
+    const v = leafValueAtPath(preview.from.key_before, preview.path);
+    if (typeof v === "string") moving.add(v);
+    return moving;
+  }
+  if (preview.kind === "permission_list") {
+    const kind = permissionKindForPath(preview.path);
+    if (!kind) return moving;
+    for (const rule of extractPermissionList(preview.from.key_before, kind)) moving.add(rule);
+  }
+  return moving;
 }
 
 function openConfirmModal(opts: {
@@ -1032,7 +1252,7 @@ function openConfirmModal(opts: {
  * Escape / backdrop-click / Enter behavior, and focus restoration — so
  * callers only supply the body and the action buttons they need.
  *
- * The goal is to keep `confirmMove` / `confirmMoveKey` / `openSettings`
+ * The goal is to keep `confirmMoveLeaf` / `openSettings`
  * from drifting on accessibility details over time. Each caller passes
  * its own activation callbacks that receive a `close` function; the
  * helper never closes on its own except when the caller asks it to.
@@ -1168,57 +1388,6 @@ function openModal(opts: {
   document.body.appendChild(backdrop);
   const initial = actionButtons.find((_, i) => opts.actions[i].focus) ?? actionButtons[0];
   initial?.focus();
-}
-
-function keyDiffSide(side: MoveKeySide, mode: "add" | "remove"): HTMLElement {
-  const col = document.createElement("div");
-  col.className = `modal-side modal-side-${mode}`;
-
-  const head = document.createElement("div");
-  head.className = "modal-side-head";
-  const label = document.createElement("h3");
-  label.textContent = SCOPE_LABELS[side.scope];
-  head.appendChild(label);
-
-  const path = document.createElement("div");
-  path.className = "modal-side-path";
-  path.textContent = side.path;
-  head.appendChild(path);
-
-  const verdict = document.createElement("div");
-  verdict.className = "modal-side-verdict";
-  if (!side.will_write) {
-    verdict.textContent = "(no change)";
-    verdict.classList.add("muted");
-  } else if (mode === "remove") {
-    verdict.textContent = "key removed";
-    verdict.classList.add("removed");
-  } else {
-    // `undefined` means the backend skipped the field because the key was
-    // absent; a present-but-null value arrives as `null` and counts as a
-    // real existing value to merge against.
-    verdict.textContent = side.value_before === undefined ? "key added" : "key merged";
-    verdict.classList.add("added");
-  }
-  head.appendChild(verdict);
-  col.appendChild(head);
-
-  if (side.note) {
-    const note = document.createElement("div");
-    note.className = "modal-side-note";
-    note.textContent = side.note;
-    col.appendChild(note);
-  }
-
-  const body = document.createElement("div");
-  body.className = "modal-side-value";
-  const pre = document.createElement("pre");
-  pre.className = "modal-side-json";
-  pre.textContent = formatValue(mode === "remove" ? side.value_before : side.value_after);
-  body.appendChild(pre);
-  col.appendChild(body);
-
-  return col;
 }
 
 function formatValue(v: JsonValue | undefined): string {
@@ -1364,80 +1533,4 @@ function settingsColumnsSection(props: SettingsProps): HTMLElement {
   }
   section.appendChild(list);
   return section;
-}
-
-function diffSide(side: MoveSide, mode: "add" | "remove", movingRule: string): HTMLElement {
-  const col = document.createElement("div");
-  col.className = `modal-side modal-side-${mode}`;
-
-  const head = document.createElement("div");
-  head.className = "modal-side-head";
-  const label = document.createElement("h3");
-  label.textContent = SCOPE_LABELS[side.scope];
-  head.appendChild(label);
-
-  const path = document.createElement("div");
-  path.className = "modal-side-path";
-  path.textContent = side.path;
-  head.appendChild(path);
-
-  // Derive the verdict from the actual list lengths so duplicates (the
-  // backend removes *every* occurrence) and any future changes to the move
-  // semantics stay in sync with what the modal claims will happen.
-  const delta = side.rules_after.length - side.rules_before.length;
-  const verdict = document.createElement("div");
-  verdict.className = "modal-side-verdict";
-  if (delta === 0) {
-    verdict.textContent = "(no change)";
-    verdict.classList.add("muted");
-  } else if (delta > 0) {
-    verdict.textContent = `+${delta} rule${delta === 1 ? "" : "s"}`;
-    verdict.classList.add("added");
-  } else {
-    const n = -delta;
-    verdict.textContent = `−${n} rule${n === 1 ? "" : "s"}`;
-    verdict.classList.add("removed");
-  }
-  head.appendChild(verdict);
-  col.appendChild(head);
-
-  if (side.note) {
-    const note = document.createElement("div");
-    note.className = "modal-side-note";
-    note.textContent = side.note;
-    col.appendChild(note);
-  }
-
-  // Remove side shows the pre-move list with the moved rule struck through
-  // (diff context, not the post-write contents — apply_move will actually
-  // persist rules_after there). Add side shows the backend's rules_after so
-  // the dest column mirrors exactly what will be written.
-  const rules = mode === "remove" ? side.rules_before : side.rules_after;
-  const list = document.createElement("ul");
-  list.className = "modal-diff-list";
-  for (const rule of rules) {
-    const li = document.createElement("li");
-    const code = document.createElement("code");
-    code.textContent = rule;
-    if (rule === movingRule) {
-      if (mode === "remove") {
-        li.className = "diff-removed";
-      } else if (side.will_write) {
-        // will_write=false means the rule was already present on the dest;
-        // render it neutrally so it doesn't look like a fresh addition.
-        li.className = "diff-added";
-      }
-    }
-    li.appendChild(code);
-    list.appendChild(li);
-  }
-  if (list.children.length === 0) {
-    const li = document.createElement("li");
-    li.className = "diff-empty";
-    li.textContent = "(empty)";
-    list.appendChild(li);
-  }
-  col.appendChild(list);
-
-  return col;
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -49,7 +49,18 @@ function isMovablePath(path: PathSeg[]): boolean {
     if (path.length === 2 && typeof path[1] === "string") {
       return PERMISSION_KINDS.includes(path[1] as PermissionKind);
     }
-    if (path.length === 3 && typeof path[1] === "string" && typeof path[2] === "number") {
+    if (
+      path.length === 3 &&
+      typeof path[1] === "string" &&
+      // Constrain to non-negative integers — the Rust side deserializes
+      // path indices into `usize`, so floats / negatives would be rejected
+      // at the IPC boundary. Today every index we generate comes from
+      // tree-walking so it's already a non-negative integer; this guard
+      // keeps it that way under future refactors.
+      typeof path[2] === "number" &&
+      Number.isInteger(path[2]) &&
+      path[2] >= 0
+    ) {
       return PERMISSION_KINDS.includes(path[1] as PermissionKind);
     }
   }
@@ -713,17 +724,30 @@ function treeLeaf(
     const badge = lintBadge(rule);
     if (badge) row.appendChild(badge);
     if (props) {
-      row.appendChild(leafMoveButtons(scope, path, props));
+      // Pass the rule string as the move-button label so the screen
+      // reader announces "Move Bash(git status) from …" instead of
+      // the meaningless path "permissions.allow[0]".
+      row.appendChild(leafMoveButtons(scope, path, props, rule));
     }
     return row;
   }
+
+  // Permission entries that aren't strings are rare (they only show up in
+  // hand-edited settings.json) but they exist; the backend rejects a move
+  // for them at `merge_at_path`, so suppress the affordances here rather
+  // than offer an action that's guaranteed to fail. The path itself is
+  // still classified as movable by `isMovablePath` — the gate is on the
+  // value's runtime shape, which lives only at this leaf.
+  const isMalformedPermissionEntry =
+    permKind !== null && path.length === 3 && typeof value !== "string";
+  const offerMoveAffordance = !isMalformedPermissionEntry && isMovablePath(path);
 
   const row = document.createElement("div");
   row.className = "tree-node tree-leaf";
   const name = document.createElement("span");
   name.className = "tree-key";
   name.textContent = label;
-  if (props && !props.busy && isMovablePath(path)) {
+  if (props && !props.busy && offerMoveAffordance) {
     setupLeafDragSource(name, scope, path);
   }
   row.appendChild(name);
@@ -731,16 +755,25 @@ function treeLeaf(
   val.className = `tree-value tree-value-${leafType(value)}`;
   val.textContent = formatLeaf(value);
   row.appendChild(val);
-  if (props && isMovablePath(path)) {
+  if (props && offerMoveAffordance) {
     row.appendChild(leafMoveButtons(scope, path, props));
   }
   return row;
 }
 
-function leafMoveButtons(scope: Scope, path: PathSeg[], props: AppProps): HTMLElement {
+function leafMoveButtons(
+  scope: Scope,
+  path: PathSeg[],
+  props: AppProps,
+  // Optional override for the screen-reader label. Permission rule rows
+  // pass the rule string so the button announces something meaningful;
+  // top-level key and rule-list rows fall back to the path's
+  // dotted-bracket form, which is informative at that level.
+  ariaSubject?: string,
+): HTMLElement {
   const moveBtns = document.createElement("div");
   moveBtns.className = "rule-moves tree-key-moves";
-  const describe = describePath(path);
+  const subject = ariaSubject ?? describePath(path);
   for (const target of SCOPES) {
     if (target === scope) continue;
     // Mirror scopeGrid: don't offer moves into columns the user hid — the
@@ -752,7 +785,7 @@ function leafMoveButtons(scope: Scope, path: PathSeg[], props: AppProps): HTMLEl
     btn.textContent = `→ ${SCOPE_LABELS[target]}`;
     btn.setAttribute(
       "aria-label",
-      `Move ${describe} from ${SCOPE_LABELS[scope]} to ${SCOPE_LABELS[target]}`,
+      `Move ${subject} from ${SCOPE_LABELS[scope]} to ${SCOPE_LABELS[target]}`,
     );
     btn.disabled = props.busy;
     btn.addEventListener("click", (e) => {
@@ -1148,12 +1181,14 @@ function leafDiffSide(preview: MoveLeafPreview, mode: "add" | "remove"): HTMLEle
 
 /**
  * Chip-list before/after for permission moves. Highlights are driven by the
- * delta between this side's `key_before` / `key_after`, not by membership
- * in the source's list — for a `permission_list` move the destination may
- * already share rules with the source, and those rules are *not* "added"
- * (the array-union skips them). The remove side highlights rules that
- * disappear (`before` minus `after`); the add side highlights rules that
- * appear (`after` minus `before`).
+ * multiset delta between this side's `key_before` / `key_after`, not by
+ * set membership — for a `permission_list` move the destination may
+ * already share rules with the source (those are *not* "added"; array-
+ * union dedupes), and a hand-edited file with the same rule listed twice
+ * may have one copy removed (set membership would miss that, since the
+ * value still appears). Walk `before` (or `after`) and consume entries
+ * from the delta bag in iteration order so the highlight maps onto the
+ * actual entries that change.
  */
 function permissionListDiff(
   preview: MoveLeafPreview,
@@ -1173,16 +1208,26 @@ function permissionListDiff(
   const itemsBefore = extractPermissionList(side.key_before, kind);
   const itemsAfter = extractPermissionList(side.key_after, kind);
   const items = mode === "remove" ? itemsBefore : itemsAfter;
-  const beforeSet = new Set(itemsBefore);
-  const afterSet = new Set(itemsAfter);
+  // Multiset subtraction: B \ A retains duplicates correctly. Computed
+  // once outside the loop, then drained by the per-item walk so each
+  // highlighted chip corresponds to exactly one delta entry.
+  const deltaBag =
+    mode === "remove"
+      ? multisetSubtract(itemsBefore, itemsAfter)
+      : multisetSubtract(itemsAfter, itemsBefore);
 
   for (const rule of items) {
     const li = document.createElement("li");
     const code = document.createElement("code");
     code.textContent = rule;
-    const isDelta = mode === "remove" ? !afterSet.has(rule) : !beforeSet.has(rule);
-    if (isDelta) {
+    const remaining = deltaBag.get(rule) ?? 0;
+    if (remaining > 0) {
       li.className = mode === "remove" ? "diff-removed" : "diff-added";
+      if (remaining === 1) {
+        deltaBag.delete(rule);
+      } else {
+        deltaBag.set(rule, remaining - 1);
+      }
     }
     li.appendChild(code);
     list.appendChild(li);
@@ -1194,6 +1239,24 @@ function permissionListDiff(
     list.appendChild(li);
   }
   return list;
+}
+
+/**
+ * Multiset subtraction `a - b`: returns a `Map<string, number>` whose
+ * entries are the per-string surplus counts in `a` that aren't covered
+ * by `b`. Used by `permissionListDiff` so duplicate rule strings get
+ * counted, not collapsed by set semantics.
+ */
+function multisetSubtract(a: readonly string[], b: readonly string[]): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const x of a) out.set(x, (out.get(x) ?? 0) + 1);
+  for (const x of b) {
+    const c = out.get(x);
+    if (c === undefined) continue;
+    if (c <= 1) out.delete(x);
+    else out.set(x, c - 1);
+  }
+  return out;
 }
 
 function removeVerdict(kind: MoveLeafKind): string {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -571,7 +571,11 @@ function seedDefaultOpenPermissions(loaded: LoadedScopes): void {
     openTreeNodes.add(treeKey(view.scope, ["permissions"]));
     const permsObj = perms as { [k: string]: JsonValue };
     for (const kind of PERMISSION_KINDS) {
-      if (Array.isArray(permsObj[kind])) {
+      const arr = permsObj[kind];
+      // Skip empty arrays — opening a branch that has nothing under it
+      // is just visual noise on a fresh project load. The user can still
+      // open it manually if they want to add rules.
+      if (Array.isArray(arr) && arr.length > 0) {
         openTreeNodes.add(treeKey(view.scope, ["permissions", kind]));
       }
     }
@@ -879,11 +883,20 @@ function treeBranchPeek(
       typeof path[1] === "string" &&
       PERMISSION_KINDS.includes(path[1] as PermissionKind)
     ) {
+      // Both the numerator and denominator count only string entries —
+      // matches `countPermissionRules` / `countMatchingRules` /
+      // `extractPermissionList`, which all treat non-string array items
+      // (possible in hand-edited JSON) as non-rules. Mixing the two
+      // would surface an `m/N` where N over-counts items that the rest
+      // of the UI hides.
+      let total = 0;
       let matched = 0;
       for (const item of value) {
-        if (typeof item === "string" && matchesLoweredQuery(item, lowerQuery)) matched++;
+        if (typeof item !== "string") continue;
+        total++;
+        if (matchesLoweredQuery(item, lowerQuery)) matched++;
       }
-      return `[${matched}/${value.length}]`;
+      return `[${matched}/${total}]`;
     }
     return `[${value.length}]`;
   }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -617,7 +617,7 @@ function treeBranch(
   summary.appendChild(name);
   const peek = document.createElement("span");
   peek.className = "tree-peek";
-  peek.textContent = Array.isArray(value) ? `[${value.length}]` : `{${Object.keys(value).length}}`;
+  peek.textContent = treeBranchPeek(path, value, lowerQuery);
   summary.appendChild(peek);
   if (props && isMovablePath(path)) {
     summary.appendChild(leafMoveButtons(scope, path, props));
@@ -688,8 +688,9 @@ function treeLeaf(
   // Permission rule leaves under `permissions.<kind>` get the rule-chip
   // styling, lint badge, origin tooltip, drag handle, and per-target move
   // buttons that the old `ruleRow` used to render. Filter the row out
-  // entirely when the search query is active and doesn't match — keeps the
-  // "(m/n)" hint on the parent branch summary truthful.
+  // entirely when the search query is active and doesn't match — that drop
+  // is what `treeBranchPeek` then surfaces as the `m/N` count on the
+  // parent branch summary.
   if (isPermissionRule && permKind) {
     const rule = value as string;
     if (lowerQuery !== "" && !matchesLoweredQuery(rule, lowerQuery)) {
@@ -781,6 +782,38 @@ function describePath(path: PathSeg[]): string {
     }
   }
   return out || "(root)";
+}
+
+/**
+ * Compact summary shown in the branch row's right gutter. For most
+ * branches it's the unfiltered shape — `[N]` for arrays, `{N}` for
+ * objects. For a `permissions.<kind>` array under an active filter it
+ * becomes `[m/N]` so the user can see how many rules in this list match,
+ * mirroring the old rule-group `(m/n)` indicator that lived above each
+ * kind section before the unified-tree migration.
+ */
+function treeBranchPeek(
+  path: PathSeg[],
+  value: JsonValue[] | { [key: string]: JsonValue },
+  lowerQuery: string,
+): string {
+  if (Array.isArray(value)) {
+    if (
+      lowerQuery !== "" &&
+      path.length === 2 &&
+      path[0] === "permissions" &&
+      typeof path[1] === "string" &&
+      PERMISSION_KINDS.includes(path[1] as PermissionKind)
+    ) {
+      let matched = 0;
+      for (const item of value) {
+        if (typeof item === "string" && matchesLoweredQuery(item, lowerQuery)) matched++;
+      }
+      return `[${matched}/${value.length}]`;
+    }
+    return `[${value.length}]`;
+  }
+  return `{${Object.keys(value).length}}`;
 }
 
 function leafType(value: JsonValue): string {
@@ -935,7 +968,14 @@ function countPermissionRules(values: { [key: string]: JsonValue }): number {
   let total = 0;
   for (const kind of PERMISSION_KINDS) {
     const list = (perms as { [k: string]: JsonValue })[kind];
-    if (Array.isArray(list)) total += list.length;
+    if (!Array.isArray(list)) continue;
+    // Mirror Rust's `permissions_from_values` and `countMatchingRules`:
+    // only string entries count as permission rules. Hand-edited files
+    // can put numbers / objects in the array, and counting those would
+    // make the column status disagree with the renderer + filter UI.
+    for (const item of list) {
+      if (typeof item === "string") total++;
+    }
   }
   return total;
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -660,6 +660,19 @@ function treeBranch(
   if (permKind) details.classList.add(`tree-perm-${permKind}`);
   const key = treeKey(scope, path);
 
+  // Permission-list branches with any non-string entries can't be moved
+  // — the backend's `merge_at_path` rejects them so the renderer + combined
+  // panel + count helpers stay consistent (only string entries count as
+  // rules). Suppress the affordance here so the action isn't offered before
+  // the IPC says no. The check fires only at the `permissions.<kind>` depth
+  // (length 2) where the value is the rule array itself.
+  const isMalformedPermissionListBranch =
+    permKind !== null &&
+    path.length === 2 &&
+    Array.isArray(value) &&
+    value.some((item) => typeof item !== "string");
+  const offerMoveAffordance = isMovablePath(path) && !isMalformedPermissionListBranch;
+
   const summary = document.createElement("summary");
   summary.className = "tree-summary";
   const name = document.createElement("span");
@@ -669,7 +682,7 @@ function treeBranch(
   // branches: starting a drag on the inner span lets the browser suppress
   // the `<details>` toggle that would otherwise fire on click, and isolates
   // the affordance from nested key labels which aren't movable.
-  if (props && !props.busy && isMovablePath(path)) {
+  if (props && !props.busy && offerMoveAffordance) {
     setupLeafDragSource(name, scope, path);
   }
   summary.appendChild(name);
@@ -677,7 +690,7 @@ function treeBranch(
   peek.className = "tree-peek";
   peek.textContent = treeBranchPeek(path, value, lowerQuery);
   summary.appendChild(peek);
-  if (props && isMovablePath(path)) {
+  if (props && offerMoveAffordance) {
     summary.appendChild(leafMoveButtons(scope, path, props));
   }
   details.appendChild(summary);

--- a/test/fixtures/loadedScopes.ts
+++ b/test/fixtures/loadedScopes.ts
@@ -26,6 +26,7 @@ interface ScopeViewOverrides {
   path?: string | null;
   exists?: boolean;
   permissions?: Partial<PermissionRules>;
+  /** Non-permission top-level keys, merged into the unified `values` map. */
   other_values?: { [key: string]: JsonValue };
   parse_error?: string | null;
 }
@@ -38,6 +39,25 @@ export function emptyOrigins(): PermissionRuleOrigins {
   return { allow: [], deny: [], ask: [] };
 }
 
+/**
+ * Pull the permission rule snapshot out of a ScopeView's unified `values`
+ * map. Mirrors the Rust `SettingsDoc::permissions` accessor (missing /
+ * malformed shapes degrade to empty lists rather than throwing) so the
+ * fixture's combined-panel walk and the renderer agree on what's there.
+ */
+export function permissionsOf(view: ScopeView): PermissionRules {
+  const out = emptyPermissions();
+  const perms = view.values.permissions;
+  if (!perms || typeof perms !== "object" || Array.isArray(perms)) return out;
+  const obj = perms as { [k: string]: JsonValue };
+  for (const kind of ["allow", "deny", "ask"] as const) {
+    const arr = obj[kind];
+    if (!Array.isArray(arr)) continue;
+    out[kind] = arr.filter((v): v is string => typeof v === "string");
+  }
+  return out;
+}
+
 export function buildScopeView(overrides: ScopeViewOverrides): ScopeView {
   const permissions = { ...emptyPermissions(), ...(overrides.permissions ?? {}) };
   // `path` is `string | null` on the wire — the Rust backend serializes
@@ -46,12 +66,27 @@ export function buildScopeView(overrides: ScopeViewOverrides): ScopeView {
   // tests, so check for `undefined` explicitly.
   const path =
     overrides.path !== undefined ? overrides.path : `/fake/${overrides.scope}/settings.json`;
+  // Compose `values` so `permissions` rides at the top of the on-disk key
+  // order when the override supplies any rules — matches what the backend
+  // emits for a real settings.json with `{"permissions": {...}, ...}`.
+  const values: { [key: string]: JsonValue } = {};
+  const hasPermissions =
+    permissions.allow.length > 0 || permissions.deny.length > 0 || permissions.ask.length > 0;
+  if (hasPermissions) {
+    values.permissions = {
+      allow: permissions.allow,
+      deny: permissions.deny,
+      ask: permissions.ask,
+    };
+  }
+  if (overrides.other_values) {
+    for (const [k, v] of Object.entries(overrides.other_values)) values[k] = v;
+  }
   return {
     scope: overrides.scope,
     path,
     exists: overrides.exists ?? true,
-    permissions,
-    other_values: overrides.other_values ?? {},
+    values,
     parse_error: overrides.parse_error ?? null,
   };
 }
@@ -90,7 +125,7 @@ export function buildLoadedScopes(overrides: LoadedScopesOverrides = {}): Loaded
   const kinds: PermissionKind[] = ["allow", "deny", "ask"];
   for (const kind of kinds) {
     for (const view of precedenceOrder) {
-      for (const rule of view.permissions[kind]) {
+      for (const rule of permissionsOf(view)[kind]) {
         const idx = combined[kind].indexOf(rule);
         if (idx === -1) {
           combined[kind].push(rule);

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { MoveOptions, MoveRequest, Scope, Theme } from "../../src/types.ts";
+import type { MoveLeafRequest, MoveOptions, Scope, Theme } from "../../src/types.ts";
 import { SEARCH_INPUT_ID } from "../../src/types.ts";
 import { openSettings, renderApp } from "../../src/ui.ts";
 import { buildLoadedScopes, buildPreferences, buildRuntimeInfo } from "../fixtures/loadedScopes.ts";
@@ -22,7 +22,7 @@ interface PropsOverrides {
   query?: string;
   preferences?: ReturnType<typeof buildPreferences>;
   runtime?: ReturnType<typeof buildRuntimeInfo>;
-  onMove?: (req: MoveRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
+  onMoveLeaf?: (req: MoveLeafRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
 }
 
 function makeProps(overrides: PropsOverrides = {}) {
@@ -43,8 +43,7 @@ function makeProps(overrides: PropsOverrides = {}) {
     runtime: overrides.runtime ?? buildRuntimeInfo(),
     onPickProject: vi.fn(),
     onReload: vi.fn(),
-    onMove: overrides.onMove ?? vi.fn(),
-    onMoveKey: vi.fn(),
+    onMoveLeaf: overrides.onMoveLeaf ?? vi.fn(),
     onOpenSettings: vi.fn(),
     onQueryChange: vi.fn(),
   };
@@ -128,25 +127,25 @@ describe("renderApp", () => {
     expect(after?.selectionEnd).toBe(2);
   });
 
-  it("invokes onMove with the expected request when a per-scope move button is clicked", () => {
-    const onMove = vi.fn();
+  it("invokes onMoveLeaf with a path-based request when a per-scope move button is clicked", () => {
+    // Permission rules now live as tree leaves under `permissions.allow[*]`,
+    // so the move button rides on the leaf's `.rule .rule-moves .move-btn`
+    // and the request payload carries a JSON path instead of {rule, kind}.
+    const onMoveLeaf = vi.fn();
     const scopes = buildLoadedScopes({
       scopes: [{ scope: "project", permissions: { allow: ["Bash(git status)"] } }],
     });
-    renderApp(root, makeProps({ scopes, onMove }));
-    // The project column has buttons targeting every other visible scope.
-    // Pick the one targeting "user" so the click is unambiguous.
+    renderApp(root, makeProps({ scopes, onMoveLeaf }));
     const buttons = Array.from(
-      root.querySelectorAll<HTMLButtonElement>(".rule-group .rule-moves .move-btn"),
+      root.querySelectorAll<HTMLButtonElement>(".rule.rule-allow .rule-moves .move-btn"),
     );
     const toUser = buttons.find((b) => b.textContent === "→ User");
     expect(toUser).toBeDefined();
     toUser?.click();
-    expect(onMove).toHaveBeenCalledTimes(1);
-    const [req] = onMove.mock.calls[0];
+    expect(onMoveLeaf).toHaveBeenCalledTimes(1);
+    const [req] = onMoveLeaf.mock.calls[0];
     expect(req).toEqual({
-      rule: "Bash(git status)",
-      kind: "allow",
+      path: ["permissions", "allow", 0],
       from: "project",
       to: "user",
     });


### PR DESCRIPTION
Closes #67.

## Summary

Migrates ClaudeScope from two parallel move surfaces (per-rule for permissions, per-key for everything else) to a single JSON-path-addressable move primitive, then renders \`permissions\` inline in the same tree as \`env\` / \`hooks\` / \`theme\` / etc., with individual rules movable as leaves under \`permissions.<kind>\`.

## Status

**Draft — both commits landed; ready for review. UI dogfood pending.**

### Commit 1 — backend primitive

- New types in \`model.rs\`: \`PathSeg\` (untagged \`String\` / \`usize\` to match the JSON-Pointer-ish wire format), \`MovablePath\` classifier, \`validate_movable_path\`. Three movable shapes accepted in v1: whole top-level key, whole \`permissions.<kind>\` array, single rule under \`permissions.<kind>\`. Other intermediate paths are explicitly rejected — broader sub-key moves (e.g. \`env.PATH\`) are a follow-up, not in scope for #67.
- \`SettingsDoc\` grows \`get_at_path\` / \`remove_at_path\` / \`merge_at_path\`. The merge dispatches on \`MovablePath\` so existing per-key policies (\`Replace\` / \`DeepMerge\` / \`ArrayUnion\` / \`Sandbox\` / \`ReplaceUnknown\`) keep governing top-level moves, while permission paths array-union into \`permissions.<kind>\`.
- New \`MoveLeafRequest\` / \`MoveLeafPreview\` / \`MoveLeafSide\` types and \`diff_move_leaf\` / \`apply_move_leaf\` commands. Same destination-first save ordering and rollback shape as the existing \`apply_move\` / \`apply_move_key\`. \`MoveLeafKind\` enum on the preview so the diff modal can pick the right rendering without re-classifying.
- 26 new tests (18 in \`model\`, 8 in \`commands\`).

### Commit 2 — frontend migration + legacy IPC removal

- Backend: drops \`MoveRequest\` / \`MoveKeyRequest\` / their previews and sides + the four legacy commands and impls and \`validate_move_key\`. \`ScopeView\` wire shape: drops the typed \`permissions\` field and renames \`other_values\` → \`values\` (now the on-disk top-level map including \`permissions\`). \`SettingsDoc\` loses \`add_rule\` / \`remove_rule\` / \`remove_top_level\` (subsumed by the path-based methods); \`permissions()\` / \`other_entries()\` stay under \`#[cfg(test)]\` for test convenience. \`lib.rs\` invoke handler trims to the new commands only.
- Frontend: \`types.ts\` drops the legacy move types; adds \`PathSeg\`, \`MoveLeafRequest\`, \`MoveLeafKind\`, \`MoveLeafSide\`, \`MoveLeafPreview\`. \`main.ts\` collapses \`moveRule\` + \`moveKey\` into a single \`moveLeaf\`. \`ui.ts\` drops \`rule-group\` / \`ruleRow\` rendering — \`permissions\` renders through \`treeNode\` like every other key, with the \`permissions\` and \`permissions.<kind>\` branches auto-expanded so the user lands on the same content as before. \`treeBranch\` / \`treeLeaf\` grow path-based move buttons + drag at any backend-marked movable path; permission rule leaves still get the rule-chip styling, lint badge, origin tooltip, drag handle, and allow/deny/ask color class. Single \`setupLeafDragSource\` replaces the per-rule + per-key drag setup. \`confirmMoveLeaf\` branches by \`MoveLeafKind\`: chip-list before/after for permission shapes, raw JSON for top-level key moves.
- Tests: drops legacy rule-move + key-move backend tests (covered by the move_leaf tests). Migrates \`combined_*\` tests to the new shape via a \`make_view\` helper. \`preview_note_*\` tests untouched. Frontend \`renderApp\` test asserts the path-based \`onMoveLeaf\` payload on a per-scope rule leaf.

## Test plan

- [x] \`cargo test --lib -- --skip scope::\` — 123 pass on Windows
- [x] \`cargo clippy --tests --lib -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 12/12 pass
- [x] \`npx biome check\` — clean
- [ ] CI green on all three platforms
- [ ] Dogfood the UI: drag a rule from Project → User, click → User on an env leaf, verify allow/deny/ask coloring, verify combined panel still mirrors per-scope contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)