### PR TITLE
feat(cli): add claude-scope-cli for terminal use (#109)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,9 +390,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "claude-scope"
 version = "0.3.0"
 dependencies = [
+ "clap",
  "dirs",
  "notify-debouncer-mini",
  "serde",
@@ -363,6 +454,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1732,6 +1829,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,6 +2520,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"
@@ -4475,6 +4584,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,6 +11,10 @@ rust-version = "1.88"
 name = "claude_scope_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[[bin]]
+name = "claude-scope-cli"
+path = "src/bin/cli.rs"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
@@ -24,6 +28,7 @@ thiserror = "2"
 dirs = "6"
 tempfile = "3"
 notify-debouncer-mini = "0.7"
+clap = { version = "4", features = ["derive"] }
 
 [features]
 # By default Tauri runs in production mode.

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -533,3 +533,105 @@ fn print_preview(preview: &MoveLeafPreview, json: bool) -> Result<(), Box<dyn st
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claude_scope_lib::io_atomic::Indent;
+    use claude_scope_lib::model::SettingsDoc;
+    use serde_json::json;
+    use std::path::Path;
+
+    fn doc_from(value: serde_json::Value) -> SettingsDoc {
+        SettingsDoc::from_value(value, Indent::Spaces(2))
+    }
+
+    #[test]
+    fn resolve_paths_uses_project_dir_literally_without_walk_up() {
+        // The CLI must honor `--project-dir <PATH>` as-is. The GUI's
+        // `scope::resolve_with_home` walks up to a parent `.git`/`.claude`,
+        // which would hijack to an unrelated repo on a system where any
+        // ancestor (e.g. $HOME) happens to be a git working tree. Pin the
+        // CLI-literal behavior so a future refactor can't quietly route
+        // back through the walk-up.
+        let project = Path::new("/tmp/clitest-fixture/project");
+        let home = Path::new("/tmp/clitest-fixture/home");
+        let paths = resolve_paths(Some(project), Some(home)).unwrap();
+        assert_eq!(paths.project_dir, project);
+        assert_eq!(
+            paths.local.as_deref().unwrap(),
+            project.join(".claude").join("settings.local.json")
+        );
+        assert_eq!(
+            paths.project.as_deref().unwrap(),
+            project.join(".claude").join("settings.json")
+        );
+    }
+
+    #[test]
+    fn resolve_paths_roots_user_scopes_under_home_override() {
+        // Sandbox / dogfooding parity with the GUI's `--home` override.
+        // Verify user + user-local both resolve under the supplied home,
+        // not the real `dirs::home_dir()`.
+        let project = Path::new("/tmp/clitest-fixture/project");
+        let home = Path::new("/tmp/clitest-fixture/home");
+        let paths = resolve_paths(Some(project), Some(home)).unwrap();
+        assert_eq!(
+            paths.user.as_deref().unwrap(),
+            home.join(".claude").join("settings.json")
+        );
+        assert_eq!(
+            paths.user_local.as_deref().unwrap(),
+            home.join(".claude").join("settings.local.json")
+        );
+    }
+
+    #[test]
+    fn rules_at_returns_rules_for_each_kind() {
+        let doc = doc_from(json!({
+            "permissions": {
+                "allow": ["Bash(git status)", "Read(**)"],
+                "deny": ["WebFetch(domain:evil.example)"],
+            }
+        }));
+        assert_eq!(
+            rules_at(&doc, "allow"),
+            vec!["Bash(git status)".to_string(), "Read(**)".to_string()]
+        );
+        assert_eq!(
+            rules_at(&doc, "deny"),
+            vec!["WebFetch(domain:evil.example)".to_string()]
+        );
+        assert!(rules_at(&doc, "ask").is_empty());
+    }
+
+    #[test]
+    fn rules_at_degrades_to_empty_when_permissions_absent() {
+        // A settings file without a `permissions` key (or with a non-array
+        // shape after hand-editing) must not panic — match the lib's
+        // "partial corruption shouldn't break the UI" stance.
+        let doc = doc_from(json!({ "theme": "dark" }));
+        assert!(rules_at(&doc, "allow").is_empty());
+
+        let weird = doc_from(json!({ "permissions": { "allow": "not-an-array" } }));
+        assert!(rules_at(&weird, "allow").is_empty());
+    }
+
+    #[test]
+    fn locate_rule_finds_index_and_misses_correctly() {
+        let doc = doc_from(json!({
+            "permissions": { "allow": ["Bash(git status)", "Read(**)"] }
+        }));
+        assert_eq!(
+            locate_rule(&doc, PermissionKind::Allow, "Read(**)"),
+            Some(1)
+        );
+        assert_eq!(locate_rule(&doc, PermissionKind::Allow, "Missing(*)"), None);
+        // Looking under a kind that doesn't exist on disk must also miss
+        // rather than panic.
+        assert_eq!(
+            locate_rule(&doc, PermissionKind::Deny, "Bash(git status)"),
+            None
+        );
+    }
+}

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -1,0 +1,535 @@
+//! `claude-scope-cli` — terminal front end for the same backend the GUI uses.
+//!
+//! Re-uses `claude_scope_lib` for scope discovery, atomic writes, and the
+//! move-leaf primitive. The GUI's `#[tauri::command]` wrappers and this
+//! binary call the same impl functions, so the two surfaces can't drift on
+//! semantics.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand, ValueEnum};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use claude_scope_lib::commands::{
+    apply_move_leaf_impl, build_loaded, diff_move_leaf_impl, MoveLeafPreview, MoveLeafRequest,
+};
+use claude_scope_lib::io_atomic::{self, BackupTracker};
+use claude_scope_lib::model::{PathSeg, PermissionKind};
+use claude_scope_lib::scope::{self, Scope, ScopePaths};
+use claude_scope_lib::watcher::WatchState;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "claude-scope-cli",
+    version,
+    about = "View and move Claude Code settings between scopes from the terminal",
+    long_about = None,
+)]
+struct Cli {
+    /// Project root override. Defaults to walking up from the current directory
+    /// for the nearest `.git` or `.claude/` entry.
+    #[arg(long, value_name = "PATH", global = true)]
+    project_dir: Option<PathBuf>,
+
+    /// Home directory override. Redirects `user` and `user-local` scopes to a
+    /// sandbox home for dogfooding without touching the real `~/.claude/`.
+    #[arg(long, value_name = "PATH", global = true)]
+    home_dir: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// List recognized scopes and their on-disk state.
+    Scopes {
+        /// Emit machine-readable JSON instead of a human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Show one scope's raw contents, or the effective merged view.
+    Show {
+        /// Scope to print. Mutually exclusive with `--effective`.
+        #[arg(long, value_name = "SCOPE", conflicts_with = "effective")]
+        scope: Option<ScopeArg>,
+
+        /// Print the effective merged view across all scopes.
+        #[arg(long, conflicts_with = "scope")]
+        effective: bool,
+
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List permission rules across scopes.
+    ListRules {
+        /// Limit to a single scope.
+        #[arg(long, value_name = "SCOPE")]
+        scope: Option<ScopeArg>,
+
+        /// Limit to a single permission kind.
+        #[arg(long, value_name = "KIND")]
+        kind: Option<KindArg>,
+
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Move a permission rule between scopes. Writes are atomic and create a
+    /// `.bak` of the original on the first write of the session.
+    Move {
+        /// The permission rule string to move, exactly as it appears on disk
+        /// (e.g. `"Bash(git status)"`).
+        rule: String,
+
+        /// Permission kind the rule belongs to.
+        #[arg(long, value_name = "KIND")]
+        kind: KindArg,
+
+        /// Source scope.
+        #[arg(long, value_name = "SCOPE")]
+        from: ScopeArg,
+
+        /// Destination scope.
+        #[arg(long, value_name = "SCOPE")]
+        to: ScopeArg,
+
+        /// Print the preview without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum ScopeArg {
+    Local,
+    Project,
+    #[value(name = "user-local")]
+    UserLocal,
+    User,
+}
+
+impl From<ScopeArg> for Scope {
+    fn from(s: ScopeArg) -> Scope {
+        match s {
+            ScopeArg::Local => Scope::Local,
+            ScopeArg::Project => Scope::Project,
+            ScopeArg::UserLocal => Scope::UserLocal,
+            ScopeArg::User => Scope::User,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum KindArg {
+    Allow,
+    Deny,
+    Ask,
+}
+
+impl KindArg {
+    fn key(self) -> &'static str {
+        match self {
+            KindArg::Allow => "allow",
+            KindArg::Deny => "deny",
+            KindArg::Ask => "ask",
+        }
+    }
+
+    fn as_permission_kind(self) -> PermissionKind {
+        match self {
+            KindArg::Allow => PermissionKind::Allow,
+            KindArg::Deny => PermissionKind::Deny,
+            KindArg::Ask => PermissionKind::Ask,
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match run(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+    let paths = resolve_paths(cli.project_dir.as_deref(), cli.home_dir.as_deref())?;
+    match cli.command {
+        Command::Scopes { json } => cmd_scopes(&paths, json),
+        Command::Show {
+            scope,
+            effective,
+            json,
+        } => cmd_show(&paths, scope, effective, json),
+        Command::ListRules { scope, kind, json } => cmd_list_rules(&paths, scope, kind, json),
+        Command::Move {
+            rule,
+            kind,
+            from,
+            to,
+            dry_run,
+            json,
+        } => cmd_move(&paths, &rule, kind, from.into(), to.into(), dry_run, json),
+    }
+}
+
+/// Resolve scope paths for the CLI.
+///
+/// When `--project-dir` is explicit, the CLI treats it as a literal — no
+/// walk-up to a parent `.git`. The GUI's `scope::resolve_with_home` walks
+/// upward to discover a repo root from the picker's selection, which is the
+/// right default there but the wrong default for a CLI flag the user just
+/// typed. When no override is given, fall through to the shared lib so the
+/// CLI still finds the project root from anywhere inside a repo.
+fn resolve_paths(
+    project_dir: Option<&std::path::Path>,
+    home_dir: Option<&std::path::Path>,
+) -> Result<ScopePaths, Box<dyn std::error::Error>> {
+    let Some(project_root) = project_dir else {
+        return Ok(scope::resolve_with_home(None, home_dir)?);
+    };
+    let home = home_dir
+        .map(std::path::Path::to_path_buf)
+        .or_else(dirs::home_dir);
+    Ok(ScopePaths {
+        project_dir: project_root.to_path_buf(),
+        local: Some(project_root.join(".claude").join("settings.local.json")),
+        project: Some(project_root.join(".claude").join("settings.json")),
+        user_local: home
+            .as_ref()
+            .map(|h| h.join(".claude").join("settings.local.json")),
+        user: home.map(|h| h.join(".claude").join("settings.json")),
+    })
+}
+
+fn cmd_scopes(paths: &ScopePaths, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    #[derive(Serialize)]
+    struct ScopeEntry {
+        scope: String,
+        path: Option<String>,
+        exists: bool,
+        parse_error: Option<String>,
+    }
+
+    let mut entries = Vec::with_capacity(Scope::ALL.len());
+    for scope in Scope::ALL {
+        let path = paths.path_for(scope);
+        let (exists, parse_error) = match path {
+            Some(p) => match io_atomic::load(p) {
+                Ok(Some(_)) => (true, None),
+                Ok(None) => (false, None),
+                Err(e) => (p.exists(), Some(e.to_string())),
+            },
+            None => (false, None),
+        };
+        entries.push(ScopeEntry {
+            scope: scope.label().to_string(),
+            path: path.map(|p| p.display().to_string()),
+            exists,
+            parse_error,
+        });
+    }
+
+    if json {
+        let out = json!({
+            "project-dir": paths.project_dir.display().to_string(),
+            "scopes": entries,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        println!("project-dir: {}", paths.project_dir.display());
+        for e in &entries {
+            let status = if e.exists { "present" } else { "absent" };
+            let path = e.path.as_deref().unwrap_or("(unresolvable)");
+            println!("  {:<11} [{status}] {path}", e.scope);
+            if let Some(err) = &e.parse_error {
+                println!("              parse-error: {err}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cmd_show(
+    paths: &ScopePaths,
+    scope: Option<ScopeArg>,
+    effective: bool,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let loaded = build_loaded(paths)?;
+
+    if effective {
+        let perms = &loaded.combined_permissions;
+        if json {
+            let out = json!({
+                "project-dir": loaded.project_dir,
+                "effective": {
+                    "permissions": {
+                        "allow": perms.allow,
+                        "deny": perms.deny,
+                        "ask": perms.ask,
+                    },
+                },
+            });
+            println!("{}", serde_json::to_string_pretty(&out)?);
+        } else {
+            println!("effective merged permissions ({}):", loaded.project_dir);
+            print_permissions_section("allow", &perms.allow);
+            print_permissions_section("deny", &perms.deny);
+            print_permissions_section("ask", &perms.ask);
+        }
+        return Ok(());
+    }
+
+    let target = scope.ok_or_else::<Box<dyn std::error::Error>, _>(|| {
+        "show requires either --scope <SCOPE> or --effective".into()
+    })?;
+    let target_scope: Scope = target.into();
+    let view = loaded
+        .scopes
+        .iter()
+        .find(|v| v.scope == target_scope)
+        .ok_or_else::<Box<dyn std::error::Error>, _>(|| {
+            format!(
+                "internal error: scope `{}` missing from load",
+                target_scope.label()
+            )
+            .into()
+        })?;
+
+    if json {
+        let out = json!({
+            "project-dir": loaded.project_dir,
+            "scope": target_scope.label(),
+            "path": view.path,
+            "exists": view.exists,
+            "values": view.values,
+            "parse-error": view.parse_error,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        let path = view.path.as_deref().unwrap_or("(unresolvable)");
+        let status = if view.exists { "present" } else { "absent" };
+        println!("scope: {} [{status}] {path}", target_scope.label());
+        if let Some(err) = &view.parse_error {
+            println!("parse-error: {err}");
+            return Ok(());
+        }
+        if view.values.is_empty() {
+            println!("(no top-level keys)");
+        } else {
+            let pretty = serde_json::to_string_pretty(&Value::Object(view.values.clone()))?;
+            println!("{pretty}");
+        }
+    }
+    Ok(())
+}
+
+fn print_permissions_section(kind: &str, rules: &[String]) {
+    println!("  {kind}:");
+    if rules.is_empty() {
+        println!("    (none)");
+    } else {
+        for rule in rules {
+            println!("    - {rule}");
+        }
+    }
+}
+
+fn cmd_list_rules(
+    paths: &ScopePaths,
+    scope_filter: Option<ScopeArg>,
+    kind_filter: Option<KindArg>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    #[derive(Serialize)]
+    struct RuleRow {
+        scope: String,
+        kind: String,
+        rule: String,
+    }
+
+    let target_scope: Option<Scope> = scope_filter.map(Into::into);
+    let kind_str = kind_filter.map(|k| k.key());
+
+    let mut rows = Vec::new();
+    for scope in Scope::ALL {
+        if let Some(want) = target_scope {
+            if scope != want {
+                continue;
+            }
+        }
+        let Some(path) = paths.path_for(scope) else {
+            continue;
+        };
+        let Ok(Some(doc)) = io_atomic::load(path) else {
+            continue;
+        };
+        for k in ["allow", "deny", "ask"] {
+            if let Some(want_kind) = kind_str {
+                if k != want_kind {
+                    continue;
+                }
+            }
+            for rule in rules_at(&doc, k) {
+                rows.push(RuleRow {
+                    scope: scope.label().to_string(),
+                    kind: k.to_string(),
+                    rule,
+                });
+            }
+        }
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+    } else if rows.is_empty() {
+        println!("(no rules)");
+    } else {
+        for row in &rows {
+            println!("{:<11} {:<6} {}", row.scope, row.kind, row.rule);
+        }
+    }
+    Ok(())
+}
+
+fn cmd_move(
+    paths: &ScopePaths,
+    rule: &str,
+    kind: KindArg,
+    from: Scope,
+    to: Scope,
+    dry_run: bool,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if from == to {
+        return Err("--from and --to must differ".into());
+    }
+    let from_path = paths
+        .path_for(from)
+        .ok_or_else::<Box<dyn std::error::Error>, _>(|| {
+            format!("cannot resolve path for scope `{}`", from.label()).into()
+        })?;
+    let from_doc =
+        io_atomic::load(from_path)?.ok_or_else::<Box<dyn std::error::Error>, _>(|| {
+            format!("source file {} does not exist", from_path.display()).into()
+        })?;
+    let idx = locate_rule(&from_doc, kind.as_permission_kind(), rule)
+        .ok_or_else::<Box<dyn std::error::Error>, _>(|| {
+            format!(
+                "rule `{rule}` not found in {} permissions.{} ({})",
+                from.label(),
+                kind.key(),
+                from_path.display()
+            )
+            .into()
+        })?;
+
+    let req = MoveLeafRequest {
+        path: vec![
+            PathSeg::Key("permissions".into()),
+            PathSeg::Key(kind.key().into()),
+            PathSeg::Index(idx),
+        ],
+        from,
+        to,
+        to_kind: None,
+    };
+
+    if dry_run {
+        let preview = diff_move_leaf_impl(paths, &req)?;
+        print_preview(&preview, json)?;
+        return Ok(());
+    }
+
+    apply_move_leaf_impl(paths, &req, &BackupTracker::new(), &WatchState::default())?;
+
+    if json {
+        let out = json!({
+            "moved": true,
+            "rule": rule,
+            "kind": kind.key(),
+            "from": from.label(),
+            "to": to.label(),
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        println!(
+            "moved {} rule `{rule}` from {} to {}",
+            kind.key(),
+            from.label(),
+            to.label()
+        );
+    }
+    Ok(())
+}
+
+fn rules_at(doc: &claude_scope_lib::model::SettingsDoc, kind_key: &str) -> Vec<String> {
+    let Some(arr) = doc.get_at_path(&[
+        PathSeg::Key("permissions".into()),
+        PathSeg::Key(kind_key.into()),
+    ]) else {
+        return Vec::new();
+    };
+    let Some(items) = arr.as_array() else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_string))
+        .collect()
+}
+
+fn locate_rule(
+    doc: &claude_scope_lib::model::SettingsDoc,
+    kind: PermissionKind,
+    rule: &str,
+) -> Option<usize> {
+    let key = match kind {
+        PermissionKind::Allow => "allow",
+        PermissionKind::Deny => "deny",
+        PermissionKind::Ask => "ask",
+    };
+    let arr = doc.get_at_path(&[PathSeg::Key("permissions".into()), PathSeg::Key(key.into())])?;
+    arr.as_array()?
+        .iter()
+        .position(|v| v.as_str() == Some(rule))
+}
+
+fn print_preview(preview: &MoveLeafPreview, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(preview)?);
+        return Ok(());
+    }
+    println!("dry-run preview:");
+    println!(
+        "  from: scope={} path={} will-write={}",
+        preview.from.scope.label(),
+        preview.from.file_path,
+        preview.from.will_write
+    );
+    println!(
+        "  to:   scope={} path={} will-write={}",
+        preview.to.scope.label(),
+        preview.to.file_path,
+        preview.to.will_write
+    );
+    if let Some(note) = &preview.to.note {
+        println!("  note: {note}");
+    }
+    Ok(())
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -312,7 +312,7 @@ pub fn save_preferences(prefs: Preferences) -> Result<(), String> {
     preferences::save(&prefs).map_err(|e| e.to_string())
 }
 
-fn build_loaded(paths: &ScopePaths) -> Result<LoadedScopes, Box<dyn std::error::Error>> {
+pub fn build_loaded(paths: &ScopePaths) -> Result<LoadedScopes, Box<dyn std::error::Error>> {
     let mut views = Vec::with_capacity(Scope::ALL.len());
 
     for scope in Scope::ALL {
@@ -581,7 +581,7 @@ fn validate_move_request(
     }
 }
 
-fn diff_move_leaf_impl(
+pub fn diff_move_leaf_impl(
     paths: &ScopePaths,
     req: &MoveLeafRequest,
 ) -> Result<MoveLeafPreview, Box<dyn std::error::Error>> {
@@ -767,7 +767,7 @@ fn diff_change_kind_same_scope(
     })
 }
 
-fn apply_move_leaf_impl(
+pub fn apply_move_leaf_impl(
     paths: &ScopePaths,
     req: &MoveLeafRequest,
     backups: &BackupTracker,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,13 +1,19 @@
-mod commands;
-mod io_atomic;
-mod model;
+pub mod commands;
+pub mod io_atomic;
+pub mod model;
 mod preferences;
 mod runtime;
-mod scope;
-mod watcher;
+pub mod scope;
+pub mod watcher;
 
+/// Tauri entry point for the GUI. The caller supplies the build-time
+/// `tauri::Context` (via `tauri::generate_context!()` at the bin's compile
+/// site) so the macro — which requires the bundled frontend assets — only
+/// expands when the GUI bin is being built. The CLI bin re-uses the same
+/// library but never calls this function, so it can build without the
+/// frontend's `dist/` being present.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
+pub fn run(context: tauri::Context) {
     // Sandbox / scratch-home overrides (#66): parse `--home` / `--project`
     // from argv and `CLAUDE_SCOPE_HOME` / `CLAUDE_SCOPE_PROJECT` from env at
     // launch. Stored as managed state so every subsequent scope::resolve
@@ -47,6 +53,6 @@ pub fn run() {
             commands::save_preferences,
             commands::load_runtime_info,
         ])
-        .run(tauri::generate_context!())
+        .run(context)
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    claude_scope_lib::run();
+    claude_scope_lib::run(tauri::generate_context!());
 }

--- a/src-tauri/tests/cli.rs
+++ b/src-tauri/tests/cli.rs
@@ -1,0 +1,266 @@
+//! Integration tests for the `claude-scope-cli` binary.
+//!
+//! Drives the compiled binary via `env!("CARGO_BIN_EXE_*")` against a
+//! sandbox tempdir tree. Pinning the CLI surface this way means a future
+//! "let's quietly rename a subcommand or flag" refactor fails CI loudly
+//! instead of breaking shell scripts in the wild.
+//!
+//! Every test passes both `--project-dir` and `--home-dir` so the binary
+//! never touches the developer's real `~/.claude/`. Working from the
+//! tempdir's project directory also guarantees no stray walk-up to an
+//! ancestor `.git` (the explicit `--project-dir` is honored literally,
+//! covered separately in the bin's unit tests).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+const BIN: &str = env!("CARGO_BIN_EXE_claude-scope-cli");
+
+struct Sandbox {
+    _tmp: TempDir,
+    project: PathBuf,
+    home: PathBuf,
+}
+
+impl Sandbox {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let project = tmp.path().join("project");
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(project.join(".claude")).unwrap();
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        Self {
+            _tmp: tmp,
+            project,
+            home,
+        }
+    }
+
+    fn write_project(&self, body: &str) {
+        std::fs::write(self.project.join(".claude").join("settings.json"), body).unwrap();
+    }
+
+    fn write_user(&self, body: &str) {
+        std::fs::write(self.home.join(".claude").join("settings.json"), body).unwrap();
+    }
+
+    fn project_settings(&self) -> String {
+        std::fs::read_to_string(self.project.join(".claude").join("settings.json")).unwrap()
+    }
+
+    fn user_settings(&self) -> String {
+        std::fs::read_to_string(self.home.join(".claude").join("settings.json")).unwrap()
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(BIN)
+            .args([
+                "--project-dir",
+                self.project.to_str().unwrap(),
+                "--home-dir",
+                self.home.to_str().unwrap(),
+            ])
+            .args(args)
+            .output()
+            .expect("failed to execute claude-scope-cli")
+    }
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("non-utf8 stdout")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("non-utf8 stderr")
+}
+
+fn read_allow(path: &Path) -> Vec<String> {
+    let body = std::fs::read_to_string(path).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    v["permissions"]["allow"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[test]
+fn scopes_lists_all_four_recognized_scopes() {
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":[]}}"#);
+
+    let out = sb.run(&["scopes"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let s = stdout(&out);
+    for label in ["local", "project", "user-local", "user"] {
+        assert!(s.contains(label), "scopes output missing `{label}`: {s}");
+    }
+    // Tempdir project is present (we created the file), tempdir user is
+    // present (we created the file). Local + user-local stay absent.
+    assert!(s.contains("project     [present]"));
+    assert!(s.contains("user        [present]"));
+    assert!(s.contains("local       [absent]"));
+    assert!(s.contains("user-local  [absent]"));
+}
+
+#[test]
+fn show_effective_merges_permissions_across_scopes() {
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Bash(git status)","Read(**)"]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
+
+    let out = sb.run(&["show", "--effective"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let s = stdout(&out);
+    // Effective view should surface rules from both files.
+    assert!(s.contains("Bash(git status)"));
+    assert!(s.contains("Read(**)"));
+    assert!(s.contains("Bash(ls)"));
+}
+
+#[test]
+fn list_rules_filters_by_scope_and_kind() {
+    let sb = Sandbox::new();
+    sb.write_project(
+        r#"{"permissions":{"allow":["Bash(git status)"],"deny":["WebFetch(domain:evil.example)"]}}"#,
+    );
+    sb.write_user(r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
+
+    let scoped = sb.run(&["list-rules", "--scope", "project", "--kind", "allow"]);
+    assert!(scoped.status.success(), "stderr: {}", stderr(&scoped));
+    let body = stdout(&scoped);
+    assert!(body.contains("Bash(git status)"));
+    // Other-scope and other-kind rows must be filtered out.
+    assert!(!body.contains("Bash(ls)"));
+    assert!(!body.contains("WebFetch(domain:evil.example)"));
+}
+
+#[test]
+fn move_dry_run_previews_without_writing() {
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Bash(git status)","Read(**)"]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":[]}}"#);
+
+    let project_before = sb.project_settings();
+    let user_before = sb.user_settings();
+
+    let out = sb.run(&[
+        "move",
+        "Bash(git status)",
+        "--kind",
+        "allow",
+        "--from",
+        "project",
+        "--to",
+        "user",
+        "--dry-run",
+    ]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let body = stdout(&out);
+    assert!(body.contains("dry-run preview:"));
+    assert!(body.contains("will-write=true"));
+
+    // The on-disk files must be byte-for-byte unchanged.
+    assert_eq!(sb.project_settings(), project_before);
+    assert_eq!(sb.user_settings(), user_before);
+}
+
+#[test]
+fn move_atomically_relocates_rule_and_creates_backups() {
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Bash(git status)","Read(**)"]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
+
+    let out = sb.run(&[
+        "move",
+        "Bash(git status)",
+        "--kind",
+        "allow",
+        "--from",
+        "project",
+        "--to",
+        "user",
+    ]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+
+    let project_allow = read_allow(&sb.project.join(".claude").join("settings.json"));
+    let user_allow = read_allow(&sb.home.join(".claude").join("settings.json"));
+    assert_eq!(project_allow, vec!["Read(**)".to_string()]);
+    assert!(user_allow.contains(&"Bash(git status)".to_string()));
+    assert!(user_allow.contains(&"Bash(ls)".to_string()));
+
+    // First write of the session must drop `.bak` snapshots of the
+    // pre-write state alongside both files.
+    assert!(sb
+        .project
+        .join(".claude")
+        .join("settings.json.bak")
+        .exists());
+    assert!(sb.home.join(".claude").join("settings.json.bak").exists());
+}
+
+#[test]
+fn move_rejects_rule_missing_from_source_with_nonzero_exit() {
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Read(**)"]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":[]}}"#);
+
+    let out = sb.run(&[
+        "move",
+        "DoesNotExist",
+        "--kind",
+        "allow",
+        "--from",
+        "project",
+        "--to",
+        "user",
+    ]);
+    assert!(!out.status.success());
+    assert!(stderr(&out).contains("not found"));
+    // The source file must not be touched on the rejected path.
+    assert!(sb.project_settings().contains("Read(**)"));
+}
+
+#[test]
+fn move_rejects_same_source_and_destination_scope() {
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
+
+    let out = sb.run(&[
+        "move", "Bash(ls)", "--kind", "allow", "--from", "project", "--to", "project",
+    ]);
+    assert!(!out.status.success());
+    assert!(stderr(&out).contains("must differ"));
+}
+
+#[test]
+fn show_without_scope_or_effective_errors_out() {
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":[]}}"#);
+
+    let out = sb.run(&["show"]);
+    assert!(!out.status.success());
+    let msg = stderr(&out);
+    assert!(
+        msg.contains("--scope") || msg.contains("--effective"),
+        "expected the error to point at the missing flag pair, got: {msg}"
+    );
+}
+
+#[test]
+fn version_flag_prints_crate_version() {
+    let out = Command::new(BIN).arg("--version").output().unwrap();
+    assert!(out.status.success());
+    let s = String::from_utf8(out.stdout).unwrap();
+    // `claude-scope-cli <version>`. Avoid pinning the exact version so the
+    // test survives release-please bumps; just check the binary name and a
+    // version-shaped trailer.
+    assert!(s.starts_with("claude-scope-cli "));
+    assert!(s.split_whitespace().nth(1).is_some());
+}


### PR DESCRIPTION
## Summary

- Add `claude-scope-cli`, a terminal front end for the same backend the GUI uses. Re-uses `claude_scope_lib::scope`, `io_atomic`, `model`, and the move-leaf primitive in `commands` — GUI and CLI dispatch into the same impl functions so they can't drift on semantics.
- Move `tauri::generate_context!()` from `lib::run` into `src/main.rs` so the CLI bin can build without the frontend's `dist/`. `lib::run` now takes a `tauri::Context` constructed at the GUI bin's compile site.
- CLI honors explicit `--project-dir <PATH>` literally (no walk-up to a parent `.git`), so the CLI works inside any directory regardless of whether an ancestor is itself a git repo.

Closes #109.

## CLI surface (kebab-case throughout)

\`\`\`
claude-scope-cli [--project-dir <PATH>] [--home-dir <PATH>] <COMMAND>

  scopes [--json]
  show [--scope <SCOPE>|--effective] [--json]
  list-rules [--scope <SCOPE>] [--kind <KIND>] [--json]
  move <RULE> --kind <KIND> --from <SCOPE> --to <SCOPE> [--dry-run] [--json]
\`\`\`

- Scope values: \`local | project | user-local | user\`
- Kind values: \`allow | deny | ask\`
- All flags and subcommands are kebab-case. JSON output uses the same conventions as the lib's existing serde shapes.
- `--version` / `-V` and `--help` / `-h` work at the top level and on each subcommand.

## Test plan

- [x] `cargo build --bin claude-scope-cli` (no dist required)
- [x] `cargo test --lib -- --skip scope::` — 126 passed, 0 failed (scope:: tests skipped per Brian's local-env quirk; CI runs the full set)
- [x] End-to-end smoke against a sandboxed `--project-dir` / `--home-dir`:
  - `scopes` lists all four scopes with present/absent state
  - `show --scope project`, `show --effective` render correctly
  - `list-rules` flat-lists rules; `--scope` and `--kind` filters work
  - `move <rule> --kind allow --from project --to user --dry-run` prints preview, no write
  - `move <rule> ...` (no dry-run) moves atomically, creates `.bak`s on both files
  - negative cases (`rule not found`, `--from == --to`, `show` without target) exit 1 with messages on stderr
- [ ] CI green on the new branch