### PR TITLE
feat: discover known Claude projects for Move-to submenu (#106)

### DIFF
--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -17,6 +17,7 @@ use claude_scope_lib::commands::{
 };
 use claude_scope_lib::io_atomic::{self, BackupTracker};
 use claude_scope_lib::model::{PathSeg, PermissionKind};
+use claude_scope_lib::projects::{self, KnownProject};
 use claude_scope_lib::scope::{self, Scope, ScopePaths};
 use claude_scope_lib::watcher::WatchState;
 
@@ -76,6 +77,14 @@ enum Command {
         #[arg(long, value_name = "KIND")]
         kind: Option<KindArg>,
 
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List Claude projects discovered on this machine via the
+    /// `~/.claude/projects/` transcript registry (#106).
+    ListProjects {
         /// Emit machine-readable JSON.
         #[arg(long)]
         json: bool,
@@ -167,6 +176,13 @@ fn main() -> ExitCode {
 }
 
 fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+    // `list-projects` operates on the home registry only and doesn't need a
+    // resolved project root, so dispatch it before `resolve_paths` to avoid
+    // a spurious walk-up when the CLI is invoked outside any repo.
+    if let Command::ListProjects { json } = cli.command {
+        return cmd_list_projects(cli.home_dir.as_deref(), json);
+    }
+
     let paths = resolve_paths(cli.project_dir.as_deref(), cli.home_dir.as_deref())?;
     match cli.command {
         Command::Scopes { json } => cmd_scopes(&paths, json),
@@ -176,6 +192,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             json,
         } => cmd_show(&paths, scope, effective, json),
         Command::ListRules { scope, kind, json } => cmd_list_rules(&paths, scope, kind, json),
+        Command::ListProjects { .. } => unreachable!("handled above"),
         Command::Move {
             rule,
             kind,
@@ -402,6 +419,41 @@ fn cmd_list_rules(
     } else {
         for row in &rows {
             println!("{:<11} {:<6} {}", row.scope, row.kind, row.rule);
+        }
+    }
+    Ok(())
+}
+
+fn cmd_list_projects(
+    home: Option<&std::path::Path>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let entries = projects::list_known_projects(home)?;
+    if json {
+        // Wrap in `KnownProjectOut` so the wire format is stable even if
+        // the lib struct grows new fields. `serde_json::to_value` on
+        // `KnownProject` would silently start exposing those fields.
+        #[derive(Serialize)]
+        struct KnownProjectOut<'a> {
+            name: &'a str,
+            root: String,
+        }
+        let out: Vec<KnownProjectOut<'_>> = entries
+            .iter()
+            .map(|p: &KnownProject| KnownProjectOut {
+                name: &p.name,
+                root: p.root.display().to_string(),
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "projects": out }))?
+        );
+    } else if entries.is_empty() {
+        println!("(no Claude projects discovered)");
+    } else {
+        for p in &entries {
+            println!("{}\t{}", p.name, p.root.display());
         }
     }
     Ok(())

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,6 +12,7 @@ use crate::model::{
     PermissionKind, PermissionRules, SettingsDoc,
 };
 use crate::preferences::{self, Preferences};
+use crate::projects::{self, KnownProject};
 use crate::runtime::{RuntimeInfo, RuntimeOverrides};
 use crate::scope::{self, Scope, ScopePaths};
 use crate::watcher::WatchState;
@@ -294,6 +295,16 @@ pub fn apply_add_leaf(
 #[tauri::command]
 pub fn load_runtime_info(overrides: State<'_, RuntimeOverrides>) -> RuntimeInfo {
     RuntimeInfo::from_overrides(&overrides)
+}
+
+/// Enumerate every Claude project on this machine for the Move-to submenu
+/// (#106). Routes through `RuntimeOverrides::home` so sandbox mode (#66)
+/// reads from the scratch home instead of the real `~/.claude/projects/`.
+#[tauri::command]
+pub fn list_known_projects(
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<Vec<KnownProject>, String> {
+    projects::list_known_projects(overrides.home()).map_err(|e| e.to_string())
 }
 
 /// Read user preferences. A missing / malformed config file falls back to

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,6 +53,7 @@ pub fn run(context: tauri::Context) {
             commands::load_preferences,
             commands::save_preferences,
             commands::load_runtime_info,
+            commands::list_known_projects,
         ])
         .run(context)
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ pub mod commands;
 pub mod io_atomic;
 pub mod model;
 mod preferences;
+pub mod projects;
 mod runtime;
 pub mod scope;
 pub mod watcher;

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -1,0 +1,366 @@
+//! Discovery of Claude Code projects on this machine.
+//!
+//! Claude Code maintains a per-project transcript registry at
+//! `~/.claude/projects/<encoded-cwd>/<session>.jsonl`. The encoded directory
+//! name collapses drive letters and path separators to `-`, so it's lossy
+//! and can't be reversed deterministically. The transcripts themselves
+//! record the original absolute path in a `cwd` JSON field, so we use the
+//! filesystem as a registry but ignore its keys: we open the most recent
+//! `.jsonl` in each subdirectory and extract `cwd` directly. That makes the
+//! list authoritative on Windows (where decoding `D--bminier-claude-scope`
+//! is ambiguous) without inventing a new on-disk registry.
+
+use std::fs;
+use std::io::{self, BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+/// Bounded scan over each transcript looking for the first `cwd`. The first
+/// few records are session-metadata wrappers (`type: "last-prompt"`,
+/// `"custom-title"`, `"agent-name"`, `"permission-mode"`, `"bridge-session"`)
+/// that don't carry `cwd`; the field appears once the first real
+/// prompt/response record lands. Cap the scan so a corrupt or truncated
+/// transcript can't make discovery O(file size).
+const CWD_SCAN_LINE_CAP: usize = 50;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct KnownProject {
+    /// Basename of `root`. Stable display label for the Move-to submenu.
+    pub name: String,
+    /// Absolute path to the project root, as recorded in the transcript's
+    /// `cwd` field. Always an existing directory with a `.claude/`
+    /// subdirectory at the time of discovery.
+    pub root: PathBuf,
+}
+
+/// Minimal shape we need from each transcript line. `serde` ignores the
+/// dozens of other fields each record carries, so a single struct works for
+/// both session-metadata and prompt/response records — only the ones with a
+/// `cwd` value contribute.
+#[derive(Debug, Deserialize)]
+struct TranscriptLine {
+    cwd: Option<String>,
+}
+
+/// Enumerate every Claude project visible to this machine. `home` overrides
+/// `dirs::home_dir()` for sandboxed tests (and the runtime `--home`
+/// override). Missing `~/.claude/projects/` is not an error — fresh
+/// installs simply return an empty list.
+pub fn list_known_projects(home: Option<&Path>) -> io::Result<Vec<KnownProject>> {
+    let Some(projects_dir) = projects_dir(home) else {
+        return Ok(Vec::new());
+    };
+
+    let entries = match fs::read_dir(&projects_dir) {
+        Ok(it) => it,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+
+    let mut found: Vec<KnownProject> = Vec::new();
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let Some(cwd) = latest_cwd_in(&entry.path())? else {
+            continue;
+        };
+        if !is_loadable_project(&cwd) {
+            continue;
+        }
+        let name = display_name_for(&cwd);
+        found.push(KnownProject { name, root: cwd });
+    }
+
+    dedupe_and_sort(&mut found);
+    Ok(found)
+}
+
+fn projects_dir(home: Option<&Path>) -> Option<PathBuf> {
+    let base = home.map(Path::to_path_buf).or_else(dirs::home_dir)?;
+    Some(base.join(".claude").join("projects"))
+}
+
+/// Pick the newest transcript file in `dir` and extract its first `cwd`.
+/// Newest-wins because a project the user has come back to most recently
+/// has the truest current path: an old transcript could reference a path
+/// from before a directory rename.
+fn latest_cwd_in(dir: &Path) -> io::Result<Option<PathBuf>> {
+    let mut newest: Option<(SystemTime, PathBuf)> = None;
+    for entry in fs::read_dir(dir)?.flatten() {
+        let file_type = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if !file_type.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        // mtime fallback to UNIX_EPOCH keeps ordering stable on filesystems
+        // that fail to report a modified time (rare, but seen on some
+        // Windows network shares); the comparison still yields *some* total
+        // order so the loop terminates with a definite winner.
+        let modified = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        match &newest {
+            Some((best, _)) if *best >= modified => {}
+            _ => newest = Some((modified, path)),
+        }
+    }
+
+    let Some((_, path)) = newest else {
+        return Ok(None);
+    };
+    Ok(extract_first_cwd(&path)?.map(PathBuf::from))
+}
+
+fn extract_first_cwd(path: &Path) -> io::Result<Option<String>> {
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    for line in reader.lines().take(CWD_SCAN_LINE_CAP) {
+        let line = match line {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(parsed) = serde_json::from_str::<TranscriptLine>(&line) else {
+            continue;
+        };
+        if let Some(cwd) = parsed.cwd {
+            if !cwd.is_empty() {
+                return Ok(Some(cwd));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// A project is "loadable" by ClaudeScope when its `.claude/` directory
+/// still exists. Without it there's nothing for the Move-to submenu to
+/// target, so silently hide the entry rather than offer a destination that
+/// would immediately fail in `scope::resolve`.
+fn is_loadable_project(root: &Path) -> bool {
+    root.join(".claude").is_dir()
+}
+
+fn display_name_for(root: &Path) -> String {
+    root.file_name()
+        .and_then(|s| s.to_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| root.display().to_string())
+}
+
+/// De-dupe by canonicalized path, then sort alphabetically (case-insensitive
+/// on the display name) for a stable Move-to ordering. Canonicalization
+/// catches the same project showing up under two encoded directory names
+/// (e.g. after a path-case change on Windows that left a stale transcript
+/// alongside the new one).
+fn dedupe_and_sort(projects: &mut Vec<KnownProject>) {
+    projects.sort_by_key(|p| canonical_key(&p.root));
+    projects.dedup_by(|a, b| canonical_key(&a.root) == canonical_key(&b.root));
+    projects.sort_by_key(|p| p.name.to_lowercase());
+}
+
+fn canonical_key(p: &Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+    use std::path::Path;
+
+    fn write_jsonl(path: &Path, lines: &[&str]) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, lines.join("\n")).unwrap();
+    }
+
+    fn seed_project(home: &Path, encoded: &str, cwd: &Path) {
+        let dir = home.join(".claude").join("projects").join(encoded);
+        // Emit a few session-metadata records before the cwd-bearing record
+        // so the test exercises the bounded scan past the prelude. Mirrors
+        // the shape Claude Code writes in real transcripts.
+        let cwd_str = cwd.to_string_lossy().replace('\\', "\\\\");
+        let lines = [
+            r#"{"type":"last-prompt","leafUuid":"u","sessionId":"s"}"#.to_string(),
+            r#"{"type":"custom-title","customTitle":"t","sessionId":"s"}"#.to_string(),
+            format!(r#"{{"sessionId":"s","cwd":"{cwd_str}"}}"#),
+        ];
+        write_jsonl(
+            &dir.join("0001-session.jsonl"),
+            &lines.iter().map(String::as_str).collect::<Vec<_>>(),
+        );
+    }
+
+    /// Build a project root with a `.claude/` so it survives the loadability
+    /// filter. Returns the path so the test can compare against it.
+    fn make_loadable_project(parent: &Path, name: &str) -> PathBuf {
+        let root = parent.join(name);
+        fs::create_dir_all(root.join(".claude")).unwrap();
+        root
+    }
+
+    #[test]
+    fn returns_empty_when_projects_dir_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No `~/.claude/projects/` at all.
+        let got = list_known_projects(Some(tmp.path())).unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn extracts_cwd_from_transcript_prelude() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = make_loadable_project(tmp.path(), "alpha");
+        seed_project(&home, "D--alpha", &project);
+
+        let got = list_known_projects(Some(&home)).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].name, "alpha");
+        assert_eq!(canonical_key(&got[0].root), canonical_key(&project));
+    }
+
+    #[test]
+    fn hides_projects_whose_directory_no_longer_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        // Transcript references a path that does NOT exist on disk.
+        let bogus = tmp.path().join("deleted-project");
+        seed_project(&home, "D--gone", &bogus);
+
+        let got = list_known_projects(Some(&home)).unwrap();
+        assert!(got.is_empty(), "expected stale project to be filtered out");
+    }
+
+    #[test]
+    fn hides_projects_with_no_dot_claude() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        // Real directory, but no `.claude/` — not a Claude project as far as
+        // ClaudeScope is concerned.
+        let project = tmp.path().join("not-a-claude-project");
+        fs::create_dir_all(&project).unwrap();
+        seed_project(&home, "D--bare", &project);
+
+        let got = list_known_projects(Some(&home)).unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn skips_transcripts_with_no_cwd_record() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let dir = home.join(".claude").join("projects").join("D--no-cwd");
+        // Session-metadata only — no record carries a `cwd` field.
+        write_jsonl(
+            &dir.join("0001.jsonl"),
+            &[
+                r#"{"type":"last-prompt","leafUuid":"u","sessionId":"s"}"#,
+                r#"{"type":"custom-title","customTitle":"t","sessionId":"s"}"#,
+            ],
+        );
+
+        let got = list_known_projects(Some(&home)).unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn sorts_alphabetically_case_insensitive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let alpha = make_loadable_project(tmp.path(), "alpha");
+        let beta = make_loadable_project(tmp.path(), "Beta");
+        let gamma = make_loadable_project(tmp.path(), "gamma");
+        seed_project(&home, "p-gamma", &gamma);
+        seed_project(&home, "p-alpha", &alpha);
+        seed_project(&home, "p-Beta", &beta);
+
+        let got = list_known_projects(Some(&home)).unwrap();
+        let names: Vec<&str> = got.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "Beta", "gamma"]);
+    }
+
+    #[test]
+    fn dedupes_two_encoded_dirs_pointing_at_same_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = make_loadable_project(tmp.path(), "shared");
+        // Same `cwd` written under two different encoded dirs — simulates a
+        // path-case change on Windows that leaves a stale transcript dir
+        // alongside the new one.
+        seed_project(&home, "D--SHARED", &project);
+        seed_project(&home, "D--shared", &project);
+
+        let got = list_known_projects(Some(&home)).unwrap();
+        assert_eq!(got.len(), 1);
+    }
+
+    #[test]
+    fn ignores_non_jsonl_files_and_nested_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = make_loadable_project(tmp.path(), "mixed");
+        let dir = home.join(".claude").join("projects").join("D--mixed");
+
+        // Real transcript with cwd.
+        let cwd_str = project.to_string_lossy().replace('\\', "\\\\");
+        write_jsonl(
+            &dir.join("session.jsonl"),
+            &[&format!(r#"{{"sessionId":"s","cwd":"{cwd_str}"}}"#)],
+        );
+        // Extension-less file: should be skipped, not parsed.
+        fs::write(dir.join("scratch"), "not jsonl").unwrap();
+        // A nested directory shaped like a uuid — real Claude Code does
+        // this. Must not be opened as a transcript.
+        fs::create_dir_all(dir.join("1fad75bd-3add-4aba-85d6-9ac4b8369d34")).unwrap();
+
+        let got = list_known_projects(Some(&home)).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].name, "mixed");
+    }
+
+    #[test]
+    fn newest_transcript_wins_when_cwd_changed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let old_root = make_loadable_project(tmp.path(), "old-name");
+        let new_root = make_loadable_project(tmp.path(), "new-name");
+        let dir = home.join(".claude").join("projects").join("D--renamed");
+
+        // Older transcript points at the old path...
+        let old_str = old_root.to_string_lossy().replace('\\', "\\\\");
+        write_jsonl(
+            &dir.join("0001-old.jsonl"),
+            &[&format!(r#"{{"cwd":"{old_str}"}}"#)],
+        );
+        // ...newer one at the new path. Force a distinct mtime so the test
+        // is deterministic on filesystems with coarse-grained mtime
+        // resolution (e.g. FAT32 has 2s granularity).
+        let new_str = new_root.to_string_lossy().replace('\\', "\\\\");
+        let newer = dir.join("0002-new.jsonl");
+        write_jsonl(&newer, &[&format!(r#"{{"cwd":"{new_str}"}}"#)]);
+        // Force a distinct mtime so the test is deterministic on
+        // filesystems with coarse mtime resolution (FAT32 has 2s
+        // granularity). `File::set_modified` is stable since 1.75 and
+        // ClaudeScope's MSRV is 1.88.
+        let later = SystemTime::now() + std::time::Duration::from_secs(60);
+        let f = fs::OpenOptions::new().write(true).open(&newer).unwrap();
+        f.set_modified(later).unwrap();
+
+        let got = list_known_projects(Some(&home)).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].name, "new-name");
+    }
+}

--- a/src-tauri/tests/cli.rs
+++ b/src-tauri/tests/cli.rs
@@ -54,6 +54,23 @@ impl Sandbox {
         std::fs::read_to_string(self.home.join(".claude").join("settings.json")).unwrap()
     }
 
+    /// Seed a fake `~/.claude/projects/<encoded>/<session>.jsonl` referencing
+    /// `cwd_root`. The created root has a `.claude/` directory so it passes
+    /// the loadability filter in `projects::list_known_projects`.
+    fn seed_known_project(&self, encoded: &str, name: &str) -> PathBuf {
+        let cwd = self._tmp.path().join(name);
+        std::fs::create_dir_all(cwd.join(".claude")).unwrap();
+        let dir = self.home.join(".claude").join("projects").join(encoded);
+        std::fs::create_dir_all(&dir).unwrap();
+        let cwd_str = cwd.to_string_lossy().replace('\\', "\\\\");
+        std::fs::write(
+            dir.join("0001-session.jsonl"),
+            format!(r#"{{"sessionId":"s","cwd":"{cwd_str}"}}"#),
+        )
+        .unwrap();
+        cwd
+    }
+
     fn run(&self, args: &[&str]) -> Output {
         Command::new(BIN)
             .args([
@@ -263,4 +280,72 @@ fn version_flag_prints_crate_version() {
     // version-shaped trailer.
     assert!(s.starts_with("claude-scope-cli "));
     assert!(s.split_whitespace().nth(1).is_some());
+}
+
+#[test]
+fn list_projects_reports_empty_when_registry_missing() {
+    let sb = Sandbox::new();
+    // No `~/.claude/projects/` exists in the sandbox home.
+    let out = sb.run(&["list-projects"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    assert!(stdout(&out).contains("(no Claude projects discovered)"));
+}
+
+#[test]
+fn list_projects_lists_seeded_projects_sorted() {
+    let sb = Sandbox::new();
+    sb.seed_known_project("D--gamma", "gamma");
+    sb.seed_known_project("D--alpha", "alpha");
+    sb.seed_known_project("D--Beta", "Beta");
+
+    let out = sb.run(&["list-projects"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let s = stdout(&out);
+    // Each line: "<name>\t<root>". Pull names in output order and assert
+    // alphabetical (case-insensitive).
+    let names: Vec<&str> = s
+        .lines()
+        .filter(|l| !l.is_empty())
+        .filter_map(|l| l.split('\t').next())
+        .collect();
+    assert_eq!(names, vec!["alpha", "Beta", "gamma"]);
+}
+
+#[test]
+fn list_projects_json_shape_is_stable() {
+    let sb = Sandbox::new();
+    sb.seed_known_project("D--alpha", "alpha");
+
+    let out = sb.run(&["list-projects", "--json"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let v: serde_json::Value = serde_json::from_str(&stdout(&out)).expect("non-json stdout");
+    let arr = v["projects"].as_array().expect("projects array missing");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "alpha");
+    assert!(arr[0]["root"].as_str().unwrap().ends_with("alpha"));
+}
+
+#[test]
+fn list_projects_hides_stale_roots_with_no_dot_claude() {
+    let sb = Sandbox::new();
+    // Seed a transcript that points at a path with no `.claude/` —
+    // simulating a project that was deleted or never had Claude state.
+    let bogus = sb._tmp.path().join("stale-root");
+    std::fs::create_dir_all(&bogus).unwrap();
+    let dir = sb.home.join(".claude").join("projects").join("D--stale");
+    std::fs::create_dir_all(&dir).unwrap();
+    let cwd_str = bogus.to_string_lossy().replace('\\', "\\\\");
+    std::fs::write(dir.join("0001.jsonl"), format!(r#"{{"cwd":"{cwd_str}"}}"#)).unwrap();
+    // And a real one alongside so the test asserts filtering, not just
+    // emptiness.
+    sb.seed_known_project("D--real", "real");
+
+    let out = sb.run(&["list-projects"]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+    let s = stdout(&out);
+    assert!(s.contains("real"), "expected loadable project in output");
+    assert!(
+        !s.contains("stale-root"),
+        "stale root should be filtered out: {s}"
+    );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import type {
   AddLeafRequest,
   DeleteLeafPreview,
   DeleteLeafRequest,
+  KnownProject,
   LoadedScopes,
   MoveLeafPreview,
   MoveLeafRequest,
@@ -44,6 +45,7 @@ const state: {
   query: string;
   preferences: Preferences;
   runtime: RuntimeInfo;
+  knownProjects: KnownProject[];
 } = {
   scopes: null,
   projectDir: null,
@@ -54,6 +56,10 @@ const state: {
   // sandbox banner is simply omitted in that case, so a slow IPC boot
   // doesn't flash a misleading "Sandbox: …" line.
   runtime: { home_override: null, project_override: null },
+  // Populated by list_known_projects at bootstrap and refreshed when the
+  // user picks a new project (#106). Defaults to empty so the Move-to
+  // submenu degrades gracefully before the IPC resolves.
+  knownProjects: [],
 };
 
 // Set by the scopes-changed listener when it fires while another load or
@@ -70,6 +76,11 @@ async function load(projectDir: string | null): Promise<void> {
     const scopes = await invoke<LoadedScopes>("load_scopes", { project_dir: projectDir });
     state.scopes = scopes;
     state.projectDir = scopes.project_dir;
+    // Refresh the known-projects list alongside the scope load so the
+    // Move-to submenu reflects projects that appeared since launch (e.g.
+    // the user just ran Claude in a new directory). Tolerated failure:
+    // an empty list still lets all other UI work.
+    refreshKnownProjects();
   } catch (err) {
     alert(`Failed to load settings: ${err}`);
   } finally {
@@ -80,6 +91,17 @@ async function load(projectDir: string | null): Promise<void> {
       void load(state.projectDir);
     }
   }
+}
+
+function refreshKnownProjects(): void {
+  invoke<KnownProject[]>("list_known_projects")
+    .then((projects) => {
+      state.knownProjects = projects;
+      render();
+    })
+    .catch((err) => {
+      console.warn("failed to list known projects:", err);
+    });
 }
 
 // Guards against a second move flow starting while one is still running
@@ -383,6 +405,7 @@ function render(): void {
     query: state.query,
     preferences: state.preferences,
     runtime: state.runtime,
+    knownProjects: state.knownProjects,
     onPickProject: pickProject,
     onReload: reload,
     onMoveLeaf: moveLeaf,

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,3 +186,14 @@ export interface RuntimeInfo {
   home_override: string | null;
   project_override: string | null;
 }
+
+/**
+ * One Claude project discovered on this machine (#106). Mirrors Rust's
+ * `KnownProject`. `name` is the project root's basename; `root` is the
+ * absolute path. Used to populate the per-project section of the Move-to
+ * context-menu submenu.
+ */
+export interface KnownProject {
+  name: string;
+  root: string;
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -6,6 +6,7 @@ import type {
   DeleteLeafPreview,
   DeleteLeafRequest,
   JsonValue,
+  KnownProject,
   LoadedScopes,
   MoveLeafKind,
   MoveLeafPreview,
@@ -29,6 +30,12 @@ interface AppProps {
   query: string;
   preferences: Preferences;
   runtime: RuntimeInfo;
+  /** Every Claude project discovered on this machine (#106). Sourced from
+   *  the Rust backend's `list_known_projects` IPC; empty until that
+   *  resolves and after a discovery failure. The Move-to submenu folds the
+   *  current project in via `getKnownProjects` so the menu is never empty
+   *  even on a fresh install. */
+  knownProjects: KnownProject[];
   onPickProject: () => void;
   onReload: () => void;
   onMoveLeaf: (req: MoveLeafRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
@@ -48,20 +55,30 @@ interface AppProps {
 }
 
 /**
- * Stub for #106 (project discovery). Returns the list of known Claude
- * projects to populate the Move-to submenu — for v1, just the currently
- * loaded project. Replaced when #106 lands; keeping the indirection means
- * the menu rendering doesn't need to change at that point.
+ * Build the list of known Claude projects feeding the Move-to submenu.
+ * Sources from the backend's discovery (`props.knownProjects`) but always
+ * folds in the currently loaded project — so a freshly cloned repo with no
+ * transcripts yet still surfaces *somewhere* in the menu, and the user
+ * never has to leave-and-return to land the current project under their
+ * cursor.
  */
-function getKnownProjects(props: AppProps): { name: string; root: string }[] {
-  if (!props.projectDir) return [];
-  // Use the directory's basename (final path segment) as the display name.
-  // Handles both Windows back-slashes and POSIX forward-slashes so the
-  // label looks right regardless of the OS the loaded project lives on.
-  const root = props.projectDir;
-  const sepIdx = Math.max(root.lastIndexOf("/"), root.lastIndexOf("\\"));
-  const name = sepIdx >= 0 ? root.slice(sepIdx + 1) || root : root;
-  return [{ name, root }];
+function getKnownProjects(props: AppProps): KnownProject[] {
+  const merged: KnownProject[] = [...props.knownProjects];
+  if (props.projectDir) {
+    const root = props.projectDir;
+    const sepIdx = Math.max(root.lastIndexOf("/"), root.lastIndexOf("\\"));
+    const name = sepIdx >= 0 ? root.slice(sepIdx + 1) || root : root;
+    // Case-insensitive de-dupe against the backend list. On Windows the
+    // discovery side's path may differ in case from the picker's, but they
+    // refer to the same directory; surfacing both would put two identical
+    // entries side-by-side in the submenu.
+    const norm = root.toLowerCase();
+    if (!merged.some((p) => p.root.toLowerCase() === norm)) {
+      merged.push({ name, root });
+    }
+  }
+  merged.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+  return merged;
 }
 
 const PERMISSION_KINDS: ReadonlyArray<PermissionKind> = ["allow", "deny", "ask"];

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { MoveLeafRequest, MoveOptions, Scope, Theme } from "../../src/types.ts";
+import type { KnownProject, MoveLeafRequest, MoveOptions, Scope, Theme } from "../../src/types.ts";
 import { SEARCH_INPUT_ID } from "../../src/types.ts";
 import { openSettings, renderApp } from "../../src/ui.ts";
 import { buildLoadedScopes, buildPreferences, buildRuntimeInfo } from "../fixtures/loadedScopes.ts";
@@ -22,6 +22,7 @@ interface PropsOverrides {
   query?: string;
   preferences?: ReturnType<typeof buildPreferences>;
   runtime?: ReturnType<typeof buildRuntimeInfo>;
+  knownProjects?: KnownProject[];
   onMoveLeaf?: (req: MoveLeafRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
 }
 
@@ -41,6 +42,7 @@ function makeProps(overrides: PropsOverrides = {}) {
     query: overrides.query ?? "",
     preferences: overrides.preferences ?? buildPreferences(),
     runtime: overrides.runtime ?? buildRuntimeInfo(),
+    knownProjects: overrides.knownProjects ?? [],
     onPickProject: vi.fn(),
     onReload: vi.fn(),
     onMoveLeaf: overrides.onMoveLeaf ?? vi.fn(),
@@ -315,6 +317,39 @@ describe("context menu (#8)", () => {
     expect(moveItems).toContain("User");
     expect(moveItems).toContain("User-Local");
     expect(moveItems).toContain("myproject");
+  });
+
+  it("merges backend-discovered projects with the current project in the Move-to submenu", () => {
+    const scopes = buildLoadedScopes({
+      scopes: [{ scope: "project", permissions: { allow: ["Bash(git status)"] } }],
+      project_dir: "/tmp/myproject",
+    });
+    renderApp(
+      root,
+      makeProps({
+        scopes,
+        knownProjects: [
+          { name: "other-repo", root: "/tmp/other-repo" },
+          // Same path as the loaded project — `getKnownProjects` should
+          // dedupe so the entry doesn't appear twice in the submenu.
+          { name: "myproject", root: "/tmp/myproject" },
+        ],
+      }),
+    );
+    const ruleRow = root.querySelector<HTMLElement>(".rule.rule-allow");
+    if (!ruleRow) throw new Error("expected rule row");
+    rightClick(ruleRow);
+    findMenuItem("Move to")?.click();
+    const menus = document.querySelectorAll<HTMLElement>(".context-menu");
+    const moveItems = Array.from(
+      menus[1].querySelectorAll<HTMLButtonElement>(".context-menu-item"),
+    ).map((b) => b.textContent?.replace(/\s*▸$/, "").trim() ?? "");
+    // Both projects show up, exactly once each, and the global scopes are
+    // still present above the divider.
+    expect(moveItems).toContain("User");
+    expect(moveItems).toContain("User-Local");
+    expect(moveItems.filter((l) => l === "myproject")).toHaveLength(1);
+    expect(moveItems).toContain("other-repo");
   });
 
   it("closes the context menu on Escape", () => {


### PR DESCRIPTION
## Summary

Closes #106. The Move-to context-menu submenu (#8) now lists every Claude project on the machine, not just the currently loaded one.

- **Discovery via the transcript registry.** `~/.claude/projects/<encoded>/` is the source of truth; the encoded directory names are lossy on Windows so we read the original absolute path from the first `cwd`-bearing record in the newest `.jsonl`. No new on-disk format invented.
- **Three layers, one primitive.** New `projects` lib module → `list_known_projects` Tauri command (sandbox-aware via `RuntimeOverrides::home`) → `claude-scope-cli list-projects [--json]` subcommand. GUI and CLI consume the same impl.
- **Frontend.** `state.knownProjects` is refreshed alongside every scope load. `getKnownProjects` merges the backend list with the currently loaded project (case-insensitive de-dupe, alphabetical sort) so a freshly cloned repo without transcripts still surfaces.

## Filters & ordering (per the issue)

- Missing `~/.claude/projects/` is not an error.
- Roots whose `.claude/` no longer exists are dropped silently.
- Newest transcript wins per encoded dir, so a path rename takes effect on the next session.
- De-dupe by canonicalized root, then sort alphabetically (case-insensitive).

## Tests

- **9 Rust unit tests** covering the bounded prelude scan, missing-`.claude` filter, deleted-directory filter, no-cwd transcripts, alphabetical sort, dedupe, newest-wins, and the nested-uuid-dir gotcha that real Claude Code transcripts hit.
- **4 CLI integration tests** asserting empty output / sort order / JSON shape stability / stale-root filtering through the compiled binary.
- **1 new UI test** asserting the Move-to submenu's merge + dedupe between backend list and current project.

Smoke-tested locally against my real `~/.claude/projects/` (10+ projects discovered, all paths resolve).

## Follow-ups

- #111 — filter the discovered list by recency / session count / keywords. Filed in this session; deferred from v1 per the issue's "cheapest and least surprising" guidance.

## Test plan

- [ ] `cargo test` passes on Linux (CI) — the `scope::tests` Windows-local flakes don't apply.
- [ ] `cargo test --test cli` passes on all three platforms.
- [ ] `npx vitest run` passes.
- [ ] Manual: right-click a permission rule on a fresh checkout → "Move to" submenu lists multiple projects, current project appears exactly once.
- [ ] Manual: `claude-scope-cli list-projects` and `--json` against real `~/.claude/projects/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)