### PR TITLE
feat: opt-out preference for .bak file creation (#88)

### DIFF
--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -538,7 +538,12 @@ fn cmd_move(
         return Ok(());
     }
 
-    apply_move_leaf_impl(paths, &req, &BackupTracker::new(), &WatchState::default())?;
+    apply_move_leaf_impl(
+        paths,
+        &req,
+        Some(&BackupTracker::new()),
+        &WatchState::default(),
+    )?;
 
     if json {
         let out = json!({

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -26,6 +26,22 @@ fn backups() -> &'static BackupTracker {
     BACKUPS.get_or_init(BackupTracker::new)
 }
 
+/// Resolve which backup-tracker (if any) a write command should pass into
+/// the impl. Reads `Preferences::backup_on_write` on every call so a
+/// toggle in the Settings dialog takes effect on the very next write
+/// without needing a restart or in-memory cache invalidation. Read costs
+/// one small JSON parse; negligible against the rest of the write path.
+/// Defaults to `Some(backups())` when the preferences file is missing or
+/// malformed — the load helper itself collapses to defaults in that
+/// case (#88).
+fn backups_for_session() -> Option<&'static BackupTracker> {
+    if preferences::load().backup_on_write {
+        Some(backups())
+    } else {
+        None
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct ScopeView {
     pub scope: Scope,
@@ -241,7 +257,7 @@ pub fn apply_move_leaf(
 ) -> Result<(), String> {
     let paths =
         resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
-    apply_move_leaf_impl(&paths, &req, backups(), &watch).map_err(|e| e.to_string())
+    apply_move_leaf_impl(&paths, &req, backups_for_session(), &watch).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -264,7 +280,7 @@ pub fn apply_delete_leaf(
 ) -> Result<(), String> {
     let paths =
         resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
-    apply_delete_leaf_impl(&paths, &req, backups(), &watch).map_err(|e| e.to_string())
+    apply_delete_leaf_impl(&paths, &req, backups_for_session(), &watch).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -287,7 +303,7 @@ pub fn apply_add_leaf(
 ) -> Result<(), String> {
     let paths =
         resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
-    apply_add_leaf_impl(&paths, &req, backups(), &watch).map_err(|e| e.to_string())
+    apply_add_leaf_impl(&paths, &req, backups_for_session(), &watch).map_err(|e| e.to_string())
 }
 
 /// Snapshot of the launch-time overrides — the front-end uses this to
@@ -791,7 +807,7 @@ fn diff_change_kind_same_scope(
 pub fn apply_move_leaf_impl(
     paths: &ScopePaths,
     req: &MoveLeafRequest,
-    backups: &BackupTracker,
+    backups: Option<&BackupTracker>,
     watch: &WatchState,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let movable = validate_movable_path(&req.path)?;
@@ -900,7 +916,7 @@ fn apply_change_kind_same_scope(
     paths: &ScopePaths,
     req: &MoveLeafRequest,
     movable: &MovablePath<'_>,
-    backups: &BackupTracker,
+    backups: Option<&BackupTracker>,
     watch: &WatchState,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let path = require_path(paths, req.from)?.to_path_buf();
@@ -1014,7 +1030,7 @@ fn diff_delete_leaf_impl(
 fn apply_delete_leaf_impl(
     paths: &ScopePaths,
     req: &DeleteLeafRequest,
-    backups: &BackupTracker,
+    backups: Option<&BackupTracker>,
     watch: &WatchState,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let movable = validate_movable_path(&req.path)?;
@@ -1092,7 +1108,7 @@ fn diff_add_leaf_impl(
 fn apply_add_leaf_impl(
     paths: &ScopePaths,
     req: &AddLeafRequest,
-    backups: &BackupTracker,
+    backups: Option<&BackupTracker>,
     watch: &WatchState,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _movable = validate_movable_path(&req.path)?;
@@ -1506,7 +1522,7 @@ mod tests {
                 to: Scope::User,
                 to_kind: None,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -1526,6 +1542,59 @@ mod tests {
             user_doc.permissions().allow,
             vec!["Bash(git status)".to_string()]
         );
+    }
+
+    #[test]
+    fn apply_move_leaf_with_none_backups_writes_without_creating_bak() {
+        // #88: when the user opts out of `.bak` files via Preferences, the
+        // command handler passes `None` into the impl. Verify both that the
+        // write still lands AND that no sibling `.bak` is created — the
+        // latter is the whole point of the opt-out.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        write(
+            paths.project.as_ref().unwrap(),
+            r#"{"permissions":{"allow":["Bash(git status)"]}}"#,
+        );
+        write(
+            paths.user.as_ref().unwrap(),
+            r#"{"permissions":{"allow":[]}}"#,
+        );
+
+        apply_move_leaf_impl(
+            &paths,
+            &MoveLeafRequest {
+                path: vec![key("permissions"), key("allow"), idx(0)],
+                from: Scope::Project,
+                to: Scope::User,
+                to_kind: None,
+            },
+            None,
+            &WatchState::default(),
+        )
+        .unwrap();
+
+        // Move landed on both sides.
+        let project_doc = io_atomic::load(paths.project.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert!(project_doc.permissions().allow.is_empty());
+        let user_doc = io_atomic::load(paths.user.as_ref().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            user_doc.permissions().allow,
+            vec!["Bash(git status)".to_string()]
+        );
+
+        // No `.bak` for either file. Probing both because the move writes to
+        // *both* the source and destination scopes, and a regression on
+        // either arm would silently re-introduce the clutter the pref opts
+        // out of.
+        let project_bak = paths.project.as_ref().unwrap().with_extension("json.bak");
+        let user_bak = paths.user.as_ref().unwrap().with_extension("json.bak");
+        assert!(!project_bak.exists(), "expected no .bak at {project_bak:?}");
+        assert!(!user_bak.exists(), "expected no .bak at {user_bak:?}");
     }
 
     #[test]
@@ -1552,7 +1621,7 @@ mod tests {
                 to: Scope::User,
                 to_kind: None,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -1595,7 +1664,7 @@ mod tests {
                 to: Scope::User,
                 to_kind: None,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -1641,7 +1710,7 @@ mod tests {
                 to: Scope::User,
                 to_kind: None,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -1690,7 +1759,7 @@ mod tests {
                 to: Scope::User,
                 to_kind: None,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -1771,7 +1840,7 @@ mod tests {
                 to: Scope::User,
                 to_kind: None,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap_err();
@@ -1791,7 +1860,7 @@ mod tests {
                 to: Scope::Project,
                 to_kind: None,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap_err();
@@ -1811,7 +1880,7 @@ mod tests {
                 to: Scope::User,
                 to_kind: None,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap_err();
@@ -1841,7 +1910,7 @@ mod tests {
                 to: Scope::Project,
                 to_kind: Some(PermissionKind::Deny),
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -1876,7 +1945,7 @@ mod tests {
                 to: Scope::Project,
                 to_kind: Some(PermissionKind::Deny),
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -1910,7 +1979,7 @@ mod tests {
                 to: Scope::User,
                 to_kind: Some(PermissionKind::Deny),
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -1946,7 +2015,7 @@ mod tests {
                 to: Scope::Project,
                 to_kind: Some(PermissionKind::Allow),
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap_err();
@@ -1972,7 +2041,7 @@ mod tests {
                 to: Scope::User,
                 to_kind: Some(PermissionKind::Deny),
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap_err();
@@ -1986,7 +2055,7 @@ mod tests {
                 to: Scope::User,
                 to_kind: Some(PermissionKind::Allow),
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap_err();
@@ -2046,7 +2115,7 @@ mod tests {
                 path: vec![key("permissions"), key("allow"), idx(0)],
                 from: Scope::Project,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -2075,7 +2144,7 @@ mod tests {
                 path: vec![key("permissions"), key("allow"), idx(0)],
                 from: Scope::Project,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -2101,7 +2170,7 @@ mod tests {
                 path: vec![key("theme")],
                 from: Scope::Project,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -2124,7 +2193,7 @@ mod tests {
                 path: vec![key("permissions"), key("allow"), idx(0)],
                 from: Scope::Project,
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap_err();
@@ -2181,7 +2250,7 @@ mod tests {
                 to: Scope::User,
                 value: serde_json::json!("WebFetch(domain:evil.example)"),
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -2213,7 +2282,7 @@ mod tests {
                 to: Scope::User,
                 value: serde_json::json!("Bash(ls)"),
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();
@@ -2245,7 +2314,7 @@ mod tests {
                 to: Scope::User,
                 value: serde_json::json!("Bash(ls)"),
             },
-            &BackupTracker::new(),
+            Some(&BackupTracker::new()),
             &WatchState::default(),
         )
         .unwrap();

--- a/src-tauri/src/io_atomic.rs
+++ b/src-tauri/src/io_atomic.rs
@@ -188,21 +188,26 @@ pub fn load_with_stamp(path: &Path) -> Result<(Option<SettingsDoc>, FileStamp), 
     ))
 }
 
-/// Atomic write with revalidation and one-time-per-session backup.
+/// Atomic write with revalidation and (optionally) a one-time-per-session
+/// backup.
 ///
 /// Convenience wrapper that renders a [`SettingsDoc`] and routes the bytes
-/// through [`atomic_write_json`] with backups enabled. `expected` carries
-/// the [`FileStamp`] the caller captured at load time so a concurrent edit
-/// is detected and refused — pass `None` to skip the check (e.g. on a
-/// rollback path where the app is the canonical writer).
+/// through [`atomic_write_json`]. `backups` is `Some(_)` for user-data files
+/// where a one-shot recovery copy is worth the surprise of an extra file on
+/// disk; `None` opts out of the `.bak` (#88) — both the user preference and
+/// callers like `preferences::save` (for ClaudeScope-owned config files)
+/// use this arm. `expected` carries the [`FileStamp`] the caller captured
+/// at load time so a concurrent edit is detected and refused — pass `None`
+/// to skip the check (e.g. on a rollback path where the app is the
+/// canonical writer).
 pub fn save(
     path: &Path,
     doc: &SettingsDoc,
-    backups: &BackupTracker,
+    backups: Option<&BackupTracker>,
     expected: Option<&FileStamp>,
 ) -> Result<(), IoError> {
     let rendered = doc.render();
-    atomic_write_json(path, rendered.as_bytes(), Some(backups), expected)
+    atomic_write_json(path, rendered.as_bytes(), backups, expected)
 }
 
 /// The single chokepoint every write path in the app must use.
@@ -405,14 +410,14 @@ mod tests {
 
         let backups = BackupTracker::new();
         let doc = load(&path).unwrap().unwrap();
-        save(&path, &doc, &backups, None).unwrap();
+        save(&path, &doc, Some(&backups), None).unwrap();
 
         let bak = path.with_file_name("settings.json.bak");
         assert!(bak.exists(), "first save should create .bak");
 
         // Second save should not update the .bak.
         let bak_mtime = std::fs::metadata(&bak).unwrap().modified().unwrap();
-        save(&path, &doc, &backups, None).unwrap();
+        save(&path, &doc, Some(&backups), None).unwrap();
         let bak_mtime2 = std::fs::metadata(&bak).unwrap().modified().unwrap();
         assert_eq!(bak_mtime, bak_mtime2);
     }
@@ -428,7 +433,7 @@ mod tests {
 
         let backups = BackupTracker::new();
         let doc = load(&path).unwrap().unwrap();
-        save(&path, &doc, &backups, None).unwrap();
+        save(&path, &doc, Some(&backups), None).unwrap();
 
         let bak_contents = std::fs::read_to_string(&bak).unwrap();
         assert!(

--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -46,6 +46,13 @@ pub struct Preferences {
     /// `Light`/`Dark` pin the palette regardless of OS preference.
     #[serde(default, deserialize_with = "deserialize_theme")]
     pub theme: Theme,
+    /// Whether to drop a `.bak` next to a settings file on the first write
+    /// per session (#88). Default `true` — silently dropping the safety net
+    /// for existing users would be a worse default than minor clutter for
+    /// the users who opt out. When `false`, command handlers pass `None`
+    /// into `io_atomic::save` and the existing no-backup arm runs.
+    #[serde(default = "default_backup_on_write")]
+    pub backup_on_write: bool,
 }
 
 impl Default for Preferences {
@@ -53,12 +60,17 @@ impl Default for Preferences {
         Self {
             visible_scopes: default_visible_scopes(),
             theme: Theme::default(),
+            backup_on_write: default_backup_on_write(),
         }
     }
 }
 
 fn default_visible_scopes() -> Vec<Scope> {
     Scope::ALL.to_vec()
+}
+
+fn default_backup_on_write() -> bool {
+    true
 }
 
 /// Normalize a `visible_scopes` list: dedupe, reorder to match `Scope::ALL`,
@@ -208,6 +220,7 @@ mod tests {
         let prefs = Preferences {
             visible_scopes: vec![Scope::Local, Scope::Project],
             theme: Theme::Light,
+            backup_on_write: false,
         };
         let json = serde_json::to_string(&prefs).unwrap();
         let parsed: Preferences = serde_json::from_str(&json).unwrap();
@@ -234,6 +247,7 @@ mod tests {
             let prefs = Preferences {
                 visible_scopes: default_visible_scopes(),
                 theme,
+                backup_on_write: true,
             };
             let json = serde_json::to_string(&prefs).unwrap();
             let parsed: Preferences = serde_json::from_str(&json).unwrap();
@@ -257,11 +271,37 @@ mod tests {
         let prefs = Preferences {
             visible_scopes: default_visible_scopes(),
             theme: Theme::Dark,
+            backup_on_write: true,
         };
         let json = serde_json::to_string(&prefs).unwrap();
         // The JS side reads this string verbatim — pinning the casing
         // here keeps the IPC contract from drifting silently.
         assert!(json.contains(r#""theme":"dark""#));
+    }
+
+    #[test]
+    fn backup_on_write_defaults_to_true() {
+        // Default constructor (the load-path fallback) must keep the
+        // existing safety behavior so a fresh install or unreadable config
+        // doesn't silently regress to no-backup writes.
+        let prefs = Preferences::default();
+        assert!(prefs.backup_on_write);
+    }
+
+    #[test]
+    fn backup_on_write_missing_field_defaults_to_true() {
+        // Older configs predate the field; missing key must collapse to
+        // the safe default, not deserialize as `false` (the bool default).
+        let prefs: Preferences = serde_json::from_str(r#"{"visible_scopes":["project"]}"#).unwrap();
+        assert!(prefs.backup_on_write);
+    }
+
+    #[test]
+    fn backup_on_write_explicit_false_survives_round_trip() {
+        let prefs: Preferences = serde_json::from_str(r#"{"backup_on_write":false}"#).unwrap();
+        assert!(!prefs.backup_on_write);
+        let json = serde_json::to_string(&prefs).unwrap();
+        assert!(json.contains(r#""backup_on_write":false"#));
     }
 
     /// Exercise the save path against a real filesystem so the
@@ -277,6 +317,7 @@ mod tests {
         let first = Preferences {
             visible_scopes: vec![Scope::Local],
             theme: Theme::Auto,
+            backup_on_write: true,
         };
         let body = serde_json::to_vec_pretty(&first).unwrap();
         let parent = target.parent().unwrap();
@@ -291,6 +332,7 @@ mod tests {
         let second = Preferences {
             visible_scopes: vec![Scope::Project, Scope::User],
             theme: Theme::Dark,
+            backup_on_write: false,
         };
         let body2 = serde_json::to_vec_pretty(&second).unwrap();
         let mut tmpfile2 = tempfile::NamedTempFile::new_in(parent).unwrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import {
 const DEFAULT_PREFERENCES: Preferences = {
   visible_scopes: [...SCOPES],
   theme: "auto",
+  backup_on_write: true,
 };
 
 const state: {
@@ -391,12 +392,18 @@ function onChangeTheme(theme: Theme): void {
   void persistPreferences({ ...state.preferences, theme });
 }
 
+function onToggleBackupOnWrite(enabled: boolean): void {
+  if (state.preferences.backup_on_write === enabled) return;
+  void persistPreferences({ ...state.preferences, backup_on_write: enabled });
+}
+
 function onOpenSettings(trigger?: HTMLElement): void {
   void openSettings(
     {
       preferences: state.preferences,
       onToggleScopeVisibility,
       onChangeTheme,
+      onToggleBackupOnWrite,
     },
     trigger,
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,11 @@ export type Theme = "auto" | "light" | "dark";
 export interface Preferences {
   visible_scopes: Scope[];
   theme: Theme;
+  /** Whether to drop a `.bak` next to every settings file on the first
+   *  write per session (#88). Default `true` on a fresh install — older
+   *  configs without the field also default to `true` server-side, so the
+   *  frontend can read it as a plain `boolean` here. */
+  backup_on_write: boolean;
 }
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2226,6 +2226,10 @@ interface SettingsProps {
   preferences: Preferences;
   onToggleScopeVisibility: (scope: Scope, visible: boolean) => void;
   onChangeTheme: (theme: Theme) => void;
+  /** Toggle `.bak` creation on writes (#88). Same persist-on-click model
+   *  as the other settings — the new pref hits the backend immediately so
+   *  the very next move respects it without a dialog round-trip. */
+  onToggleBackupOnWrite: (enabled: boolean) => void;
 }
 
 const THEME_OPTIONS: ReadonlyArray<{ value: Theme; label: string }> = [
@@ -2250,6 +2254,7 @@ export function openSettings(props: SettingsProps, trigger?: HTMLElement | null)
   const body = document.createElement("div");
   body.appendChild(settingsThemeSection(props));
   body.appendChild(settingsColumnsSection(props));
+  body.appendChild(settingsBackupSection(props));
 
   openModal({
     titleText: "Settings",
@@ -2356,6 +2361,48 @@ function settingsColumnsSection(props: SettingsProps): HTMLElement {
     row.appendChild(label);
     list.appendChild(row);
   }
+  section.appendChild(list);
+  return section;
+}
+
+/**
+ * Backup toggle section in the Settings dialog (#88). One checkbox,
+ * persisted on click via the same `onToggleBackupOnWrite` callback the
+ * other settings rows use. The hint copy spells out *why* the safety
+ * exists so a user who's about to flip it sees the trade-off before
+ * removing the net — recoverability from a misclicked move.
+ */
+function settingsBackupSection(props: SettingsProps): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "settings-section";
+
+  const heading = document.createElement("h3");
+  heading.id = "settings-backup-heading";
+  heading.className = "settings-heading";
+  heading.textContent = "Backups";
+  section.appendChild(heading);
+
+  const hint = document.createElement("p");
+  hint.className = "settings-hint";
+  hint.textContent =
+    "On the first write of each session, ClaudeScope can drop a `.bak` next to each settings file. Disable if your `.claude/` directory is version-controlled or you don't want the extra files.";
+  section.appendChild(hint);
+
+  const list = document.createElement("div");
+  list.className = "settings-checklist";
+  const row = document.createElement("label");
+  row.className = "settings-check";
+  const cb = document.createElement("input");
+  cb.type = "checkbox";
+  cb.checked = props.preferences.backup_on_write;
+  cb.addEventListener("change", () => {
+    props.onToggleBackupOnWrite(cb.checked);
+  });
+  row.appendChild(cb);
+  const label = document.createElement("span");
+  label.textContent = "Create `.bak` files on save";
+  row.appendChild(label);
+  list.appendChild(row);
   section.appendChild(list);
   return section;
 }

--- a/test/fixtures/loadedScopes.ts
+++ b/test/fixtures/loadedScopes.ts
@@ -154,6 +154,7 @@ export function buildPreferences(overrides: Partial<Preferences> = {}): Preferen
   return {
     visible_scopes: overrides.visible_scopes ?? [...SCOPES],
     theme: overrides.theme ?? "auto",
+    backup_on_write: overrides.backup_on_write ?? true,
   };
 }
 

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -490,6 +490,7 @@ describe("openSettings – theme radios", () => {
       preferences: buildPreferences({ theme }),
       onToggleScopeVisibility: vi.fn(),
       onChangeTheme,
+      onToggleBackupOnWrite: vi.fn(),
     };
   }
 
@@ -533,5 +534,49 @@ describe("openSettings – theme radios", () => {
     expect(group).not.toBeNull();
     const heading = document.getElementById("settings-theme-heading");
     expect(heading?.textContent).toBe("Theme");
+  });
+});
+
+describe("openSettings – backup toggle (#88)", () => {
+  afterEach(() => {
+    clearBody();
+  });
+
+  function backupCheckbox(): HTMLInputElement {
+    const heading = document.getElementById("settings-backup-heading");
+    if (!heading) throw new Error("expected backup section heading");
+    const section = heading.parentElement;
+    if (!section) throw new Error("expected backup section parent");
+    const cb = section.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    if (!cb) throw new Error("expected backup checkbox");
+    return cb;
+  }
+
+  it("reflects the current preference value on render", () => {
+    for (const enabled of [true, false]) {
+      clearBody();
+      openSettings({
+        preferences: buildPreferences({ backup_on_write: enabled }),
+        onToggleScopeVisibility: vi.fn(),
+        onChangeTheme: vi.fn(),
+        onToggleBackupOnWrite: vi.fn(),
+      });
+      expect(backupCheckbox().checked).toBe(enabled);
+    }
+  });
+
+  it("calls onToggleBackupOnWrite with the new value when the checkbox is changed", () => {
+    const onToggleBackupOnWrite = vi.fn();
+    openSettings({
+      preferences: buildPreferences({ backup_on_write: true }),
+      onToggleScopeVisibility: vi.fn(),
+      onChangeTheme: vi.fn(),
+      onToggleBackupOnWrite,
+    });
+    const cb = backupCheckbox();
+    cb.checked = false;
+    cb.dispatchEvent(new Event("change"));
+    expect(onToggleBackupOnWrite).toHaveBeenCalledTimes(1);
+    expect(onToggleBackupOnWrite).toHaveBeenCalledWith(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes #88. Adds a Settings checkbox so users with version-controlled `.claude/` directories (or anyone who finds the per-write `.bak` files clutter) can turn the safety net off without editing source. Default stays `true` — silently dropping the recovery file would be a worse default than minor clutter.

## How the toggle reaches the writer

- New `Preferences.backup_on_write: bool` with `#[serde(default = "default_backup_on_write")]` so older configs without the field still load as `true`.
- `io_atomic::save` accepts `Option<&BackupTracker>` directly (the underlying `atomic_write_json` already did), and the three `apply_*_impl` writers + the CLI thread the Option through.
- New `commands::backups_for_session()` reads `preferences::load().backup_on_write` on every write call and yields `Some(backups())` or `None`. Reading the pref each time (instead of caching) costs one small JSON parse and means a Settings toggle takes effect on the next write with no in-memory invalidation.
- Frontend wires `onToggleBackupOnWrite` through `persistPreferences` like the existing column-visibility and theme settings.

## Tests

- **3 new Rust serde tests** pin the schema contract: default true, missing field defaults to true, explicit `false` survives round-trip.
- **1 new Rust integration test** drives `apply_move_leaf_impl(... None ...)` end-to-end and asserts the move lands on both scopes while no sibling `.bak` is created.
- **2 new UI tests** assert the Settings checkbox reflects the current pref (both branches) and that flipping it calls `onToggleBackupOnWrite` with the new value.

Existing test count unchanged elsewhere — 164 lib tests still pass (2 known Windows-local `scope::tests` flakes are unrelated), 27 vitest tests pass.

## Decisions made

- **Read pref every write vs. cache it**: reading every time is cheap and lets the toggle take effect on the next write without an explicit cache invalidation. The "read once at session start" alternative would force the user to restart for the change to take effect — worse UX for no real perf win.
- **`Option<&BackupTracker>` vs. an `enabled` flag on `BackupTracker`**: matches the issue's preferred seam (no new code paths in `io_atomic`) and aligns with `atomic_write_json`'s existing signature.
- **CLI behavior**: stays hard-wired to `Some(&BackupTracker::new())` — the CLI is single-shot, doesn't read the preferences file, and the per-process tracker semantics don't apply there.

## Out of scope (per the issue)

- Per-scope or per-file overrides.
- `.gitignore`-aware auto-suppression.
- Retention policies for old `.bak` files.

## Test plan

- [ ] `cargo test --lib` passes on Linux/macOS in CI.
- [ ] `npx vitest run` passes.
- [ ] Manual: toggle the new "Create `.bak` files on save" checkbox off, perform a rule move, confirm no `.bak` lands next to the touched settings files.
- [ ] Manual: toggle back on, perform a move on a *different* settings file (one not yet backed up this session), confirm the `.bak` appears.
- [ ] Manual: edit `~/.config/claude-scope/config.json` to omit the field entirely, restart, confirm Settings shows the checkbox as checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)