### PR TITLE
feat: collapse like permissions under a tool prefix (#68)

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -140,6 +140,92 @@ function matchesLoweredQuery(rule: string, lowerQuery: string): boolean {
   return rule.toLowerCase().includes(lowerQuery);
 }
 
+/**
+ * Threshold above which a tool's rules collapse under a synthetic group
+ * node in the per-scope tree view (#68). At 2, two rules sharing a tool
+ * (e.g. `handoff(copilot *)` + `handoff(claude *)`) fold together. A future
+ * Settings option (#115) will parameterize this; for now it's the single
+ * compile-time knob the grouping helper reads.
+ */
+const TOOL_GROUP_THRESHOLD = 2;
+
+/**
+ * Entry in the per-kind rule list after grouping. `Single` keeps the
+ * original index so the leaf's path stays addressable; `Group` carries
+ * every member's index so the children can each rebuild their path.
+ *
+ * Children inside a group preserve their original disk index in `members`
+ * — the backend still addresses rules by their position in the on-disk
+ * array, and the UI grouping is purely visual.
+ */
+export type GroupedRuleEntry =
+  | { kind: "single"; index: number; rule: string }
+  | { kind: "group"; tool: string; members: Array<{ index: number; rule: string }> };
+
+/**
+ * Group a flat permission-rule list by the `Tool` prefix in each
+ * `Tool(args)` rule. Rules that don't match `Tool(...)` syntax (no
+ * parentheses, or anything else the regex misses) stay flat as singles.
+ *
+ * Order rule: emit each tool's group at the position of its first member,
+ * absorb later members silently. Singles emit at their original position.
+ * That preserves the user's top-down reading order — a rule never moves
+ * past a sibling that came after it on disk.
+ *
+ * Single-member "groups" collapse back to a `Single` entry so a tool with
+ * only one rule doesn't render a one-child fold.
+ */
+export function groupByToolPrefix(
+  rules: string[],
+  threshold: number = TOOL_GROUP_THRESHOLD,
+): GroupedRuleEntry[] {
+  // First pass: count rules per tool so the second pass knows whether a
+  // tool meets the threshold without rescanning the tail of the list each
+  // time it sees a member.
+  const counts = new Map<string, number>();
+  const tools: Array<string | null> = rules.map((rule) => {
+    const tool = toolPrefixOf(rule);
+    if (tool !== null) counts.set(tool, (counts.get(tool) ?? 0) + 1);
+    return tool;
+  });
+
+  const emitted = new Set<string>();
+  const out: GroupedRuleEntry[] = [];
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+    const tool = tools[i];
+    if (tool === null || (counts.get(tool) ?? 0) < threshold) {
+      out.push({ kind: "single", index: i, rule });
+      continue;
+    }
+    if (emitted.has(tool)) continue;
+    emitted.add(tool);
+    const members: Array<{ index: number; rule: string }> = [];
+    for (let j = i; j < rules.length; j++) {
+      if (tools[j] === tool) members.push({ index: j, rule: rules[j] });
+    }
+    out.push({ kind: "group", tool, members });
+  }
+  return out;
+}
+
+/**
+ * Extract the `Tool` part of a `Tool(args)` rule. Returns null when the
+ * rule doesn't have a `(` (malformed or shorthand the lint flags), so the
+ * caller falls back to rendering it as a plain single.
+ *
+ * Whitespace-tolerant on either side of the `(` to match the lint's
+ * permissive parsing — we'd rather group `handoff (copilot *)` with the
+ * rest of the handoff family than orphan it on a literal whitespace
+ * mismatch.
+ */
+function toolPrefixOf(rule: string): string | null {
+  const paren = rule.indexOf("(");
+  if (paren <= 0) return null;
+  const tool = rule.slice(0, paren).trim();
+  return tool === "" ? null : tool;
+}
+
 const SCOPE_LABELS: Record<Scope, string> = {
   local: "Local",
   project: "Project",
@@ -641,7 +727,18 @@ function seedDefaultOpenPermissions(loaded: LoadedScopes): void {
       // is just visual noise on a fresh project load. The user can still
       // open it manually if they want to add rules.
       if (Array.isArray(arr) && arr.length > 0) {
-        openTreeNodes.add(treeKey(view.scope, ["permissions", kind]));
+        const kindPath: PathSeg[] = ["permissions", kind];
+        openTreeNodes.add(treeKey(view.scope, kindPath));
+        // Seed open state for tool groups (#68) so the synthetic
+        // `<details>` nodes inside an already-open permissions branch
+        // start expanded — users opened the kind branch to read its
+        // rules, so collapsed groups would just hide them again.
+        const ruleStrings = arr.map((v) => (typeof v === "string" ? v : ""));
+        for (const entry of groupByToolPrefix(ruleStrings)) {
+          if (entry.kind === "group") {
+            openTreeNodes.add(treeKey(view.scope, [...kindPath, "__group__", entry.tool]));
+          }
+        }
       }
     }
   }
@@ -774,12 +871,18 @@ function treeBranch(
     if (populated) return;
     populated = true;
     if (Array.isArray(value)) {
-      value.forEach((child, i) => {
-        // Permission rule arrays carry their kind via the parent path; child
-        // construction passes `props` and `lowerQuery` through so the leaf
-        // gets its move buttons + drag + lint badge + filter test.
-        children.appendChild(treeNode(scope, [...path, i], `[${i}]`, child, props, lowerQuery));
-      });
+      // Permission-list arrays (`permissions.<kind>`) collapse rules that
+      // share a `Tool(...)` prefix under synthetic group nodes (#68). Non-
+      // permission arrays fall through to the unchanged flat iteration so
+      // `env` / `hooks` / arbitrary user keys keep today's shape.
+      const isPermissionList = permKind !== null && path.length === 2;
+      if (isPermissionList) {
+        populatePermissionList(scope, path, value, children, props, lowerQuery);
+      } else {
+        value.forEach((child, i) => {
+          children.appendChild(treeNode(scope, [...path, i], `[${i}]`, child, props, lowerQuery));
+        });
+      }
     } else {
       for (const [k, v] of Object.entries(value)) {
         children.appendChild(treeNode(scope, [...path, k], k, v, props, lowerQuery));
@@ -793,6 +896,148 @@ function treeBranch(
   // first render per project, so the unified tree starts in the same
   // shape as the old single-pane view; subsequent renders defer to
   // whatever the user toggled.
+  if (openTreeNodes.has(key)) {
+    details.open = true;
+    populate();
+  }
+  details.addEventListener("toggle", () => {
+    if (details.open) {
+      openTreeNodes.add(key);
+      populate();
+    } else {
+      openTreeNodes.delete(key);
+    }
+  });
+
+  return details;
+}
+
+/**
+ * Populate a `permissions.<kind>` branch's children using the tool-prefix
+ * grouping helper (#68). Each `Single` from the grouper renders exactly
+ * like the pre-#68 flat branch did — `treeNode` with the original index in
+ * the path. Each `Group` renders as a synthetic `<details>` whose
+ * children are the group's members at their original indices, so move /
+ * drag / context menu wiring stays leaf-local.
+ */
+function populatePermissionList(
+  scope: Scope,
+  path: PathSeg[],
+  value: JsonValue[],
+  children: HTMLElement,
+  props: AppProps | undefined,
+  lowerQuery: string,
+): void {
+  // Only string-typed entries participate in tool-prefix grouping — a hand-
+  // edited settings.json can put e.g. an object in `permissions.allow[2]`,
+  // and grouping `null` or a struct under a fake tool name would be more
+  // surprise than help. Keep the malformed entries inline at their
+  // original index so the existing leaf renderer can flag them.
+  const ruleStrings: string[] = value.map((v) => (typeof v === "string" ? v : ""));
+  const grouped = groupByToolPrefix(ruleStrings);
+  for (const entry of grouped) {
+    if (entry.kind === "single") {
+      children.appendChild(
+        treeNode(
+          scope,
+          [...path, entry.index],
+          `[${entry.index}]`,
+          value[entry.index],
+          props,
+          lowerQuery,
+        ),
+      );
+    } else {
+      children.appendChild(toolGroupNode(scope, path, entry, value, props, lowerQuery));
+    }
+  }
+}
+
+/**
+ * Render a synthetic `<details>` for a tool group (#68). The group has no
+ * backend identity — its members each retain their original
+ * `permissions.<kind>[i]` path — but its open/close state is tracked via
+ * an `openTreeNodes` key that uses a `"__group__"` sentinel segment so it
+ * can't collide with a real key path (permission lists are arrays, never
+ * objects with a `__group__` key).
+ *
+ * Filter behavior: when a query is active, hide the group entirely if no
+ * member matches, otherwise show it with the non-matching members
+ * filtered out. The summary's count badge mirrors the combined panel's
+ * `(matched/total)` format so the matched-count signal is consistent
+ * across the two surfaces.
+ */
+function toolGroupNode(
+  scope: Scope,
+  path: PathSeg[],
+  group: Extract<GroupedRuleEntry, { kind: "group" }>,
+  rawValue: JsonValue[],
+  props: AppProps | undefined,
+  lowerQuery: string,
+): HTMLElement {
+  const permKind = permissionKindForPath(path);
+  const matchedMembers =
+    lowerQuery === ""
+      ? group.members
+      : group.members.filter((m) => matchesLoweredQuery(m.rule, lowerQuery));
+  // If nothing in the group matches the active filter, return an empty
+  // hidden node so the children container doesn't grow a "ghost" group
+  // summary with no visible members beneath it.
+  if (lowerQuery !== "" && matchedMembers.length === 0) {
+    const skip = document.createElement("span");
+    skip.hidden = true;
+    return skip;
+  }
+
+  const groupPath: PathSeg[] = [...path, "__group__", group.tool];
+  const key = treeKey(scope, groupPath);
+
+  const details = document.createElement("details");
+  details.className = "tree-node tree-branch tree-tool-group";
+  if (permKind) details.classList.add(`tree-perm-${permKind}`);
+
+  const summary = document.createElement("summary");
+  summary.className = "tree-summary";
+  const name = document.createElement("span");
+  name.className = "tree-key";
+  name.textContent = group.tool;
+  summary.appendChild(name);
+  const peek = document.createElement("span");
+  peek.className = "tree-peek";
+  peek.textContent =
+    lowerQuery === ""
+      ? `(${group.members.length})`
+      : `(${matchedMembers.length}/${group.members.length})`;
+  summary.appendChild(peek);
+  details.appendChild(summary);
+
+  const childrenWrap = document.createElement("div");
+  childrenWrap.className = "tree-children";
+  details.appendChild(childrenWrap);
+
+  let populated = false;
+  function populate(): void {
+    if (populated) return;
+    populated = true;
+    for (const member of matchedMembers) {
+      childrenWrap.appendChild(
+        treeNode(
+          scope,
+          [...path, member.index],
+          `[${member.index}]`,
+          rawValue[member.index],
+          props,
+          lowerQuery,
+        ),
+      );
+    }
+  }
+
+  // Default open: tool groups inside an already-open `permissions.<kind>`
+  // branch should reveal their rules without an extra click — users opened
+  // the parent to read the rules. `seedDefaultOpenPermissions` seeds the
+  // synthetic key for each group at first render; manual collapses then
+  // override.
   if (openTreeNodes.has(key)) {
     details.open = true;
     populate();

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -8,7 +8,13 @@ import type {
   Theme,
 } from "../../src/types.ts";
 import { SEARCH_INPUT_ID } from "../../src/types.ts";
-import { openAbout, openSettings, renderApp, renderDiagnosticsMarkdown } from "../../src/ui.ts";
+import {
+  groupByToolPrefix,
+  openAbout,
+  openSettings,
+  renderApp,
+  renderDiagnosticsMarkdown,
+} from "../../src/ui.ts";
 import { buildLoadedScopes, buildPreferences, buildRuntimeInfo } from "../fixtures/loadedScopes.ts";
 
 // `openAbout` calls into the Tauri clipboard plugin, which probes the IPC
@@ -578,5 +584,212 @@ describe("openSettings – backup toggle (#88)", () => {
     cb.dispatchEvent(new Event("change"));
     expect(onToggleBackupOnWrite).toHaveBeenCalledTimes(1);
     expect(onToggleBackupOnWrite).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("groupByToolPrefix (#68)", () => {
+  it("folds 2+ rules sharing a tool into a group", () => {
+    const got = groupByToolPrefix(["handoff(copilot *)", "handoff(claude *)", "handoff(codex *)"]);
+    expect(got).toHaveLength(1);
+    expect(got[0]).toEqual({
+      kind: "group",
+      tool: "handoff",
+      members: [
+        { index: 0, rule: "handoff(copilot *)" },
+        { index: 1, rule: "handoff(claude *)" },
+        { index: 2, rule: "handoff(codex *)" },
+      ],
+    });
+  });
+
+  it("emits a single-rule tool as a Single, not a one-child group", () => {
+    const got = groupByToolPrefix(["Read(**)"]);
+    expect(got).toEqual([{ kind: "single", index: 0, rule: "Read(**)" }]);
+  });
+
+  it("preserves original disk order: group emits at the position of its first member", () => {
+    // Read sits between Bash[0] and Bash[2]. The Bash group should emit at
+    // position 0 (Bash's first member), and Read should still be reachable
+    // — Bash[2] gets absorbed silently into the group rather than re-
+    // emitting at index 2.
+    const got = groupByToolPrefix(["Bash(ls)", "Read(**)", "Bash(grep)"]);
+    expect(got.length).toBe(2);
+    expect(got[0]).toMatchObject({ kind: "group", tool: "Bash" });
+    expect(got[1]).toEqual({ kind: "single", index: 1, rule: "Read(**)" });
+    if (got[0].kind !== "group") throw new Error("expected group");
+    expect(got[0].members.map((m) => m.index)).toEqual([0, 2]);
+  });
+
+  it("rules without a Tool(args) shape stay flat", () => {
+    // No paren → no tool prefix → never grouped. Two malformed rules don't
+    // get folded together as an empty-tool group.
+    const got = groupByToolPrefix(["weird-rule-no-parens", "another-weirdo"]);
+    expect(got).toEqual([
+      { kind: "single", index: 0, rule: "weird-rule-no-parens" },
+      { kind: "single", index: 1, rule: "another-weirdo" },
+    ]);
+  });
+
+  it("threshold parameter controls when a tool folds", () => {
+    const rules = ["Bash(ls)", "Bash(grep)"];
+    expect(groupByToolPrefix(rules, 2)[0].kind).toBe("group");
+    // Two rules, threshold 3 → stays flat.
+    const at3 = groupByToolPrefix(rules, 3);
+    expect(at3.every((e) => e.kind === "single")).toBe(true);
+  });
+
+  it("Tool() with empty args still groups by the Tool prefix", () => {
+    const got = groupByToolPrefix(["WebFetch()", "WebFetch(domain:example.com)"]);
+    expect(got).toHaveLength(1);
+    expect(got[0]).toMatchObject({ kind: "group", tool: "WebFetch" });
+  });
+});
+
+describe("tool-prefix grouping in the scope tree (#68)", () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
+
+  afterEach(() => {
+    clearBody();
+  });
+
+  it("renders a synthetic group node when 2+ rules share a tool", () => {
+    // Unique project_dir per test so `seedDefaultOpenPermissions` re-runs
+    // against this scenario's rules instead of inheriting `openTreeNodes`
+    // state from an earlier describe block that didn't include groups.
+    const scopes = buildLoadedScopes({
+      project_dir: "/fake/grouping-render",
+      scopes: [
+        {
+          scope: "project",
+          permissions: {
+            allow: ["handoff(copilot *)", "handoff(claude *)", "handoff(codex *)"],
+          },
+        },
+      ],
+    });
+    renderApp(root, makeProps({ scopes }));
+    const groups = root.querySelectorAll<HTMLDetailsElement>(".tree-tool-group");
+    expect(groups.length).toBe(1);
+    const summary = groups[0].querySelector(".tree-summary");
+    expect(summary?.textContent).toContain("handoff");
+    expect(summary?.textContent).toContain("(3)");
+    // Three rule rows nested inside the group, addressed by their original
+    // indices on disk — paths stay leaf-level for the move primitive.
+    const rules = groups[0].querySelectorAll<HTMLElement>(".rule.rule-allow");
+    expect(rules.length).toBe(3);
+    const ruleTexts = Array.from(rules).map((r) => r.querySelector(".rule-text")?.textContent);
+    expect(ruleTexts).toEqual(["handoff(copilot *)", "handoff(claude *)", "handoff(codex *)"]);
+  });
+
+  it("leaves a single-rule tool as a flat leaf alongside a multi-rule group", () => {
+    const scopes = buildLoadedScopes({
+      project_dir: "/fake/grouping-mixed",
+      scopes: [
+        {
+          scope: "project",
+          permissions: {
+            allow: ["Bash(ls)", "Read(**)", "Bash(grep)"],
+          },
+        },
+      ],
+    });
+    renderApp(root, makeProps({ scopes }));
+    const groups = root.querySelectorAll<HTMLDetailsElement>(".tree-tool-group");
+    // Only Bash collapses; Read stays a top-level leaf.
+    expect(groups.length).toBe(1);
+    expect(groups[0].querySelector(".tree-summary")?.textContent).toContain("Bash");
+    // The kind branch should still hold a direct leaf for Read at its
+    // original index, plus the group node for Bash. Picking the kind
+    // branch by class instead of by structural index keeps the assertion
+    // resilient to future seeding changes.
+    const kindBranch = root.querySelector<HTMLDetailsElement>(".tree-branch.tree-perm-allow");
+    if (!kindBranch) throw new Error("expected permissions.allow branch");
+    const directChildren = kindBranch.querySelector(".tree-children");
+    if (!directChildren) throw new Error("expected children container");
+    // First-level children: 1 group + 1 leaf (Read). The group's *own*
+    // children are deeper and don't count here.
+    const topLevel = Array.from(directChildren.children).filter(
+      (el) =>
+        el.classList.contains("tree-tool-group") ||
+        (el.classList.contains("rule") && el.classList.contains("rule-allow")),
+    );
+    expect(topLevel.length).toBe(2);
+    const readLeaf = topLevel.find(
+      (el) =>
+        el.classList.contains("rule") && el.querySelector(".rule-text")?.textContent === "Read(**)",
+    );
+    expect(readLeaf).toBeDefined();
+  });
+
+  it("filtering hides non-matching members and shows matched/total in the group label", () => {
+    const scopes = buildLoadedScopes({
+      project_dir: "/fake/grouping-filter",
+      scopes: [
+        {
+          scope: "project",
+          permissions: {
+            allow: ["handoff(copilot *)", "handoff(claude *)", "handoff(codex *)"],
+          },
+        },
+      ],
+    });
+    renderApp(root, makeProps({ scopes, query: "copilot" }));
+    const groups = root.querySelectorAll<HTMLDetailsElement>(".tree-tool-group");
+    expect(groups.length).toBe(1);
+    const summary = groups[0].querySelector(".tree-summary");
+    // Matched count first, total second — same shape the combined panel
+    // uses for kind labels under an active filter.
+    expect(summary?.textContent).toContain("(1/3)");
+    // Only the matching rule renders inside the group.
+    const rules = groups[0].querySelectorAll<HTMLElement>(".rule.rule-allow");
+    const visibleRules = Array.from(rules).filter((r) => !r.hidden);
+    expect(visibleRules.length).toBe(1);
+    expect(visibleRules[0].querySelector(".rule-text")?.textContent).toBe("handoff(copilot *)");
+  });
+
+  it("group members keep leaf-level paths so move buttons still address the rule directly", () => {
+    const onMoveLeaf = vi.fn();
+    const scopes = buildLoadedScopes({
+      project_dir: "/fake/grouping-move",
+      scopes: [
+        {
+          scope: "project",
+          permissions: { allow: ["Bash(ls)", "Bash(grep)"] },
+        },
+      ],
+    });
+    renderApp(root, makeProps({ scopes, onMoveLeaf }));
+    // Inside the Bash group: click the second member's "→ User" button and
+    // assert the dispatched path is `permissions.allow[1]`, not anything
+    // group-relative.
+    const group = root.querySelector<HTMLDetailsElement>(".tree-tool-group");
+    if (!group) throw new Error("expected tool group");
+    const memberRows = group.querySelectorAll<HTMLElement>(".rule.rule-allow");
+    expect(memberRows.length).toBe(2);
+    const toUser = memberRows[1].querySelector<HTMLButtonElement>(".rule-moves .move-btn");
+    if (!toUser || toUser.textContent !== "→ User") {
+      // The first matching scope target may differ depending on default
+      // visibility; fall back to searching by label across all buttons in
+      // the row.
+      const buttons = Array.from(
+        memberRows[1].querySelectorAll<HTMLButtonElement>(".rule-moves .move-btn"),
+      );
+      const fallback = buttons.find((b) => b.textContent === "→ User");
+      if (!fallback) throw new Error("expected → User button");
+      fallback.click();
+    } else {
+      toUser.click();
+    }
+    expect(onMoveLeaf).toHaveBeenCalledTimes(1);
+    const [req] = onMoveLeaf.mock.calls[0];
+    expect(req).toEqual({
+      path: ["permissions", "allow", 1],
+      from: "project",
+      to: "user",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #68. When the per-scope tree shows 2+ rules sharing a `Tool(...)` prefix, the matching rules fold under a synthetic `<details>` headed `Tool ▸ (N)`. The Brian example — `handoff(copilot *)` / `handoff(claude *)` / `handoff(codex *)` — collapses into a single `handoff (3) ▸` entry.

## Decisions and scope

- **Threshold = 2** for v1 (single compile-time constant). A Settings option to parameterize this lives in **[#115](https://github.com/bminier/claude-scope/issues/115)** so users who'd prefer 3 (or "never group") can pick.
- **Per-scope tree only.** The issue's phrasing — *\"group them under a handoff > key\"* — maps to the tree view's disclosure. The combined panel already columns by kind; nested tool groups inside those columns would crowd the layout. Could revisit as a follow-up if it's wanted.
- **Order preservation.** Each group emits at its first member's position; subsequent members are absorbed silently. Singles stay at their original disk index. Reading top-down, no rule moves past a sibling it came after on disk.
- **Group members keep leaf-level paths.** The synthetic group has no backend identity — moves, drags, and context menus on rule rows inside a group dispatch `permissions.<kind>[i]` exactly as they would in the flat layout.
- **Filter awareness.** A group renders only if ≥1 member matches the query; non-matching members hide inside the group; the peek shows `(matched/total)` — same shape the combined panel uses for kind labels.
- **Open state persists.** Synthetic key `permissions.<kind>.__group__.<tool>` lives in `openTreeNodes` and is seeded by `seedDefaultOpenPermissions` so groups inside an already-open kind branch start expanded. Manual collapses persist across re-renders just like every other tree node.

## Tests

10 new tests, all passing:
- **6 unit tests** on `groupByToolPrefix` — happy path, single-rule fallback, order preservation through interleaved tools, malformed (no-paren) rules, threshold parameter, and `Tool()` empty args.
- **4 render tests** against `renderApp` — synthetic group with 3 `handoff` rules; mixed single+group ordering with `Bash(ls)` / `Read(**)` / `Bash(grep)`; filter `copilot` collapses the group label to `(1/3)` and hides non-matching members; group-member move dispatches `permissions.allow[1]` (original index).

Total suite: **37 vitest tests passing**. Type-check + Vite build clean.

## Out of scope (per the issue)

- Settings option to change/disable the threshold — follow-up #115.
- Combined-panel grouping.
- Group-level move/drag/context menu (members stay individually movable).

## Test plan

- [ ] `npx vitest run` passes.
- [ ] Manual: load a project with three `handoff(...)` rules — confirm a single `handoff (3) ▸` row collapses them, default-open inside an open `permissions.allow`.
- [ ] Manual: filter for one member's args (e.g. `copilot`) — group stays, label shows `(1/3)`, only the matching rule renders.
- [ ] Manual: drag a member from inside a group to another scope column — the move lands at the correct on-disk index.
- [ ] Manual: a single-rule tool (e.g. just `Read(**)`) renders flat, not collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)