### PR TITLE
feat(audit): read-only History dialog (#19 phase 2)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -516,6 +516,51 @@ pub fn list_known_projects(
     projects::list_known_projects(overrides.home()).map_err(|e| e.to_string())
 }
 
+/// One row in the History view's audit-log list (#19 phase 2). Wraps an
+/// [`audit::Record`] with a derived `ts_ms` field so the frontend doesn't
+/// need to ship its own ULID parser to render timestamps. The 48-bit
+/// timestamp is embedded in the first half of the ULID; pulling it out
+/// here keeps that decode in one place.
+#[derive(Debug, Serialize)]
+pub struct AuditRecordView {
+    #[serde(flatten)]
+    pub record: audit::Record,
+    /// Unix millis-since-epoch, decoded from the record's ULID.
+    pub ts_ms: u64,
+}
+
+/// Payload for `list_audit_records`: the records plus a count of any
+/// malformed lines the reader skipped. `skipped > 0` is non-fatal — the
+/// History view surfaces it as a small footer warning so the user knows
+/// some entries are unreadable, but the rest of the log still renders.
+#[derive(Debug, Serialize)]
+pub struct AuditLogPage {
+    pub records: Vec<AuditRecordView>,
+    pub skipped: usize,
+}
+
+/// Read the audit log for the History view (#19 phase 2). Routes through
+/// `RuntimeOverrides::home` so sandbox sessions (#66) and unit tests read
+/// from their scratch home rather than the real `~/.claude/`. A missing
+/// file returns an empty page — fresh installs and users who haven't
+/// made any writes yet shouldn't see an error here.
+///
+/// The records are returned in file order (append order, which matches
+/// chronological order thanks to ULIDs). The frontend reverses for
+/// display.
+#[tauri::command]
+pub fn list_audit_records(overrides: State<'_, RuntimeOverrides>) -> Result<AuditLogPage, String> {
+    let (records, skipped) = audit::read_all(overrides.home()).map_err(|e| e.to_string())?;
+    let records = records
+        .into_iter()
+        .map(|r| {
+            let ts_ms = r.id.timestamp_ms();
+            AuditRecordView { record: r, ts_ms }
+        })
+        .collect();
+    Ok(AuditLogPage { records, skipped })
+}
+
 /// Build- and runtime-time diagnostic block for the About dialog (#21).
 /// `webview_version` is queried at command time — it's the one field that
 /// can vary across processes (a system WebView2 update mid-session) and
@@ -2726,5 +2771,87 @@ mod tests {
             "after snapshot should show the rule landed on destination: got {:?}",
             to_side.key_after
         );
+    }
+
+    // -- list_audit_records / AuditRecordView (#19 phase 2) ----------------
+
+    /// Build the same `AuditLogPage` shape the Tauri command emits, but
+    /// reaching past the `State<RuntimeOverrides>` wrapper that's awkward
+    /// to construct in a unit test. Verifies the ts_ms derivation is
+    /// stable across the ULID → wire round trip — that's the property
+    /// the History UI binds its timestamp rendering to.
+    #[test]
+    fn audit_record_view_decodes_ts_ms_from_ulid() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Append two records spaced apart so ts_ms differences are
+        // observable. The audit module's own tests cover empty / truncated
+        // edge cases; this one only validates the view layer.
+        let rec1 = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            None,
+            None,
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+        std::thread::sleep(std::time::Duration::from_millis(3));
+        let rec2 = audit::Record::new(
+            audit::Kind::Add,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            None,
+            None,
+            vec![key("permissions"), key("deny"), idx(0)],
+            None,
+        );
+        audit::append(&rec1, Some(tmp.path())).unwrap();
+        audit::append(&rec2, Some(tmp.path())).unwrap();
+
+        let (records, skipped) = audit::read_all(Some(tmp.path())).unwrap();
+        assert_eq!(skipped, 0);
+        let views: Vec<AuditRecordView> = records
+            .into_iter()
+            .map(|r| {
+                let ts_ms = r.id.timestamp_ms();
+                AuditRecordView { record: r, ts_ms }
+            })
+            .collect();
+
+        // The derived ts_ms matches the ULID's embedded timestamp — that's
+        // the contract the History UI binds its rendering to.
+        assert_eq!(views.len(), 2);
+        assert_eq!(views[0].ts_ms, rec1.id.timestamp_ms());
+        assert_eq!(views[1].ts_ms, rec2.id.timestamp_ms());
+        // And the second record's ts_ms is strictly greater — the
+        // 3ms sleep above guarantees ULID monotonicity.
+        assert!(views[1].ts_ms > views[0].ts_ms);
+    }
+
+    #[test]
+    fn audit_record_view_serializes_flattened_with_ts_ms() {
+        // Pin the wire format: `ts_ms` appears at the top level alongside
+        // the record's own fields (flatten), not nested. The History UI's
+        // TS interface mirrors this shape; a serde regression here would
+        // break the frontend silently.
+        let rec = audit::Record::new(
+            audit::Kind::Delete,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            None,
+            None,
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+        let ts_ms = rec.id.timestamp_ms();
+        let view = AuditRecordView { record: rec, ts_ms };
+        let json: serde_json::Value = serde_json::to_value(&view).unwrap();
+        assert_eq!(json.get("kind").and_then(|v| v.as_str()), Some("delete"));
+        assert_eq!(json.get("ts_ms").and_then(|v| v.as_u64()), Some(ts_ms));
+        // `record` is flattened — there should NOT be a nested `record` key.
+        assert!(json.get("record").is_none());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run(context: tauri::Context) {
             commands::save_preferences,
             commands::load_runtime_info,
             commands::list_known_projects,
+            commands::list_audit_records,
             commands::get_app_info,
         ])
         .run(context)

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import type {
   AddLeafPreview,
   AddLeafRequest,
   AppInfo,
+  AuditLogPage,
   DeleteLeafPreview,
   DeleteLeafRequest,
   KnownProject,
@@ -27,6 +28,7 @@ import {
   confirmDeleteLeaf,
   confirmMoveLeaf,
   openAbout,
+  openHistory,
   openSettings,
   renderApp,
 } from "./ui.ts";
@@ -460,12 +462,31 @@ function render(): void {
     onAddLeaf: addLeaf,
     onOpenSettings,
     onOpenAbout: handleOpenAbout,
+    onOpenHistory: handleOpenHistory,
     onQueryChange: setQuery,
   });
 }
 
 function handleOpenAbout(trigger?: HTMLElement): void {
   openAbout(state.appInfo, trigger ?? null);
+}
+
+/**
+ * Fetch the audit log from the backend and open the History dialog
+ * (#19 phase 2). Fetched on each click — the log grows over time and
+ * the dialog should reflect every write, including ones made in this
+ * session. On IPC failure, open the dialog with `null` so the user sees
+ * an error message rather than a silent no-op (the dialog handles that
+ * branch).
+ */
+async function handleOpenHistory(trigger?: HTMLElement): Promise<void> {
+  let page: AuditLogPage | null = null;
+  try {
+    page = await invoke<AuditLogPage>("list_audit_records");
+  } catch (err) {
+    console.warn("failed to read audit log:", err);
+  }
+  openHistory(page, trigger ?? null);
 }
 
 // Pressing "/" anywhere focuses the rule-search input, GitHub / Gmail style —

--- a/src/styles.css
+++ b/src/styles.css
@@ -1309,3 +1309,112 @@ button:disabled {
 .modal-diff-single {
   grid-template-columns: 1fr;
 }
+
+/* History dialog (#19 phase 2). Wider than About so long paths and rule
+   strings have room without wrapping into hard-to-scan multi-line blocks. */
+.modal-history {
+  max-width: 640px;
+  padding: 16px 18px;
+}
+
+.history-body {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.history-empty,
+.history-error {
+  margin: 12px 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.history-error {
+  color: var(--danger, #c0392b);
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.history-row {
+  border-top: 1px solid var(--border);
+  padding: 8px 4px;
+  font-size: 13px;
+}
+
+.history-row:first-child {
+  border-top: 0;
+}
+
+.history-row-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.history-verb {
+  font-weight: 600;
+}
+
+/* Subtle color tints by verb so the user can scan the column visually. */
+.history-verb-move {
+  color: var(--accent);
+}
+
+.history-verb-add {
+  color: var(--ok, #2c8a3e);
+}
+
+.history-verb-delete {
+  color: var(--danger, #c0392b);
+}
+
+.history-verb-change_kind {
+  color: var(--warn, #b88216);
+}
+
+.history-ts {
+  color: var(--muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.history-row-detail {
+  margin-top: 4px;
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.history-scopes {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.history-rule {
+  font-family: var(--mono, monospace);
+  font-size: 12px;
+  color: var(--text);
+  word-break: break-all;
+}
+
+.history-project {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 11px;
+  font-family: var(--mono, monospace);
+}
+
+.history-skipped {
+  margin: 10px 0 0;
+  padding: 6px 8px;
+  background: var(--panel-2);
+  color: var(--muted);
+  font-size: 12px;
+  border-radius: 4px;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,3 +224,73 @@ export interface AppInfo {
   os: string;
   arch: string;
 }
+
+/**
+ * Audit log entry kinds (#19). Mirrors Rust's `audit::Kind` — snake_case
+ * wire strings pinned by `record_kind_serializes_to_snake_case_strings`
+ * in commands.rs. `change_kind` is the same-scope reclassification flow;
+ * the full set will grow as #16 / #17 / #18 land in future phases.
+ */
+export type AuditKind = "move" | "change_kind" | "add" | "delete";
+
+/**
+ * What shape of leaf the audit record's `path` targets. Mirrors Rust's
+ * `audit::LeafKind`. The History view uses this with [[AuditKind]] to
+ * compose human-readable labels like "Move permission rule" or
+ * "Delete top-level key".
+ */
+export type AuditLeafKind = "top_level_key" | "permission_list" | "permission_rule";
+
+/**
+ * Who triggered an audit record. Phase 1 only emits `gui`; the other
+ * variants reserve wire-format slots for the CLI (#13) and undo / restore
+ * (#19 phases 3-4) so the schema can extend without breaking older
+ * History readers.
+ */
+export type AuditActor = "gui" | "cli" | "skill" | "restore";
+
+/**
+ * One side of an audit record's write. Mirrors Rust's `audit::Side` —
+ * scope, file path, and a snapshot of the affected top-level key both
+ * before and after the op. `null` distinguishes "key absent / file
+ * absent" from a literal JSON `null` (which arrives as `null` in the
+ * `key_*` fields but the surrounding object is still present).
+ */
+export interface AuditSide {
+  scope: Scope;
+  file_path: string;
+  top_level_key: string;
+  key_before?: JsonValue | null;
+  key_after?: JsonValue | null;
+}
+
+/**
+ * One entry in the History view. Mirrors the wire shape from Rust's
+ * `commands::AuditRecordView` — `audit::Record` fields flattened with a
+ * derived `ts_ms` so the frontend doesn't need to parse Crockford base32
+ * ULIDs to render timestamps.
+ */
+export interface AuditRecordView {
+  id: string;
+  kind: AuditKind;
+  leaf_kind: AuditLeafKind;
+  actor: AuditActor;
+  project_dir?: string;
+  from?: AuditSide;
+  to?: AuditSide;
+  path: PathSeg[];
+  to_kind?: PermissionKind;
+  claude_scope_version: string;
+  ts_ms: number;
+}
+
+/**
+ * Payload from `list_audit_records`. `skipped` is the count of malformed
+ * lines the reader silently dropped (truncated tail, schema drift) so
+ * the History view can surface a non-fatal footer warning rather than
+ * acting as if the log were intact.
+ */
+export interface AuditLogPage {
+  records: AuditRecordView[];
+  skipped: number;
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -4,6 +4,9 @@ import type {
   AddLeafPreview,
   AddLeafRequest,
   AppInfo,
+  AuditLogPage,
+  AuditRecordView,
+  AuditSide,
   DeleteLeafPreview,
   DeleteLeafRequest,
   JsonValue,
@@ -60,6 +63,11 @@ interface AppProps {
    *  bootstrap; the caller routes the click through main.ts so it can also
    *  refresh the cache if it's stale. */
   onOpenAbout: (trigger?: HTMLElement) => void;
+  /** Open the audit-log History dialog (#19 phase 2). main.ts fetches the
+   *  records via `list_audit_records` IPC and hands them to the renderer
+   *  in this callback's body, mirroring the openSettings / openAbout
+   *  trigger-pattern so focus restore lands on the History button. */
+  onOpenHistory: (trigger?: HTMLElement) => void;
   onQueryChange: (next: string) => void;
 }
 
@@ -707,6 +715,12 @@ function header(props: AppProps): HTMLElement {
   reload.onclick = props.onReload;
   reload.disabled = props.busy || !props.scopes;
   actions.appendChild(reload);
+
+  const history = document.createElement("button");
+  history.textContent = "History";
+  history.setAttribute("aria-label", "Open audit history");
+  history.onclick = (e) => props.onOpenHistory(e.currentTarget as HTMLElement);
+  actions.appendChild(history);
 
   const settings = document.createElement("button");
   settings.textContent = "Settings";
@@ -3180,4 +3194,273 @@ export function renderDiagnosticsMarkdown(info: AppInfo): string {
     `- Rust (MSRV): ${info.rust_version}`,
     `- OS: ${info.os} ${info.arch}`,
   ].join("\n");
+}
+
+/**
+ * Open the audit-log History dialog (#19 phase 2). Read-only: lists every
+ * write ClaudeScope has made since the audit log was first written, in
+ * reverse-chronological order. The "Restore to before this" action the
+ * issue spec mentions lands with #19 phase 3+; this dialog deliberately
+ * omits it so the read path can ship first.
+ *
+ * `page` arrives null when the bootstrap fetch failed (e.g. the audit
+ * file was unreadable) — the dialog still opens, with an explanatory
+ * status line, rather than swallowing the click. Empty `records` arrays
+ * are common (fresh install, no writes yet) and render as a friendly
+ * empty state.
+ */
+export function openHistory(page: AuditLogPage | null, trigger?: HTMLElement | null): void {
+  const body = document.createElement("div");
+  body.className = "history-body";
+
+  if (page === null) {
+    const err = document.createElement("p");
+    err.className = "history-error";
+    err.textContent = "Audit log could not be read. See the app log for details.";
+    body.appendChild(err);
+  } else if (page.records.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "history-empty";
+    empty.textContent =
+      "No audit entries yet. Every move / add / delete you make from here will appear in this list.";
+    body.appendChild(empty);
+  } else {
+    body.appendChild(historyList(page.records));
+    if (page.skipped > 0) {
+      const warn = document.createElement("p");
+      warn.className = "history-skipped";
+      warn.textContent = `${page.skipped} unreadable ${
+        page.skipped === 1 ? "entry was" : "entries were"
+      } skipped — see the app log for details.`;
+      body.appendChild(warn);
+    }
+  }
+
+  openModal({
+    titleText: "History",
+    body,
+    actions: [
+      {
+        label: "Close",
+        className: "btn-apply",
+        focus: true,
+        activate: (close) => close(),
+      },
+    ],
+    panelClassName: "modal-history",
+    trigger,
+  });
+}
+
+/**
+ * Build the reverse-chronological list of audit entries. The records
+ * arrive in file order from the IPC (which is append order = ULID-sorted
+ * = chronological); flipping here keeps "most recent first" — the most
+ * useful ordering for a "what just happened?" view — without paying for
+ * a backend sort.
+ */
+function historyList(records: AuditRecordView[]): HTMLElement {
+  const ul = document.createElement("ul");
+  ul.className = "history-list";
+  // Slice before reverse so we don't mutate the caller's array — the
+  // History dialog is intentionally side-effect-free.
+  for (const rec of records.slice().reverse()) {
+    ul.appendChild(historyRow(rec));
+  }
+  return ul;
+}
+
+function historyRow(rec: AuditRecordView): HTMLElement {
+  const li = document.createElement("li");
+  li.className = "history-row";
+
+  const head = document.createElement("div");
+  head.className = "history-row-head";
+
+  const verb = document.createElement("span");
+  verb.className = `history-verb history-verb-${rec.kind}`;
+  verb.textContent = historyVerbLabel(rec);
+  head.appendChild(verb);
+
+  const ts = document.createElement("time");
+  ts.className = "history-ts";
+  // Pin to ISO + locale: the ISO form goes in `datetime` so assistive
+  // tech reads the unambiguous absolute time, while the visible text is
+  // the locale-formatted version a user can scan. Avoids the "is that
+  // 06/05 May or June?" ambiguity that any pure-date display invites.
+  const date = new Date(rec.ts_ms);
+  ts.dateTime = date.toISOString();
+  ts.textContent = date.toLocaleString();
+  head.appendChild(ts);
+
+  li.appendChild(head);
+
+  const detail = document.createElement("div");
+  detail.className = "history-row-detail";
+  detail.appendChild(historyScopeArrow(rec));
+  const rule = historyRuleSummary(rec);
+  if (rule) detail.appendChild(rule);
+  li.appendChild(detail);
+
+  if (rec.project_dir) {
+    const proj = document.createElement("div");
+    proj.className = "history-project";
+    proj.textContent = `Project: ${rec.project_dir}`;
+    li.appendChild(proj);
+  }
+
+  return li;
+}
+
+/**
+ * Human-readable verb label for a record. Composes
+ * (`kind`, `leaf_kind`, `to_kind`) into one phrase so the History row
+ * reads as "Move permission rule" / "Delete top-level key" /
+ * "Change kind to deny" instead of forcing the user to reconcile two
+ * fields visually.
+ */
+function historyVerbLabel(rec: AuditRecordView): string {
+  if (rec.kind === "change_kind") {
+    // Same-scope reclassification: name the destination kind explicitly
+    // so the user sees the "what changed" at a glance.
+    return rec.to_kind ? `Change kind → ${rec.to_kind}` : "Change kind";
+  }
+  const noun = historyLeafNoun(rec.leaf_kind);
+  switch (rec.kind) {
+    case "move":
+      return `Move ${noun}`;
+    case "add":
+      return `Add ${noun}`;
+    case "delete":
+      return `Delete ${noun}`;
+  }
+}
+
+function historyLeafNoun(leafKind: AuditRecordView["leaf_kind"]): string {
+  switch (leafKind) {
+    case "permission_rule":
+      return "permission rule";
+    case "permission_list":
+      return "permission list";
+    case "top_level_key":
+      return "top-level key";
+  }
+}
+
+/** "Project → User" arrow for moves, single-scope label for adds/deletes. */
+function historyScopeArrow(rec: AuditRecordView): HTMLElement {
+  const span = document.createElement("span");
+  span.className = "history-scopes";
+  const from = rec.from?.scope;
+  const to = rec.to?.scope;
+  if (from && to && from !== to) {
+    span.textContent = `${scopeLabel(from)} → ${scopeLabel(to)}`;
+  } else if (from) {
+    span.textContent = scopeLabel(from);
+  } else if (to) {
+    span.textContent = scopeLabel(to);
+  } else {
+    span.textContent = "—";
+  }
+  return span;
+}
+
+function scopeLabel(scope: Scope): string {
+  switch (scope) {
+    case "user":
+      return "User";
+    case "user_local":
+      return "User-Local";
+    case "project":
+      return "Project";
+    case "local":
+      return "Local";
+  }
+}
+
+/**
+ * Extract the rule string (or key name) the op touched, by diffing the
+ * before/after snapshots. For a permission-rule op, the rule appears in
+ * either `from.key_before − from.key_after` (move/delete) or
+ * `to.key_after − to.key_before` (add). For a top-level key op, the
+ * `path[0]` segment IS the key name and a snapshot diff isn't needed.
+ *
+ * Falls back to `null` (no element appended) when the diff can't
+ * identify a single rule — better to render an unannotated row than to
+ * lie about what changed.
+ */
+function historyRuleSummary(rec: AuditRecordView): HTMLElement | null {
+  if (rec.leaf_kind === "top_level_key") {
+    const key = typeof rec.path[0] === "string" ? rec.path[0] : null;
+    if (!key) return null;
+    return makeRuleSpan(key);
+  }
+  // Permission rule or list. For a list op, the path[1] is the kind
+  // (allow/deny/ask) and that's the most informative summary.
+  if (rec.leaf_kind === "permission_list") {
+    const kind = typeof rec.path[1] === "string" ? rec.path[1] : null;
+    return kind ? makeRuleSpan(`permissions.${kind}`) : null;
+  }
+  // PermissionRule: diff the snapshots to recover the rule string.
+  const rule = extractRuleFromDiff(rec);
+  return rule ? makeRuleSpan(rule) : null;
+}
+
+function makeRuleSpan(text: string): HTMLElement {
+  const span = document.createElement("span");
+  span.className = "history-rule";
+  span.textContent = text;
+  return span;
+}
+
+/**
+ * Diff the before/after rule arrays on the side that contains the
+ * change, returning the single rule string the op acted on. Picks the
+ * side based on op kind:
+ *
+ *   - Move / ChangeKind: source side loses the rule, so before − after
+ *     on `from` is authoritative.
+ *   - Add: destination gains the rule; after − before on `to`.
+ *   - Delete: source loses the rule; before − after on `from`.
+ *
+ * Returns the first matching string; if the diff yields multiple (a
+ * batch op the schema doesn't yet model), this still surfaces a
+ * representative rule rather than nothing.
+ */
+function extractRuleFromDiff(rec: AuditRecordView): string | null {
+  const kindArg = typeof rec.path[1] === "string" ? rec.path[1] : null;
+  if (!kindArg) return null;
+  if (rec.kind === "add") {
+    const before = rulesForKind(rec.to, kindArg);
+    const after = rulesForKind(rec.to, kindArg, true);
+    return firstNewIn(after, before);
+  }
+  // Move / Delete / ChangeKind: rule disappears from the source side.
+  const before = rulesForKind(rec.from, kindArg);
+  const after = rulesForKind(rec.from, kindArg, true);
+  return firstNewIn(before, after);
+}
+
+/**
+ * Pull the `permissions.<kind>` array off a side's snapshot. `useAfter`
+ * picks `key_after` vs `key_before` — kept as a flag rather than passing
+ * the right field directly so the caller's diff logic reads top-to-bottom
+ * without branching on which side.
+ */
+function rulesForKind(side: AuditSide | undefined, kind: string, useAfter = false): string[] {
+  if (!side) return [];
+  const snapshot = useAfter ? side.key_after : side.key_before;
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) return [];
+  const arr = (snapshot as { [key: string]: JsonValue })[kind];
+  if (!Array.isArray(arr)) return [];
+  return arr.filter((v): v is string => typeof v === "string");
+}
+
+/** First element of `a` that doesn't appear in `b`, or null. */
+function firstNewIn(a: string[], b: string[]): string | null {
+  const bSet = new Set(b);
+  for (const v of a) {
+    if (!bSet.has(v)) return v;
+  }
+  return null;
 }

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AppInfo,
+  AuditRecordView,
+  AuditSide,
   KnownProject,
   MoveLeafRequest,
   MoveOptions,
@@ -15,6 +17,7 @@ import {
   lookupKindHelp,
   lookupScopeHelp,
   openAbout,
+  openHistory,
   openSettings,
   renderApp,
   renderDiagnosticsMarkdown,
@@ -73,6 +76,7 @@ function makeProps(overrides: PropsOverrides = {}) {
     knownProjects: overrides.knownProjects ?? [],
     onPickProject: overrides.onPickProject ?? vi.fn(),
     onPickRecentProject: overrides.onPickRecentProject ?? vi.fn(),
+    onOpenHistory: vi.fn(),
     onReload: vi.fn(),
     onMoveLeaf: overrides.onMoveLeaf ?? vi.fn(),
     onChangeKind: vi.fn(),
@@ -1051,5 +1055,193 @@ describe("project-dir dropdown (#47)", () => {
     renderApp(root, makeProps({ busy: true }));
     const trigger = root.querySelector<HTMLButtonElement>(".project-dir-trigger");
     expect(trigger?.disabled).toBe(true);
+  });
+});
+
+describe("History dialog (#19 phase 2)", () => {
+  beforeEach(() => {
+    // Drain any leaked modal Escape listeners from earlier tests in the
+    // file — same trick the help-tooltips suite uses. Without this, a
+    // prior leaked listener's preventDefault would fire BEFORE our own
+    // History dialog's close() and `defaultPrevented = true` would short
+    // our Escape-closes-the-dialog assertion later in the suite.
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    clearBody();
+  });
+
+  afterEach(() => {
+    // Tear down any modal that survived the test.
+    for (const b of Array.from(document.querySelectorAll(".modal-backdrop"))) b.remove();
+    clearBody();
+  });
+
+  function makeRecord(overrides: Partial<AuditRecordView> = {}): AuditRecordView {
+    return {
+      id: "01HFAKEID0000000000000000",
+      kind: "move",
+      leaf_kind: "permission_rule",
+      actor: "gui",
+      path: ["permissions", "allow", 0],
+      claude_scope_version: "0.3.0",
+      ts_ms: 1_700_000_000_000,
+      ...overrides,
+    };
+  }
+
+  function makeSide(scope: Scope, before: unknown, after: unknown): AuditSide {
+    return {
+      scope,
+      file_path: `/fake/${scope}/.claude/settings.json`,
+      top_level_key: "permissions",
+      key_before: before as never,
+      key_after: after as never,
+    };
+  }
+
+  it("empty page renders the empty-state copy and a Close button", () => {
+    openHistory({ records: [], skipped: 0 });
+    const dialog = document.querySelector<HTMLElement>(".modal-history");
+    expect(dialog).not.toBeNull();
+    expect(dialog?.textContent ?? "").toContain("No audit entries yet");
+    expect(document.querySelector(".history-list")).toBeNull();
+  });
+
+  it("null page (read failure) renders the error message instead of empty state", () => {
+    openHistory(null);
+    const dialog = document.querySelector<HTMLElement>(".modal-history");
+    expect(dialog?.textContent ?? "").toContain("could not be read");
+    // The empty-state copy is NOT shown — it would lie about state.
+    expect(dialog?.textContent ?? "").not.toContain("No audit entries yet");
+  });
+
+  it("renders one row per record in reverse-chronological order", () => {
+    const older = makeRecord({ id: "01HOLDER", ts_ms: 1_700_000_000_000 });
+    const newer = makeRecord({ id: "01HNEWER", ts_ms: 1_700_000_100_000 });
+    openHistory({ records: [older, newer], skipped: 0 });
+    const rows = Array.from(document.querySelectorAll<HTMLElement>(".history-row"));
+    expect(rows).toHaveLength(2);
+    // Newer first — that's the reverse of file order.
+    const firstTs = rows[0].querySelector<HTMLTimeElement>(".history-ts");
+    expect(firstTs?.dateTime).toBe(new Date(newer.ts_ms).toISOString());
+  });
+
+  it("renders a Move row with from→to scopes and the moved rule extracted from the diff", () => {
+    const rec = makeRecord({
+      kind: "move",
+      leaf_kind: "permission_rule",
+      from: makeSide("project", { allow: ["Bash(ls)", "Read(*)"] }, { allow: ["Read(*)"] }),
+      to: makeSide("user", { allow: [] }, { allow: ["Bash(ls)"] }),
+    });
+    openHistory({ records: [rec], skipped: 0 });
+    const row = document.querySelector(".history-row");
+    expect(row?.querySelector(".history-verb")?.textContent).toBe("Move permission rule");
+    expect(row?.querySelector(".history-scopes")?.textContent).toBe("Project → User");
+    // Rule diff: the move drops `Bash(ls)` from the source side — that's
+    // the string the History UI should surface.
+    expect(row?.querySelector(".history-rule")?.textContent).toBe("Bash(ls)");
+  });
+
+  it("renders an Add row with just the destination scope and the new rule", () => {
+    const rec = makeRecord({
+      kind: "add",
+      leaf_kind: "permission_rule",
+      from: undefined,
+      to: makeSide("user", { allow: ["Read(*)"] }, { allow: ["Read(*)", "Bash(ls)"] }),
+      path: ["permissions", "allow", 1],
+    });
+    openHistory({ records: [rec], skipped: 0 });
+    const row = document.querySelector(".history-row");
+    expect(row?.querySelector(".history-verb")?.textContent).toBe("Add permission rule");
+    expect(row?.querySelector(".history-scopes")?.textContent).toBe("User");
+    expect(row?.querySelector(".history-rule")?.textContent).toBe("Bash(ls)");
+  });
+
+  it("renders a Delete row with single scope and the dropped rule", () => {
+    const rec = makeRecord({
+      kind: "delete",
+      leaf_kind: "permission_rule",
+      from: makeSide("project", { allow: ["Bash(ls)"] }, { allow: [] }),
+      to: undefined,
+    });
+    openHistory({ records: [rec], skipped: 0 });
+    const row = document.querySelector(".history-row");
+    expect(row?.querySelector(".history-verb")?.textContent).toBe("Delete permission rule");
+    expect(row?.querySelector(".history-scopes")?.textContent).toBe("Project");
+    expect(row?.querySelector(".history-rule")?.textContent).toBe("Bash(ls)");
+  });
+
+  it("renders a ChangeKind row labelling the destination kind", () => {
+    const rec = makeRecord({
+      kind: "change_kind",
+      leaf_kind: "permission_rule",
+      from: makeSide(
+        "project",
+        { allow: ["Bash(rm *)"], deny: [] },
+        { allow: [], deny: ["Bash(rm *)"] },
+      ),
+      to: makeSide(
+        "project",
+        { allow: ["Bash(rm *)"], deny: [] },
+        { allow: [], deny: ["Bash(rm *)"] },
+      ),
+      to_kind: "deny",
+    });
+    openHistory({ records: [rec], skipped: 0 });
+    const row = document.querySelector(".history-row");
+    expect(row?.querySelector(".history-verb")?.textContent).toBe("Change kind → deny");
+    // The diff still pulls the rule string from the from-side disappearance
+    // (allow lost it). That's the property the History UI binds to —
+    // change-kind ops should still surface WHICH rule changed.
+    expect(row?.querySelector(".history-rule")?.textContent).toBe("Bash(rm *)");
+  });
+
+  it("renders a top-level-key row using the key name from the path", () => {
+    const rec = makeRecord({
+      kind: "move",
+      leaf_kind: "top_level_key",
+      path: ["env"],
+      from: makeSide("project", { FOO: "1" }, undefined),
+      to: makeSide("user", undefined, { FOO: "1" }),
+    });
+    openHistory({ records: [rec], skipped: 0 });
+    const row = document.querySelector(".history-row");
+    expect(row?.querySelector(".history-verb")?.textContent).toBe("Move top-level key");
+    expect(row?.querySelector(".history-rule")?.textContent).toBe("env");
+  });
+
+  it("renders the skipped-lines footer warning when records were unreadable", () => {
+    openHistory({ records: [makeRecord()], skipped: 3 });
+    const skipped = document.querySelector(".history-skipped");
+    expect(skipped?.textContent ?? "").toContain("3 unreadable entries were skipped");
+  });
+
+  it("singular vs plural in the skipped footer", () => {
+    openHistory({ records: [makeRecord()], skipped: 1 });
+    expect(document.querySelector(".history-skipped")?.textContent ?? "").toContain(
+      "1 unreadable entry was skipped",
+    );
+  });
+
+  it("renders the project_dir line when present", () => {
+    const rec = makeRecord({ project_dir: "/work/proj-x" });
+    openHistory({ records: [rec], skipped: 0 });
+    const row = document.querySelector(".history-row");
+    expect(row?.querySelector(".history-project")?.textContent).toBe("Project: /work/proj-x");
+  });
+
+  it("omits the project_dir line when the field is absent (user-scope-only op)", () => {
+    openHistory({ records: [makeRecord({ project_dir: undefined })], skipped: 0 });
+    expect(document.querySelector(".history-project")).toBeNull();
+  });
+
+  it("Escape closes the dialog", () => {
+    openHistory({ records: [makeRecord()], skipped: 0 });
+    expect(document.querySelector(".modal-backdrop")).not.toBeNull();
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    expect(document.querySelector(".modal-backdrop")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 of #19. A new \"History\" button in the topbar opens a modal listing every audit entry the Phase 1 log captured, newest-first. **Read-only** — restore / undo is Phase 3+, deliberately omitted here so the data view ships first.

## Backend

- New \`list_audit_records\` Tauri command returns \`AuditLogPage = { records, skipped }\`. \`AuditRecordView\` flattens \`audit::Record\` alongside a derived \`ts_ms\` decoded from the ULID — the frontend doesn't need a Crockford base32 parser to render timestamps.
- Honors \`RuntimeOverrides::home\` so sandbox sessions read from the scratch home.
- Missing log file collapses to an empty page (fresh installs / users who haven't made any writes shouldn't see an error).

## Frontend

- \`History\` button next to Settings/About. Each click re-fetches the audit page so new writes appear without a full reload.
- \`openHistory(page, trigger)\`:
  - \`null\` page → \"could not be read\" error message.
  - Empty records → friendly empty state explaining future writes will land here.
  - Records → reverse-chronological list. Each row:
    - Color-tinted verb label (\`Move permission rule\` / \`Add permission rule\` / \`Delete permission rule\` / \`Change kind → deny\` / \`Move top-level key\`).
    - Absolute ISO timestamp in \`<time datetime=…>\` with locale-formatted text for screen readers AND scannable display.
    - Scope arrow (\`Project → User\` for cross-scope moves; single scope for adds/deletes/same-scope ops).
    - Affected rule string, derived by diffing the snapshots.
    - Optional \`Project: <dir>\` line below.
  - \`skipped > 0\` → footer warning surfaces the count (singular vs plural handled).
- Rule string derivation: move/delete diff source-side, add diff destination-side, top-level-key ops use \`path[0]\` directly. Falls back to omitting the rule when the diff is ambiguous — better than lying about what changed.

## Tests

**2 new Rust tests:**
- \`audit_record_view_decodes_ts_ms_from_ulid\` — round-trips records through append/read and verifies the decoded \`ts_ms\` matches \`Ulid::timestamp_ms()\`, with a 3ms sleep proving monotonicity.
- \`audit_record_view_serializes_flattened_with_ts_ms\` — pins the wire format (no nested \`record\` key; \`ts_ms\` at top level alongside the record's own fields).

**13 new vitest tests** covering every row variant (move, add, delete, change-kind, top-level-key), the empty state, the null-page error state, the skipped-lines footer (singular + plural), reverse-chronological ordering, \`project_dir\` line presence/absence, and Escape-closes.

**Totals:** 182 Rust tests + 64 vitest tests, all green.

## Out of scope (future phases)

- **Phase 3** — undo / redo via the diff-confirm modal.
- **Phase 4** — restore-to-point (adds the \"Restore to before this\" action on each row).
- **Phase 5** — CLI parity (\`claude-scope history\`).
- Log rotation, advanced filtering, per-rule history.

## Test plan

- [ ] Open ClaudeScope, make a move/add/delete. Click \"History\" — the new entry appears at the top of the dialog.
- [ ] Click History on a fresh install (no audit.jsonl yet) — empty-state copy renders, no error.
- [ ] Verify long rule strings wrap rather than overflow.
- [ ] Manually corrupt one line in \`~/.claude/claude-scope/audit.jsonl\`. Reopen History — the well-formed lines render, the footer warns about 1 skipped entry.
- [ ] Run with \`--home /tmp/scratch\`. Make writes. Reopen History — entries appear in the scratch log, NOT the real one.
- [ ] Tab through the dialog — focus traps to Close button, Escape closes, focus returns to the History trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)