### PR TITLE
docs: GitHub Pages docs site via mdBook (#26)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,87 @@
+# Builds the mdBook docs site (#26) and publishes it to GitHub Pages
+# on every push to dev. Manual dispatch is available for one-off
+# rebuilds (e.g. re-running after a workflow tweak).
+#
+# `mdbook-linkcheck` runs as a hard gate during the build — any broken
+# internal link fails the workflow. External link rot is handled by
+# `.github/workflows/link-check.yml` (lychee, non-blocking) on a
+# weekly schedule; the two tools are complementary.
+#
+# Pages config (one-time, in repo Settings → Pages):
+#   - Source: "GitHub Actions" (not "Deploy from a branch")
+# Without that flip, the actions/deploy-pages step here errors with
+# "Get Pages site failed" — author the workflow first, then enable.
+
+name: Docs
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+concurrency:
+  # One published artifact at a time per ref. Cancel an in-flight
+  # build when a newer push lands so the latest source wins.
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build mdBook
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # `mdbook` and `mdbook-linkcheck` are small, self-contained Rust
+      # binaries. Using `cargo install` keeps the toolchain pinned to
+      # whatever version is current at workflow-run time without
+      # introducing a third-party setup action. Cached so re-runs that
+      # don't change anything skip the compile.
+      - name: Cache cargo bin
+        id: cache-cargo-bin
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-mdbook-${{ hashFiles('.github/workflows/docs.yml') }}
+
+      - name: Install mdbook + mdbook-linkcheck
+        if: steps.cache-cargo-bin.outputs.cache-hit != 'true'
+        run: |
+          cargo install mdbook --locked
+          cargo install mdbook-linkcheck --locked
+
+      - name: Build (with hard linkcheck gate)
+        # `mdbook build` returns non-zero on linkcheck errors because
+        # `book.toml` sets `warning-policy = "error"`. No extra flags
+        # needed — the config is the source of truth so a local
+        # `mdbook build docs/` reproduces CI failure modes.
+        run: mdbook build docs/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book/html
+
+  deploy:
+    name: Deploy to Pages
+    # Only publish from the canonical branch. PR builds run the build
+    # job for the linkcheck gate but don't deploy — that would leak
+    # in-progress edits to the live URL.
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
+    needs: build
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,15 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/docs.yml"
+  # PRs against dev that touch docs run the build job (linkcheck gate)
+  # but skip the deploy job — see the `if:` on the deploy job below.
+  # Without this, broken internal links could merge to dev and only
+  # fail at publish time, which is the wrong direction for a hard gate.
+  pull_request:
+    branches: [dev]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,11 +61,18 @@ jobs:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-mdbook-${{ hashFiles('.github/workflows/docs.yml') }}
 
+      # Version pinning: mdbook-linkcheck 0.7.x reads mdbook's
+      # `RenderContext` directly, and that struct changed shape in
+      # mdbook 0.5 — the linkcheck preprocessor errors with
+      # `missing field 'sections'` against newer mdbook. Pinning both
+      # crates to versions known to interoperate is the standard
+      # workaround for that upstream incompatibility. Bump in lockstep
+      # if/when mdbook-linkcheck catches up.
       - name: Install mdbook + mdbook-linkcheck
         if: steps.cache-cargo-bin.outputs.cache-hit != 'true'
         run: |
-          cargo install mdbook --locked
-          cargo install mdbook-linkcheck --locked
+          cargo install mdbook --locked --version 0.4.37
+          cargo install mdbook-linkcheck --locked --version 0.7.7
 
       - name: Build (with hard linkcheck gate)
         # `mdbook build` returns non-zero on linkcheck errors because

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ src-tauri/WixTools/
 # Releases. Belt-and-suspenders ignore in case a stale config or local run
 # resurrects the file.
 CHANGELOG.md
+
+# mdBook output (#26). `mdbook build docs/` regenerates `docs/book/` on
+# every run, and CI publishes it via actions/deploy-pages. Local builds
+# can also be served from `docs/book/`; the source of truth lives at
+# `docs/src/`.
+docs/book/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Desktop GUI for promoting [Claude Code](https://docs.claude.com/en/docs/claude-code) permission rules between scopes — without hand-editing JSON.
 
+📖 **User and architecture docs live at [bminier.github.io/claude-scope](https://bminier.github.io/claude-scope/)** — built from `docs/src/` via mdBook, deployed on every push to `dev`.
+
 > For the original problem statement, design goals, and non-goals, see [`CLAUDE.md`](./CLAUDE.md). It's the project brief; the README is the "how to use and hack on it" doc.
 
 ## What it does

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -11,10 +11,6 @@ description = "Desktop GUI for promoting Claude Code permission rules between sc
 authors = ["Brian Minier"]
 language = "en"
 src = "src"
-# Default multilingual mode would otherwise be picked up if a future
-# translation lands; pinning explicitly keeps the SUMMARY single-source
-# until that's a real concern.
-multilingual = false
 
 [build]
 # Build output goes to `docs/book/` (the mdBook default). The directory

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,47 @@
+# mdBook configuration for the ClaudeScope docs site (#26).
+#
+# Published to https://bminier.github.io/claude-scope/ via the
+# `.github/workflows/docs.yml` workflow on every push to `dev`.
+# `mdbook-linkcheck` runs as a hard gate during the build — broken
+# internal links fail the workflow.
+
+[book]
+title = "ClaudeScope"
+description = "Desktop GUI for promoting Claude Code permission rules between scopes."
+authors = ["Brian Minier"]
+language = "en"
+src = "src"
+# Default multilingual mode would otherwise be picked up if a future
+# translation lands; pinning explicitly keeps the SUMMARY single-source
+# until that's a real concern.
+multilingual = false
+
+[build]
+# Build output goes to `docs/book/` (the mdBook default). The directory
+# is gitignored; CI uploads it as the Pages artifact. Local previews
+# work via `mdbook serve docs/`.
+build-dir = "book"
+
+[output.html]
+default-theme = "rust"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/bminier/claude-scope"
+edit-url-template = "https://github.com/bminier/claude-scope/edit/dev/docs/{path}"
+site-url = "/claude-scope/"
+no-section-label = false
+
+[output.html.fold]
+enable = true
+level = 1
+
+# Hard internal-link gate (#26 DoD). The preprocessor walks every
+# rendered chapter and fails the build if any local Markdown link
+# resolves nowhere. External link rot is handled separately by
+# `.github/workflows/link-check.yml` (lychee, non-blocking) — the two
+# tools are complementary: lychee covers the whole markdown surface
+# weekly with non-fatal reporting, this gate covers the book's internal
+# graph on every build with a hard fail.
+[output.linkcheck]
+follow-web-links = false
+warning-policy = "error"
+exclude = []

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,26 @@
+# Summary
+
+[Introduction](./index.md)
+
+# User guide
+
+- [Scopes](./user-guide/scopes.md)
+- [Moving rules](./user-guide/moving-rules.md)
+- [Undo and history](./user-guide/undo-redo.md)
+
+# Reference
+
+- [Rule syntax](./reference/rule-syntax.md)
+- [CLI](./reference/cli.md)
+- [Settings keys](./reference/settings-keys.md)
+
+# Architecture
+
+- [Overview](./architecture/overview.md)
+- [Atomic writes](./architecture/atomic-writes.md)
+- [Audit log](./architecture/audit-log.md)
+
+# Project
+
+- [Contributing](./contributing.md)
+- [Security](./security.md)

--- a/docs/src/architecture/atomic-writes.md
+++ b/docs/src/architecture/atomic-writes.md
@@ -1,0 +1,77 @@
+# Atomic writes
+
+Every settings-file write in ClaudeScope funnels through a single
+`atomic_write_json` chokepoint in `src-tauri/src/io_atomic.rs`. The
+sequence:
+
+1. **Serialize** the in-memory `SettingsDoc` to bytes.
+2. **Re-parse** the produced bytes via `serde_json::from_slice` — if
+   they don't round-trip, the write is refused before anything hits
+   disk. Bad bytes never escape.
+3. **Tempfile** in the same directory as the target.
+4. **Stamp recheck** — a `FileStamp` (mtime + length) captured at load
+   time is compared to the target's current state. If the file
+   changed on disk between load and save, the write is refused with a
+   "reload and retry" error rather than overwriting the external
+   edit. The recheck has a microsecond-scale TOCTOU window between
+   the comparison and the `persist` — a writer that lands inside
+   that window will still be overwritten.
+5. **Rename** the tempfile over the target. The rename is
+   filesystem-atomic.
+6. On Unix, the parent directory is also `fsync`'d so the rename is
+   crash-durable. On Windows, the parent-dir flush is skipped —
+   `std::fs` cannot open a directory handle for flushing without a
+   small raw-winapi wrapper, and NTFS journals rename metadata in
+   `MoveFileEx` already.
+
+## Backups
+
+On the first write of a given file per session, the original is
+copied to `<file>.bak`. Existing `.bak` files from previous runs are
+preserved, not clobbered. This is a one-shot backup attempt, not a
+best-effort write-through: **if backup creation is required and the
+copy fails, the error is surfaced and the write is not attempted**.
+
+The behavior is opt-out under **Settings → Backups**
+([#88](https://github.com/bminier/claude-scope/issues/88)). Users
+whose `.claude/` is version-controlled and don't want extra files can
+turn it off — at which point the audit log
+([Undo and history](../user-guide/undo-redo.md)) becomes the only
+safety net.
+
+## Moves are two-file transactions
+
+A scope-to-scope move writes the **destination first**, then removes
+the rule from the source. If the source write fails, the destination
+write is rolled back so the rule ends up in exactly one scope rather
+than being lost *or* duplicated. If the rollback itself fails the
+user sees an explicit error rather than a silent partial state.
+
+The rollback path can't reuse `apply_move_leaf_impl` — it has to
+write the pre-move destination directly, with no `.bak` (we already
+created one), and with no stamp check (we are the canonical writer of
+the destination at that point). This is why the apply impl threads
+`backups` and `stamp` parameters down explicitly rather than reading
+them from a static.
+
+## What's atomic vs. what's not
+
+**Atomic:**
+
+- The bytes hitting any single file. Either the new contents land
+  intact or the old contents are preserved — never a partial write.
+- The rename of tempfile-over-target on a single filesystem.
+- The bytes-validate-as-JSON gate. The re-parse step runs before any
+  filesystem operation; broken JSON never reaches disk.
+
+**Not atomic:**
+
+- The pair of writes that constitute a cross-scope move. They are
+  two filesystem operations; if the process is killed between them,
+  the rollback can't run. The destination's `.bak` is the recovery
+  path in that case.
+- The audit log append relative to the settings write. The audit
+  entry lands *after* the settings write succeeds, so a process kill
+  in that narrow window means a write happened but isn't logged. The
+  log being authoritative-for-history-but-not-state
+  ([Architecture → Overview](./overview.md)) absorbs that gap.

--- a/docs/src/architecture/audit-log.md
+++ b/docs/src/architecture/audit-log.md
@@ -1,0 +1,106 @@
+# Audit log
+
+ClaudeScope appends one JSON Lines record per successful write to
+`~/.claude/claude-scope/audit.jsonl`. The log is the foundation for
+[Undo and history](../user-guide/undo-redo.md); the design document
+lives at
+[#19](https://github.com/bminier/claude-scope/issues/19).
+
+## Record shape
+
+Each line is a self-contained JSON record. Phase 1 (#122) pinned the
+schema; phases 3-5 (#124 / #125 / #126) extend the consumer surface
+but don't break it.
+
+```jsonc
+{
+  "id": "01HF...",                   // ULID (Crockford base32). Lex-sort = chrono-sort.
+  "kind": "move",                    // move | add | delete | change_kind | restore (Phase 3+)
+  "leaf_kind": "permission_rule",    // permission_rule | permission_list | top_level_key
+  "actor": "gui",                    // gui | cli | skill | restore
+  "project_dir": "/work/proj",       // optional — user-scope-only ops omit
+  "from": {                          // optional — Add omits, top-level Restore omits
+    "scope": "project",
+    "file_path": "/work/proj/.claude/settings.json",
+    "top_level_key": "permissions",
+    "key_before": { "allow": ["Bash(ls)", "Read(**)"] },
+    "key_after":  { "allow": ["Read(**)"] }
+  },
+  "to": {                            // optional — Delete omits
+    "scope": "user",
+    "file_path": "/home/me/.claude/settings.json",
+    "top_level_key": "permissions",
+    "key_before": { "allow": [] },
+    "key_after":  { "allow": ["Bash(ls)"] }
+  },
+  "path": ["permissions", "allow", 0],
+  "to_kind": null,                   // set on change-kind ops
+  "claude_scope_version": "0.3.0"
+}
+```
+
+The **affected top-level key** (`permissions` for permission ops, the
+moved key for top-level moves) is snapshotted before AND after on
+each side. That's the minimum needed for restore (Phase 4) to invert
+any logged op without re-reading history, while staying narrower than
+the whole file.
+
+## Why ULID, not timestamps
+
+ULIDs embed a 48-bit millisecond timestamp in their first half and a
+random suffix in the second. Three benefits:
+
+- **Lex-sort = chrono-sort.** A reader can `sort` the file by `id`
+  and get correct ordering without trusting wall-clock timestamps,
+  which can skew across machines or under NTP jumps.
+- **One field, not two.** A separate `ts` field could drift from
+  `id` under clock corrections. Decoding the timestamp from the ULID
+  at read time keeps the two in lockstep by construction.
+- **Compact**. 26 chars of base32, fits a line cleanly.
+
+The frontend never parses Crockford base32 directly — the
+`list_audit_records` IPC returns an `AuditRecordView` with `id` and a
+derived `ts_ms: u64` flattened together. The CLI mirrors the same
+shape with `--json`.
+
+## Append is one syscall
+
+`audit::append` opens with `O_APPEND` and writes the serialized
+record + `\n` in a single `write_all` call. For any sane record size
+that lands as a single kernel `write()` syscall, which the OS
+executes atomically against concurrent appenders. That's the
+property the truncated-tail-tolerance in `audit::read_all` relies on:
+a partial line is treated as one skipped entry, not as a parse
+failure that aborts the read.
+
+## Fail-open
+
+A failure to append never fails the primary write. The user asked
+ClaudeScope to move a rule; an `audit.jsonl` permission error
+doesn't negate that. The append happens *after* the settings write
+succeeds, so a failure here means the file is updated but not
+logged — which is the safe direction for ambiguity.
+
+Tauri emits an `audit-error` event when an append fails, surfaced as
+a non-fatal warning in the GUI.
+
+## Rotation
+
+Once `audit.jsonl` exceeds the configurable size cap (default
+10 MB), `rotate_if_needed` runs before the next append. The active
+file is renamed to `audit-YYYY-MM.jsonl` (using the file's mtime, so
+the stamp reflects the data inside) and the next entry lands in a
+fresh `audit.jsonl`. Same-month collisions become `-2`, `-3`, ...
+suffixes.
+
+The reader **only scans the active file**. Archives are archival —
+the History dialog and `claude-scope-cli history` don't surface
+them. Future restore-to-point work (#125) is similarly bounded to
+the active log; cross-archive restore would be a separate feature.
+
+## Sandbox
+
+When `--home` is set, `emit_audit` skips the rotation + append
+sequence entirely. Scratch runs cannot pollute the real
+`~/.claude/claude-scope/`. The preferences-write path has the same
+guard.

--- a/docs/src/architecture/overview.md
+++ b/docs/src/architecture/overview.md
@@ -1,0 +1,82 @@
+# Architecture overview
+
+ClaudeScope is a [Tauri 2](https://tauri.app) app — Rust backend, web
+front end, single binary output. The split:
+
+```
+┌─────────────────────────────────────────────────────┐
+│              Vanilla TS + Vite (front end)          │
+│  src/main.ts       state + IPC + keybindings        │
+│  src/ui.ts         DOM rendering, diff modal, …     │
+│  src/lint.ts       shape-level rule-string lint     │
+│  src/types.ts      shared types mirrored from Rust  │
+└────────────────────┬────────────────────────────────┘
+                     │  Tauri IPC (#[tauri::command])
+┌────────────────────┴────────────────────────────────┐
+│                     Rust backend                     │
+│  src-tauri/src/                                      │
+│    main.rs       Tauri entry                         │
+│    lib.rs        Builder + managed state + IPC reg.  │
+│    scope.rs      Scope discovery (walk-up, paths)    │
+│    projects.rs   ~/.claude/projects/ enumeration     │
+│    io_atomic.rs  Atomic read/write + .bak tracker    │
+│    model.rs      SettingsDoc, perm add/remove        │
+│    commands.rs   #[tauri::command] handlers          │
+│    watcher.rs    notify-based file watcher           │
+│    audit.rs      JSONL audit log + rotation          │
+│    preferences.rs Per-user config (theme, LRU, …)    │
+│    app_info.rs   Build/runtime diagnostics           │
+│    runtime.rs    --home / --project override layer   │
+└──────────────────────────────────────────────────────┘
+```
+
+A second binary `claude-scope-cli` (`src-tauri/src/bin/cli.rs`) re-uses
+the same library — same scope discovery, same atomic-write machinery,
+same audit log. Anything the GUI can do via IPC, the CLI eventually
+exposes as a subcommand. See [CLI](../reference/cli.md) for the
+current surface.
+
+## Boundaries
+
+- **Front end never writes files directly.** Every file-touching
+  operation goes through a Tauri command. That keeps the
+  atomic-write invariants concentrated on the Rust side where they
+  can't be reordered by a re-render.
+- **Wire types live in one place per direction.** Rust structs in
+  `commands.rs` serialize to JSON; `src/types.ts` mirrors the same
+  shapes by hand. A schema generator would be over-engineering for
+  the surface area today.
+- **The audit log is the source of truth for history; the filesystem
+  is the source of truth for state.** They can diverge — if a user
+  hand-edits a settings file between sessions, the log is stale, and
+  restore (when it lands) re-reads the current file before computing
+  any delta.
+
+## Scope discovery
+
+`scope::resolve_with_home()` walks up from a starting directory
+looking for a `.git` entry (preferred), or a `.claude/` directory, to
+identify the project root. From there it derives:
+
+- `project_dir/.claude/settings.local.json` → **Local**
+- `project_dir/.claude/settings.json` → **Project**
+- `<home>/.claude/settings.local.json` → **User-Local**
+- `<home>/.claude/settings.json` → **User**
+
+The `<home>` argument defaults to `dirs::home_dir()` but is
+overridable for sandbox runs (`--home`, `CLAUDE_SCOPE_HOME`). See
+[Moving rules → Sandbox mode](../user-guide/moving-rules.md#sandbox-mode).
+
+## Stack
+
+- **[Tauri 2](https://tauri.app)** — Rust backend + webview.
+- **Vanilla TypeScript + Vite** — front end (intentionally tiny, no
+  framework).
+- **[`serde_json`](https://docs.rs/serde_json)** with `preserve_order`
+   — key order survives round-trips.
+- **[`notify-debouncer-mini`](https://docs.rs/notify-debouncer-mini)**
+   — cross-platform file watching with built-in debouncing.
+- **[`ulid`](https://docs.rs/ulid)** — chronologically-sortable IDs
+  for audit-log records.
+- **[Biome 2](https://biomejs.dev)** — formatter + linter + import
+  sorter for the front end.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,0 +1,150 @@
+# Contributing
+
+This document covers local dev setup, the test suites, and the
+release flow. For the original project brief — problem statement,
+must-have behavior, non-goals — see [`CLAUDE.md`](https://github.com/bminier/claude-scope/blob/dev/CLAUDE.md)
+at the repo root.
+
+## Develop
+
+### Prerequisites
+
+- **Rust** — stable, 1.88+ (imposed by Tauri 2's transitive deps).
+  Install via [rustup](https://rustup.rs):
+  - **Windows:** `winget install Rustlang.Rustup` (then restart your
+    terminal).
+  - **macOS / Linux:**
+    `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`.
+
+  > The Tauri CLI is bundled as an npm dev dependency —
+  > `cargo install tauri-cli` is **not** needed. Use
+  > `npm run tauri dev` (not `cargo tauri dev`).
+- **Node.js** 20+ and **npm**.
+- **Linux build deps** (only on Linux):
+  ```sh
+  sudo apt-get install libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+  ```
+- **pre-commit** (optional, strongly recommended — CI runs the same
+  hooks):
+  ```sh
+  pip install --user pre-commit
+  pre-commit install
+  ```
+
+### Run
+
+```sh
+npm install
+npm run tauri dev
+```
+
+For a non-destructive dogfood loop against a throwaway home, see
+[Moving rules → Sandbox mode](./user-guide/moving-rules.md#sandbox-mode).
+
+### Tests
+
+```sh
+# Rust unit tests (scope discovery, atomic writes, audit log, …).
+(cd src-tauri && cargo test)
+
+# Front-end type check + Vitest.
+npx tsc --noEmit
+npx vitest run
+```
+
+A manual smoke pass for UI changes lives in
+[`docs/SMOKE_TEST.md`](https://github.com/bminier/claude-scope/blob/dev/docs/SMOKE_TEST.md)
+at the repo root — a ~5-minute checklist covering the move flow,
+watcher reload, scope visibility, and side-effect verification.
+
+### Lint / format
+
+```sh
+# Run everything the `lint` CI job runs (Biome, rustfmt, clippy,
+# hygiene hooks).
+pre-commit run --all-files
+
+# Front-end only:
+npm run lint       # biome check (lint + format check)
+npm run format     # biome format --write
+
+# Rust side:
+(cd src-tauri && cargo fmt --all --check && cargo clippy --all-targets -- -D warnings)
+```
+
+### Build
+
+```sh
+npm run tauri build
+```
+
+### Docs
+
+This site is built with [mdBook](https://rust-lang.github.io/mdBook/).
+Edit the Markdown under `docs/src/` and either of:
+
+```sh
+# Live-reload preview at http://localhost:3000.
+mdbook serve docs/
+
+# One-shot build to docs/book/ (the CI artifact).
+mdbook build docs/
+```
+
+`mdbook-linkcheck` runs as a hard gate during CI — broken internal
+links fail the build. External link rot is monitored separately by
+the lychee workflow on the same Markdown surface.
+
+## CI
+
+Every push to `dev` and every PR against `dev` runs four jobs in
+parallel:
+
+- **`build`** — matrix across `ubuntu-24.04`, `windows-latest`,
+  `macos-latest`. Each runs `npm ci`, `tsc --noEmit`, `vite build`,
+  `cargo test --lib --locked`.
+- **`msrv (1.88)`** — validates the declared MSRV via
+  `cargo check --lib --tests --locked` on Rust 1.88.0.
+- **`lint`** — `pre-commit/action@v3` (Biome, rustfmt, clippy,
+  hygiene hooks).
+- **`security`** — `rustsec/audit-check` against the RustSec
+  advisory DB + `npm audit --package-lock-only --audit-level=high`
+  (reads the lockfile directly; no `node_modules` install, no
+  lifecycle scripts).
+
+## Releasing
+
+Version bumps are automated by `release-please` but **manually
+triggered**. Run **Actions → Release Please → Run workflow** and
+release-please walks `dev` since the last tag, opens a "release PR"
+that bumps every version-carrying file in lockstep (`package.json`,
+`package-lock.json`, `src-tauri/Cargo.toml`,
+`src-tauri/tauri.conf.json`, plus `src-tauri/Cargo.lock` via a
+follow-up sync step). Merging that PR pushes a `vX.Y.Z` tag, which
+triggers `release.yml` to build and upload installers +
+`SHA256SUMS.txt`. Release notes live on the GitHub Release itself —
+`skip-changelog` is set in `release-please-config.json`, so there is
+no tracked `CHANGELOG.md`.
+
+If you ever need to bump versions by hand (e.g. release-please is
+broken), do **not** regenerate `package-lock.json` with
+`npm install --package-lock-only` on Windows — npm drops Linux-only
+optional deps (e.g. `@emnapi/*`, `@napi-rs/*`) and `npm ci` then
+fails on the Linux CI runner. Edit only the two `"version"` fields
+in the lockfile and leave the dependency tree alone.
+`scripts/sync-cargo-lock.py` updates the `claude-scope` entry in
+`Cargo.lock` without touching anything else.
+
+### Known limitation: unsigned builds
+
+Releases are currently **unsigned**:
+
+- **Windows**: first launch shows a SmartScreen warning (click "More
+  info" → "Run anyway").
+- **macOS**: first launch shows a Gatekeeper warning (right-click
+  the app → Open → Open).
+- **Linux**: no warning.
+
+Signing would require a Windows code-signing certificate and/or an
+Apple Developer ID + notarization. Planned, but out of scope until
+there's demand.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,34 @@
+# ClaudeScope
+
+Desktop GUI for promoting [Claude Code](https://docs.claude.com/en/docs/claude-code)
+permission rules between scopes — without hand-editing JSON.
+
+Claude Code reads settings from JSON files at four scopes (User, User-Local,
+Project, Local). Moving a rule from one to another by hand means editing two
+files, preserving key order, and not breaking the JSON. ClaudeScope shows
+every rule across the four scopes side-by-side and moves them with a click.
+
+## What's here
+
+- **[User guide](./user-guide/scopes.md)** — the scope model, how moves
+  work, and how history / undo (#19) lets you walk operations back.
+- **[Reference](./reference/rule-syntax.md)** — permission-rule grammar
+  ClaudeScope understands, the `claude-scope-cli` subcommand surface, and
+  the per-key help shown by tooltips.
+- **[Architecture](./architecture/overview.md)** — how the Rust backend
+  and TypeScript front end fit together; the atomic-write invariants;
+  the on-disk audit log.
+- **[Contributing](./contributing.md)** — local dev setup, the test
+  suites, and the release workflow.
+- **[Security](./security.md)** — how to report a vulnerability and what
+  CI catches.
+
+## Install
+
+Pre-built installers for Windows, macOS, and Linux are attached to each
+[GitHub Release](https://github.com/bminier/claude-scope/releases).
+First launch on Windows or macOS shows an unsigned-binary warning;
+signed builds are planned but not yet available — see
+[Contributing → Known limitation: unsigned builds](./contributing.md#known-limitation-unsigned-builds).
+
+To run from source, see [Contributing → Develop](./contributing.md#develop).

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -1,0 +1,113 @@
+# CLI
+
+`claude-scope-cli` is a terminal front end that re-uses the same Rust
+backend the GUI does — scope discovery, atomic writes, the move-leaf
+primitive, the audit log. It's installed alongside the GUI by the
+release installers and is also available via `cargo build --bin
+claude-scope-cli` for source builds.
+
+The Claude Code skill side (#13) wraps this binary; the JSON output of
+every subcommand is stable enough that a script or skill can rely on
+it.
+
+## Global flags
+
+Every subcommand accepts:
+
+- `--project-dir <PATH>` — pin the project root. Without this,
+  ClaudeScope walks up from `cwd` for the nearest `.git` or `.claude/`.
+- `--home-dir <PATH>` — sandbox mode. Redirects user / user-local
+  scope lookups (and the audit log) under this directory.
+
+## Subcommands
+
+### `scopes`
+
+List recognized scopes and their on-disk state.
+
+```sh
+claude-scope-cli scopes [--json]
+```
+
+### `show`
+
+Print one scope's raw contents, or the effective merged view.
+
+```sh
+claude-scope-cli show --scope user [--json]
+claude-scope-cli show --effective [--json]
+```
+
+`--scope` and `--effective` are mutually exclusive.
+
+### `list-rules`
+
+List permission rules across scopes.
+
+```sh
+claude-scope-cli list-rules [--scope <SCOPE>] [--kind <KIND>] [--json]
+```
+
+`--kind` accepts `allow` / `deny` / `ask`.
+
+### `list-projects`
+
+Enumerate Claude projects discovered on this machine, via the
+`~/.claude/projects/` transcript registry.
+
+```sh
+claude-scope-cli list-projects [--json]
+```
+
+### `version`
+
+Print the same diagnostic block the GUI's About dialog shows. Useful
+for bug reports — paste the output into the issue.
+
+```sh
+claude-scope-cli version [--json]
+```
+
+The clap-builtin `--version` still prints just the version line.
+
+### `move`
+
+Move a permission rule between scopes. Writes are atomic and create a
+`.bak` of the original on the first write of the session.
+
+```sh
+claude-scope-cli move "Bash(git status)" --kind allow --from project --to user [--dry-run] [--json]
+```
+
+### `history`
+
+Read the audit log. See [Undo and history](../user-guide/undo-redo.md)
+for the user-facing description; the CLI surface mirrors the History
+dialog one-for-one.
+
+```sh
+claude-scope-cli history [--since <DURATION>] [--limit <N>] [--kind <KIND>]... [--json]
+```
+
+- `--since` accepts `s` / `m` / `h` / `d` / `ms` suffixes. Bare
+  numbers are rejected — the parser refuses to guess units.
+- `--limit` defaults to 20; `0` is unlimited.
+- `--kind` is repeatable: `move` / `add` / `delete` / `change-kind`.
+  OR semantics when multiple flags are passed.
+- `--json` emits the same `AuditLogPage` wire shape the GUI's
+  `list_audit_records` IPC returns.
+
+Human output: tab-separated `ULID  ts  verb  scope-arrow  rule`,
+newest-first.
+
+## Pending subcommands
+
+These wait on the audit-log work in
+[#19](https://github.com/bminier/claude-scope/issues/19) phases 3 and 4:
+
+- `claude-scope-cli undo` — invert the most recent non-restore entry.
+- `claude-scope-cli redo` — re-apply the most recent undone op.
+- `claude-scope-cli restore <entry-id>` — multi-step rollback to
+  before a chosen log entry.
+
+Tracked in [#126](https://github.com/bminier/claude-scope/issues/126).

--- a/docs/src/reference/rule-syntax.md
+++ b/docs/src/reference/rule-syntax.md
@@ -1,0 +1,79 @@
+# Rule syntax
+
+Claude Code's permission grammar isn't publicly documented in full,
+but a few common shapes are well-established. ClaudeScope recognizes
+these and surfaces a subtle ⚠ lint badge on rules that don't match any
+of them. **The badge is best-effort, not authoritative** — a flagged
+rule may still be valid; the popover names the heuristic that tripped
+so you can judge.
+
+## Shapes ClaudeScope knows
+
+| Shape | Example | Notes |
+|---|---|---|
+| `Bash(<pattern>)` | `Bash(git status)` | Shell command. Patterns may include `*` wildcards (`Bash(git *)`). |
+| `Read(<glob>)` | `Read(**)` | File read. Standard glob syntax. |
+| `WebFetch(domain:<host>)` | `WebFetch(domain:docs.claude.com)` | URL fetch restricted to a domain. |
+| `mcp__<server>__<tool>` | `mcp__filesystem__read_file` | MCP server tool invocation. |
+| `<Tool>(<args>)` | `Edit(*.ts)` / `Write(README.md)` | Generic tool-with-arguments shape. |
+
+Rules outside these shapes (no parentheses, unrecognized tool names,
+malformed args) are still allowed on disk — Claude Code may know
+shapes ClaudeScope doesn't. The lint just flags them so you can
+double-check.
+
+## Kinds
+
+Every rule lives under one of three lists at `permissions.<kind>`:
+
+- **`allow`** — permit the action without prompting.
+- **`deny`** — refuse the action.
+- **`ask`** — prompt before allowing.
+
+ClaudeScope shows each kind in its own column within a scope and lets
+you reclassify a rule in-place (right-click → **Change kind** → pick
+the destination kind). The same primitive powers cross-scope kind
+changes — moving `Bash(rm *)` from project-allow to user-deny is one
+operation.
+
+## Examples by tool
+
+Most realistic settings files have rules clustered around a few
+tools. Two or more rules sharing a `Tool(...)` prefix fold under a
+synthetic `Tool ▸ (N)` group in the per-scope tree view:
+
+```jsonc
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status)",
+      "Bash(git diff)",
+      "Bash(npm test)",
+      "Read(**)",
+      "WebFetch(domain:docs.claude.com)"
+    ]
+  }
+}
+```
+
+In the UI:
+
+```
+permissions
+├── allow
+│   ├── Bash ▸ (3)
+│   │   ├── Bash(git status)
+│   │   ├── Bash(git diff)
+│   │   └── Bash(npm test)
+│   ├── Read(**)
+│   └── WebFetch(domain:docs.claude.com)
+```
+
+The grouping threshold defaults to 2; tracked in
+[#115](https://github.com/bminier/claude-scope/issues/115) for a
+Settings-dialog control.
+
+## Useful docs
+
+- [Claude Code permissions](https://docs.claude.com/en/docs/claude-code/iam#permission-rules) — upstream reference for the permission system.
+- [Settings keys](./settings-keys.md) — per-key help map (planned, [#9](https://github.com/bminier/claude-scope/issues/9)).

--- a/docs/src/reference/settings-keys.md
+++ b/docs/src/reference/settings-keys.md
@@ -1,0 +1,33 @@
+# Settings keys
+
+A reference for every recognized top-level key in
+`.claude/settings.json` (and the `.local.json` overrides), with the
+same one-sentence explanations the in-app hover tooltips surface.
+
+The full per-key help map lives in
+[`src/ui.ts`](https://github.com/bminier/claude-scope/blob/dev/src/ui.ts)
+today; tracked in
+[#9](https://github.com/bminier/claude-scope/issues/9) for canonical
+content with deep links to Claude Code's documentation. Until that's
+exported as structured data, this page is a stub — see the in-app
+tooltips for the current help text.
+
+## Common keys
+
+- **`permissions`** — `allow` / `deny` / `ask` rule lists. The
+  primary surface ClaudeScope manages. See
+  [Rule syntax](./rule-syntax.md).
+- **`env`** — environment variables Claude Code injects into each
+  agent invocation.
+- **`hooks`** — pre / post tool-call hooks. Powerful and easy to
+  misuse; double-check before moving these between scopes.
+- **`theme`** — UI theme override (`auto` / `light` / `dark`).
+- **`model`** — default model selector.
+- **`apiKeyHelper`** — script invoked to source the API key on
+  demand.
+- **`statusLine`** — custom status-line configuration.
+- **`enableAllProjectMcpServers`** — escape hatch for
+  per-project MCP plumbing.
+
+For the authoritative list, see
+[Claude Code's settings documentation](https://docs.claude.com/en/docs/claude-code/settings).

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -1,0 +1,63 @@
+# Security
+
+## Reporting a vulnerability
+
+Please **do not open a public GitHub issue** for security problems.
+
+Report them via
+[GitHub Private Vulnerability Reporting](https://github.com/bminier/claude-scope/security/advisories/new).
+It's the fastest channel and keeps the details private until there's
+a fix ready to announce. You don't need any special access — anyone
+with a GitHub account can file one.
+
+What to include:
+
+- A clear description of the issue and its impact.
+- Steps to reproduce (the smallest version that still demonstrates
+  the problem).
+- The affected version or commit.
+- Any suggested fix or mitigation, if you have one.
+
+Acknowledgement: within a few business days, with a sense of the
+expected timeline from there.
+
+## Supported versions
+
+ClaudeScope is pre-1.0. Only the most recent tagged release gets
+security fixes — and until `v0.1.0` actually ships, that means the
+latest commit on the `dev` branch. Older tags (once they exist) are
+archived as-is.
+
+## What CI catches
+
+These checks run on every push to `dev` and every PR against it (see
+[`.github/workflows/ci.yml`](https://github.com/bminier/claude-scope/blob/dev/.github/workflows/ci.yml)):
+
+- **`cargo-audit`** — gates on advisories in the
+  [RustSec advisory DB](https://rustsec.org) for any Rust dep in
+  `src-tauri/Cargo.lock`.
+- **`npm audit --package-lock-only --audit-level=high`** — gates on
+  high+ severity vulnerabilities in the npm tree, reading
+  `package-lock.json` directly (no `node_modules` install, no
+  lifecycle scripts).
+- **`detect-private-key`** pre-commit hook — rejects commits
+  containing common private-key headers.
+- **Dependabot** — opens weekly grouped PRs for Cargo, npm, and
+  GitHub Actions minor/patch bumps so known-patched vulns don't
+  linger.
+
+Anything `cargo-audit` or `npm audit` surfaces after a clean merge is
+a signal to ship a patch PR. The advisory DBs update continuously,
+so a dep that was clean yesterday can light up the `security` job
+tomorrow with no code change on our end.
+
+## Privacy
+
+- ClaudeScope is a **local-only** tool. It reads and writes files on
+  the user's machine; no network requests in normal operation.
+- The audit log (`~/.claude/claude-scope/audit.jsonl`) is as sensitive
+  as the settings files themselves — it contains full rule text and
+  project paths. Don't ship it anywhere. The on-disk format is
+  documented at [Architecture → Audit log](./architecture/audit-log.md).
+- The docs site (this one) has **no analytics**. No tracking
+  pixels, no third-party scripts.

--- a/docs/src/user-guide/moving-rules.md
+++ b/docs/src/user-guide/moving-rules.md
@@ -1,0 +1,70 @@
+# Moving rules
+
+Every per-rule action goes through the same primitive: pick a rule,
+pick a destination scope (or `allow` / `deny` / `ask` if you're
+reclassifying), confirm the diff, write. The destination file is
+written **first**, then the source file is rewritten without the rule.
+If the source rewrite fails, the destination is rolled back — the rule
+never ends up in two places, never goes missing. See
+[Architecture → Atomic writes](../architecture/atomic-writes.md) for
+the invariants.
+
+## From the GUI
+
+Each rule row carries move buttons for every other scope (`→ User`,
+`→ Project`, etc.). Right-click the row for the full menu:
+
+- **Move to** → submenu with scopes + a "Project…" submenu listing
+  every discovered Claude project (so a rule can land directly in
+  another repo's `.claude/settings.json` without switching the loaded
+  project).
+- **Change kind** → switch `allow` ↔ `deny` ↔ `ask` within the same scope.
+- **Copy / Paste** — clipboard plumbing for rules and rule lists.
+- **Delete** — drops the rule from its scope.
+
+Every action that writes shows a **diff preview modal** first. Apply
+the move with `Enter`, cancel with `Escape`. The trigger button gets
+focus back when the modal closes.
+
+## Search
+
+Press `/` anywhere to focus the search input. Filter is
+case-insensitive substring across rules in every scope. Match counts
+appear per group (`allow (1/3)` = one match out of three). Escape
+clears the filter.
+
+## Tool grouping
+
+When two or more rules share a tool prefix (`Bash(...)`,
+`handoff(...)`), they fold under a synthetic `Tool ▸ (N)` node. The
+threshold defaults to 2; future work tracked in
+[#115](https://github.com/bminier/claude-scope/issues/115) will
+surface it as a Settings option.
+
+## Sandbox mode
+
+Two ways to dogfood a build against a throwaway home directory rather
+than your real `~/.claude/`:
+
+```sh
+# Env vars (works with `npm run tauri dev`):
+CLAUDE_SCOPE_HOME=/tmp/scratch CLAUDE_SCOPE_PROJECT=/tmp/scratch/project npm run tauri dev
+
+# CLI flags (works against a built binary):
+claude-scope --home /tmp/scratch --project /tmp/scratch/project
+```
+
+When either override is active, a yellow **Sandbox mode** banner sits
+under the toolbar so you can't forget you're in scratch mode. The
+audit log, recent-projects LRU, and preferences write to the scratch
+home too — running ClaudeScope under `--home` cannot pollute the real
+config dir.
+
+`scripts/scratch-home.py` seeds a fresh scratch dir with realistic
+example settings:
+
+```sh
+python scripts/scratch-home.py            # auto temp dir
+python scripts/scratch-home.py /tmp/sb    # explicit, idempotent
+python scripts/scratch-home.py /tmp/sb --force   # wipe + reseed
+```

--- a/docs/src/user-guide/scopes.md
+++ b/docs/src/user-guide/scopes.md
@@ -1,0 +1,64 @@
+# Scopes
+
+Claude Code reads settings from JSON files at four scopes. The scopes are
+laid out in **precedence order, highest first** — the highest-precedence
+file that defines a key wins.
+
+| # | Scope | Path | Tracked? |
+|---|---|---|---|
+| 1 | Managed | enterprise-deployed | Out of scope for ClaudeScope. |
+| 2 | Local | `./.claude/settings.local.json` | Project-local, gitignored. |
+| 3 | Project | `./.claude/settings.json` | Committed with the project. |
+| 4 | User-Local | `~/.claude/settings.local.json` | Machine-local override. |
+| 5 | User | `~/.claude/settings.json` | Machine-global. |
+
+ClaudeScope **omits Managed** (#1) entirely — it's an enterprise concern
+that lives outside the personal-tool workflow this project targets.
+
+> **`~/.claude/settings.local.json`** was originally excluded too, but
+> Claude Code is observed to create and use it when the user's home
+> directory is itself inside a git repo. ClaudeScope treats it as a
+> first-class scope on par with the other three.
+
+## Column layout
+
+The four scopes render as columns, **broadest-on-the-left to
+narrowest-on-the-right**:
+
+```
+┌─────────┬─────────────┬──────────┬───────┐
+│  User   │ User-Local  │ Project  │ Local │
+└─────────┴─────────────┴──────────┴───────┘
+   ←──── broader / shared      narrower ───→
+```
+
+That's the opposite of precedence order. ClaudeScope's column order is
+about *audience* — User-scope rules affect every project, Local-scope
+rules affect one. The "Combined permissions" panel above the columns is
+a simple union across scopes; it's **not** a full precedence-aware
+evaluation of what Claude Code resolves at runtime, and the subtitle in
+the app says so.
+
+## Per-scope file presence
+
+A scope's column shows as **absent** when its file doesn't exist on
+disk. ClaudeScope never auto-creates a scope file just to fill the
+column; it creates the file on first write to that scope, and only
+then. A move into an empty scope produces a fresh `settings.json` (or
+`settings.local.json`) with just the moved rule.
+
+The User and User-Local scopes resolve relative to the OS home
+directory (`%USERPROFILE%` on Windows, `$HOME` elsewhere); Project and
+Local resolve from the currently-loaded project root. See
+[Architecture → Overview](../architecture/overview.md) for how scope
+discovery walks up from the project picker's selection.
+
+## Switching projects
+
+Two ways to switch the loaded project:
+
+- **Open project…** — file picker; default to `~` on first open.
+- **Recent projects dropdown** — click the project label in the topbar
+  for a menu of recently-opened roots (capped at 10, persists across
+  sessions). See [Moving rules](./moving-rules.md) for the move flows
+  that this enables across projects.

--- a/docs/src/user-guide/undo-redo.md
+++ b/docs/src/user-guide/undo-redo.md
@@ -1,0 +1,70 @@
+# Undo and history
+
+ClaudeScope keeps an append-only **audit log** of every successful
+write — moves, adds, deletes, kind changes. The log answers questions
+the single-slot `.bak` model can't:
+
+- *"What did I change in the last hour, in order?"*
+- *"Undo the last change."* (Not the whole session — just the last one.)
+- *"Take me back to before I imported that preset."*
+
+## What ships today
+
+| Phase | Feature | Status |
+|---|---|---|
+| 1 | JSONL audit log at `~/.claude/claude-scope/audit.jsonl` | Shipped ([#19](https://github.com/bminier/claude-scope/issues/19) phase 1) |
+| 2 | Read-only **History** dialog (topbar button) listing entries newest-first | Shipped (#19 phase 2) |
+| 3 | `Ctrl+Z` / `Cmd+Z` undo via the diff-confirm modal | Tracked in [#124](https://github.com/bminier/claude-scope/issues/124) |
+| 4 | "Restore to before this" — multi-step rollback from a History row | Tracked in [#125](https://github.com/bminier/claude-scope/issues/125) |
+| 5 | CLI parity (`claude-scope-cli history` shipped; `undo / redo / restore` pending) | Tracked in [#126](https://github.com/bminier/claude-scope/issues/126) |
+
+The on-disk schema is stable as of phase 1, so phases 3-5 don't break
+existing log entries. See
+[Architecture → Audit log](../architecture/audit-log.md) for the
+record format.
+
+## Using the History dialog
+
+Click **History** in the topbar. Entries appear newest-first, with:
+
+- A color-tinted **verb** (`Move permission rule` /
+  `Add permission rule` / `Delete permission rule` /
+  `Change kind → deny`).
+- An ISO timestamp (locale-formatted text, ISO `datetime=…` for
+  screen readers).
+- The scope arrow (`Project → User` for cross-scope moves; single
+  scope for adds/deletes).
+- The affected rule string, recovered by diffing the before/after
+  snapshots in the record.
+
+The bottom of the list surfaces a count of any malformed entries the
+reader skipped — useful if `audit.jsonl` was hand-edited or partially
+written during a crash.
+
+## Rotation
+
+Once the log exceeds the size cap (default 10 MB) it's renamed to
+`audit-YYYY-MM.jsonl` and the next entry lands in a fresh file. Old
+archives stay on disk indefinitely — delete them by hand if you want.
+Both behaviors are configurable under **Settings → Audit log
+rotation**.
+
+## CLI
+
+`claude-scope-cli history` mirrors the GUI dialog from a shell:
+
+```sh
+# Last 20 entries, newest first.
+claude-scope-cli history
+
+# Just deletes in the last hour, JSON.
+claude-scope-cli history --since 1h --kind delete --json
+
+# Everything in the active log (no cap).
+claude-scope-cli history --limit 0
+```
+
+`--json` emits the same `AuditLogPage` wire format the GUI uses, so a
+[Claude Code skill (#13)](https://github.com/bminier/claude-scope/issues/13)
+can consume CLI output and IPC payloads through one shared type once
+that lands.


### PR DESCRIPTION
## Summary

Closes #26. Publishes a browsable docs site at **https://bminier.github.io/claude-scope/** built from \`docs/src/\` via mdBook, with \`mdbook-linkcheck\` as a hard gate on every CI build.

The README stays as the \"what is this, how do I install\" front door. Everything longer than a screen — scope semantics, write strategy, audit-log schema, contributing, security — moved into the site, with the README pointing there.

## Scaffold

- \`docs/book.toml\` — Rust theme, navy preferred-dark, edit-on-GitHub template, internal-link gate set to \`warning-policy = \"error\"\` so broken cross-refs fail the build.
- \`docs/src/SUMMARY.md\` — User guide / Reference / Architecture / Project sections, 10 pages total.

## Seed content (10 pages)

| Page | Source |
|---|---|
| \`index.md\` | new — landing |
| \`user-guide/scopes.md\` | migrated from \`CLAUDE.md\` \"Problem\" section |
| \`user-guide/moving-rules.md\` | synthesized — GUI flows, search, grouping (#68), sandbox (#66) |
| \`user-guide/undo-redo.md\` | new — #19 phase status, History dialog walkthrough, rotation, CLI |
| \`reference/rule-syntax.md\` | synthesized — Bash / Read / WebFetch / mcp__ / generic shapes |
| \`reference/cli.md\` | new — every shipped \`claude-scope-cli\` subcommand + pending undo/redo/restore |
| \`reference/settings-keys.md\` | stub (waiting on #9) |
| \`architecture/overview.md\` | new — Rust/TS split, module map, boundaries |
| \`architecture/atomic-writes.md\` | migrated from \`README.md\` \"Write strategy\" |
| \`architecture/audit-log.md\` | new — record schema, ULID rationale, append atomicity, rotation, sandbox |
| \`contributing.md\` | migrated from \`README.md\` Develop / CI / Releasing |
| \`security.md\` | migrated from \`SECURITY.md\` + privacy note for the docs site |

## CI workflow: \`.github/workflows/docs.yml\`

- Triggers on push to \`dev\` (paths-scoped to \`docs/**\` + the workflow itself) and \`workflow_dispatch\`.
- \`cargo install\` mdbook + mdbook-linkcheck, cached on workflow hash so re-runs without docs/workflow changes skip the compile.
- \`mdbook build docs/\` — \`warning-policy = \"error\"\` in book.toml pulls the linkcheck failure into the build's exit code. **Local \`mdbook build docs/\` reproduces CI behavior exactly**, no separate gate step needed.
- Deploy job uses \`actions/deploy-pages\` on \`dev\` only — PR builds exercise the linkcheck gate without publishing in-progress edits.

## README + .gitignore

- 📖 callout in README intro pointing at the Pages URL.
- \`docs/book/\` gitignored (regenerated on every build).

## Verified locally

\`mdbook build docs/\` succeeds with zero broken links. Deliberately introducing a bad link fails the build with a descriptive error pointing at the source location — confirms the linkcheck gate works as intended.

## ⚠️ One-time repo setup needed before publish

Before this workflow can actually publish, you need to flip:

> **Settings → Pages → Source = \"GitHub Actions\"** (not \"Deploy from a branch\")

Without that, \`actions/deploy-pages\` errors with \"Get Pages site failed\" on the first run. The build job will still run successfully (so the linkcheck gate is live immediately) — only the deploy step needs Pages enabled.

## Test plan

- [ ] Run \`mdbook build docs/\` locally; verify zero errors and \`docs/book/html/index.html\` opens correctly in a browser.
- [ ] Flip the Pages setting in repo Settings; trigger a manual \`workflow_dispatch\` of the Docs workflow; verify the site appears at https://bminier.github.io/claude-scope/.
- [ ] Open a junk PR that introduces a broken internal link in a docs file; verify the build job fails with a useful error.
- [ ] Confirm the navigation tree on the published site matches \`SUMMARY.md\`.
- [ ] Confirm the README's new 📖 callout renders correctly.

## Out of scope (deferred per the issue)

- API doc generation (\`cargo doc\` / TypeDoc).
- Blog / changelog / release-notes section (release notes live on GitHub Releases per \`skip-changelog\`).
- Translations.
- Custom domain.
- Analytics.
- Multiple versions / Mike-style version switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)