### PR TITLE
feat(ui): cross-pane rule highlight on click (#49)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -420,6 +420,22 @@ button:disabled {
   outline-offset: 2px;
 }
 
+/* Cross-pane rule highlight (#49). Click a chip; every chip with the
+   same string lights up across every pane that contains it. Visually
+   distinct from:
+     - `.col-drop-active` (solid accent border, drop target)
+     - `.col-drop-available` (dashed accent border, ambient target)
+     - `:focus-visible` (browser focus ring)
+     - `.lint-warn` `.is-open` (lint popover pin)
+   so the cues don't smear. Background tint + solid amber outline reads
+   as "selected" without claiming a button/drop semantics. */
+.rule-highlight {
+  background: var(--rule-highlight-bg, rgba(255, 200, 0, 0.18));
+  outline: 2px solid var(--rule-highlight-outline, #d4a017);
+  outline-offset: 1px;
+  border-radius: 3px;
+}
+
 /* Screen-reader-only live region for the keyboard DnD announcer (#41).
    Visible to assistive tech, not to sighted users. Classic clip-rect
    technique — `display: none` would also hide it from AT. */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -519,8 +519,18 @@ export function renderApp(root: HTMLElement, props: AppProps): void {
   // the same scope+path could mean something different.
   if (props.projectDir !== lastRenderedProjectDir) {
     openTreeNodes.clear();
+    // Cross-pane highlight (#49) is project-scoped: a rule that
+    // existed in the previous project's `Bash(...)` allowlist might
+    // be totally unrelated to one with the same string in the new
+    // project. Clear to avoid surprising the user with a highlight
+    // they didn't request in the new context.
+    highlightedRule = null;
     lastRenderedProjectDir = props.projectDir;
   }
+  // Wire the document-level click/keydown handlers exactly once. The
+  // handlers themselves survive `innerHTML = ""` rebuilds; this just
+  // guarantees they're installed by the first render.
+  ensureRuleHighlightDelegation();
   root.appendChild(header(props));
   const banner = sandboxBanner(props.runtime);
   if (banner) root.appendChild(banner);
@@ -554,6 +564,10 @@ export function renderApp(root: HTMLElement, props: AppProps): void {
   root.appendChild(combinedPanel(props.scopes, props, lowerQuery));
   root.appendChild(scopeGrid(props, lowerQuery));
   restoreSearchFocus(preserveSearchFocus, caret);
+  // Re-apply the cross-pane highlight (#49) once the new chips are
+  // in the DOM. Self-heals if the previously-highlighted rule no
+  // longer appears anywhere (e.g. just-moved last copy).
+  applyRuleHighlight();
 }
 
 function restoreSearchFocus(
@@ -1093,6 +1107,118 @@ function seedDefaultOpenPermissions(loaded: LoadedScopes): void {
       }
     }
   }
+}
+
+// Cross-pane rule-highlight state (#49). One rule string at a time;
+// clicking the same chip toggles off, clicking a different chip swaps,
+// clicking outside any chip clears. Survives normal re-renders so a
+// watcher reload doesn't drop the highlight, but auto-clears when the
+// highlighted rule no longer appears anywhere on screen (e.g. after a
+// successful move that took the last copy off the grid).
+//
+// Match policy is exact string equality — no glob subsumption. That's
+// #17's job; the highlight is deliberately predictable.
+let highlightedRule: string | null = null;
+let highlightDelegationInstalled = false;
+
+/**
+ * Walk every per-scope rule chip and combined-panel chip on the page
+ * and add `.rule-highlight` to those whose textContent matches the
+ * current highlight. Called from `renderApp` after the tree is built,
+ * and from `setHighlightedRule` when the toggle fires without a full
+ * re-render. Idempotent — running twice in a row is a no-op.
+ *
+ * Self-healing: if `highlightedRule` is set but no chip matches it,
+ * the singleton is cleared. That covers the "moved the last copy"
+ * case without the move flow needing to know about highlights.
+ */
+function applyRuleHighlight(): void {
+  for (const el of document.querySelectorAll<HTMLElement>(".rule-highlight")) {
+    el.classList.remove("rule-highlight");
+  }
+  if (highlightedRule === null) return;
+  let matched = false;
+  for (const el of document.querySelectorAll<HTMLElement>(".rule-text, .chip")) {
+    if (el.textContent === highlightedRule) {
+      el.classList.add("rule-highlight");
+      matched = true;
+    }
+  }
+  if (!matched) highlightedRule = null;
+}
+
+/**
+ * Set or toggle the highlighted rule. Passing the same string twice
+ * clears (the issue spec's "second click toggles off" behavior).
+ * Passing `null` clears unconditionally — the click-outside and
+ * Escape paths use that form.
+ */
+function setHighlightedRule(rule: string | null): void {
+  if (rule !== null && highlightedRule === rule) {
+    highlightedRule = null;
+  } else {
+    highlightedRule = rule;
+  }
+  applyRuleHighlight();
+}
+
+function clearRuleHighlight(): void {
+  if (highlightedRule === null) return;
+  highlightedRule = null;
+  applyRuleHighlight();
+}
+
+/**
+ * Wire document-level click + keydown listeners that drive the
+ * cross-pane highlight. Delegation rather than per-chip handlers so
+ * the wiring survives `renderApp`'s `innerHTML = ""` rebuild — listeners
+ * stay attached, state survives, render-time `applyRuleHighlight`
+ * re-applies the class to whichever chips currently exist.
+ *
+ * Idempotent at module level: a flag prevents double-registration
+ * across reload-style renderApp calls.
+ */
+function ensureRuleHighlightDelegation(): void {
+  if (highlightDelegationInstalled) return;
+  highlightDelegationInstalled = true;
+
+  document.addEventListener("click", (e) => {
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+    const chip = target.closest<HTMLElement>(".rule-text, .chip");
+    if (chip) {
+      setHighlightedRule(chip.textContent);
+      return;
+    }
+    // Clicks on the chip's neighborhood (lint badge `.lint-info`, the
+    // chip-wrap shell, the rule row) shouldn't clear — the user is
+    // still interacting with the highlighted rule's UI. Only truly
+    // off-rule clicks dismiss.
+    if (target.closest(".chip-wrap, .rule")) return;
+    clearRuleHighlight();
+  });
+
+  document.addEventListener("keydown", (e) => {
+    // Defer to anything that already claimed the keystroke — modals
+    // (Escape closes), context menus (Escape pops one level), etc.
+    if (e.defaultPrevented) return;
+    if (e.key === "Escape") {
+      if (highlightedRule !== null) clearRuleHighlight();
+      return;
+    }
+    if (e.key === "h" || e.key === "H") {
+      const active = document.activeElement as HTMLElement | null;
+      if (!active) return;
+      // Skip while a text input has focus — `h` is a letter, the user
+      // is typing.
+      if (active.tagName === "INPUT" || active.tagName === "TEXTAREA") return;
+      if (active.isContentEditable) return;
+      const chip = active.closest<HTMLElement>(".rule-text, .chip");
+      if (!chip) return;
+      e.preventDefault();
+      setHighlightedRule(chip.textContent);
+    }
+  });
 }
 
 // HTML5 drag-and-drop source state. Set by `dragstart` on a movable tree

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -1579,3 +1579,177 @@ describe("keyboard drag-and-drop (#41)", () => {
     // which is the contract the screen reader binds to.
   });
 });
+
+describe("cross-pane rule highlight (#49)", () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    // Drain any leaked keystroke / pickup state from earlier suites so
+    // the first click here lands cleanly.
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    root = makeRoot();
+  });
+
+  afterEach(() => {
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    clearBody();
+  });
+
+  function scopesWithSharedRule(): ReturnType<typeof buildLoadedScopes> {
+    // Same rule string in Project allow AND User deny — exactly the
+    // cross-kind / cross-scope case the highlight is supposed to make
+    // visible.
+    return buildLoadedScopes({
+      project_dir: "/fake/highlight",
+      scopes: [
+        { scope: "project", permissions: { allow: ["Bash(ls)", "Read(*)"] } },
+        { scope: "user", permissions: { deny: ["Bash(ls)"] } },
+      ],
+    });
+  }
+
+  function projectRuleEl(text: string): HTMLElement {
+    const el = Array.from(root.querySelectorAll<HTMLElement>(".rule .rule-text")).find(
+      (e) => e.textContent === text,
+    );
+    if (!el) throw new Error(`expected per-scope rule chip for "${text}"`);
+    return el;
+  }
+
+  function combinedChipEl(text: string): HTMLElement {
+    const el = Array.from(root.querySelectorAll<HTMLElement>(".chip")).find(
+      (e) => e.textContent === text,
+    );
+    if (!el) throw new Error(`expected combined-panel chip for "${text}"`);
+    return el;
+  }
+
+  it("clicking a per-scope chip highlights every matching chip across panes", () => {
+    renderApp(root, makeProps({ scopes: scopesWithSharedRule() }));
+    projectRuleEl("Bash(ls)").click();
+    // Four matching chips total: Project-allow + User-deny per-scope
+    // chips, plus the combined panel's allow + deny chip variants. The
+    // combined panel renders the rule under each kind it appears in,
+    // which is exactly the cross-kind case #49 wants surfaced.
+    const highlighted = Array.from(root.querySelectorAll<HTMLElement>(".rule-highlight"));
+    const labels = highlighted.map((el) => el.textContent);
+    expect(labels.length).toBe(4);
+    expect(labels.every((l) => l === "Bash(ls)")).toBe(true);
+    // Other rules stay unhighlighted.
+    expect(projectRuleEl("Read(*)").classList.contains("rule-highlight")).toBe(false);
+  });
+
+  it("clicking the same chip a second time toggles the highlight off", () => {
+    renderApp(root, makeProps({ scopes: scopesWithSharedRule() }));
+    const chip = projectRuleEl("Bash(ls)");
+    chip.click();
+    expect(chip.classList.contains("rule-highlight")).toBe(true);
+    chip.click();
+    expect(root.querySelectorAll(".rule-highlight").length).toBe(0);
+  });
+
+  it("clicking a different chip swaps the highlight", () => {
+    renderApp(root, makeProps({ scopes: scopesWithSharedRule() }));
+    projectRuleEl("Bash(ls)").click();
+    projectRuleEl("Read(*)").click();
+    const highlighted = Array.from(root.querySelectorAll<HTMLElement>(".rule-highlight"));
+    expect(highlighted.every((el) => el.textContent === "Read(*)")).toBe(true);
+    expect(highlighted.length).toBeGreaterThan(0);
+  });
+
+  it("clicking the combined-panel chip highlights the same rule across panes", () => {
+    renderApp(root, makeProps({ scopes: scopesWithSharedRule() }));
+    combinedChipEl("Bash(ls)").click();
+    const labels = Array.from(root.querySelectorAll<HTMLElement>(".rule-highlight")).map(
+      (el) => el.textContent,
+    );
+    // Same count as the per-scope click: four matching chips.
+    expect(labels.length).toBe(4);
+    expect(labels.every((l) => l === "Bash(ls)")).toBe(true);
+  });
+
+  it("Escape clears an active highlight", () => {
+    renderApp(root, makeProps({ scopes: scopesWithSharedRule() }));
+    projectRuleEl("Bash(ls)").click();
+    expect(root.querySelector(".rule-highlight")).not.toBeNull();
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    expect(root.querySelector(".rule-highlight")).toBeNull();
+  });
+
+  it("clicking truly outside any chip clears the highlight", () => {
+    renderApp(root, makeProps({ scopes: scopesWithSharedRule() }));
+    projectRuleEl("Bash(ls)").click();
+    // Click on the topbar — definitely not a chip or chip-neighbor.
+    const topbar = root.querySelector<HTMLElement>(".topbar");
+    expect(topbar).not.toBeNull();
+    topbar?.click();
+    expect(root.querySelector(".rule-highlight")).toBeNull();
+  });
+
+  it("'h' on a focused chip toggles the highlight without conflicting with #41 pickup", () => {
+    renderApp(root, makeProps({ scopes: scopesWithSharedRule() }));
+    const chip = projectRuleEl("Bash(ls)");
+    chip.focus();
+    chip.dispatchEvent(new KeyboardEvent("keydown", { key: "h", bubbles: true }));
+    expect(chip.classList.contains("rule-highlight")).toBe(true);
+    // 'h' again toggles off (independent of click toggle).
+    chip.dispatchEvent(new KeyboardEvent("keydown", { key: "h", bubbles: true }));
+    expect(chip.classList.contains("rule-highlight")).toBe(false);
+    // And pickup (Enter) still works as a separate gesture.
+    expect(chip.getAttribute("aria-pressed")).toBeNull();
+  });
+
+  it("highlight survives a re-render when the rule still exists", () => {
+    const scopes = scopesWithSharedRule();
+    renderApp(root, makeProps({ scopes }));
+    projectRuleEl("Bash(ls)").click();
+    // Re-render with the same data (simulates a watcher reload).
+    renderApp(root, makeProps({ scopes }));
+    const highlighted = Array.from(root.querySelectorAll<HTMLElement>(".rule-highlight"));
+    expect(highlighted.length).toBe(4);
+    expect(highlighted.every((el) => el.textContent === "Bash(ls)")).toBe(true);
+  });
+
+  it("highlight auto-clears when the rule disappears from the next render", () => {
+    renderApp(root, makeProps({ scopes: scopesWithSharedRule() }));
+    projectRuleEl("Bash(ls)").click();
+    // Re-render with the rule gone everywhere.
+    const without = buildLoadedScopes({
+      project_dir: "/fake/highlight",
+      scopes: [{ scope: "project", permissions: { allow: ["Read(*)"] } }],
+    });
+    renderApp(root, makeProps({ scopes: without }));
+    expect(root.querySelectorAll(".rule-highlight").length).toBe(0);
+  });
+
+  it("highlight clears on project switch", () => {
+    renderApp(root, makeProps({ scopes: scopesWithSharedRule() }));
+    projectRuleEl("Bash(ls)").click();
+    // Same data but a different project_dir signals a project switch.
+    const switched = buildLoadedScopes({
+      project_dir: "/fake/other-project",
+      scopes: [{ scope: "project", permissions: { allow: ["Bash(ls)"] } }],
+    });
+    renderApp(root, makeProps({ scopes: switched }));
+    // Even though the rule string exists in the new project, the
+    // highlight cleared on switch — the context changed, the previous
+    // selection no longer reflects user intent.
+    expect(root.querySelectorAll(".rule-highlight").length).toBe(0);
+  });
+
+  it("'h' is ignored while a text input is focused (so typing 'h' works)", () => {
+    renderApp(root, makeProps({ scopes: scopesWithSharedRule() }));
+    const search = document.getElementById(SEARCH_INPUT_ID) as HTMLInputElement | null;
+    expect(search).not.toBeNull();
+    search?.focus();
+    search?.dispatchEvent(new KeyboardEvent("keydown", { key: "h", bubbles: true }));
+    // No chip is highlighted because the keystroke was for the text input.
+    expect(root.querySelectorAll(".rule-highlight").length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #49. Click a rule chip in any pane → every chip with the **same exact rule string** lights up across every pane that contains it. Reveals \"this rule is also in deny in User scope\" at a glance without scanning four columns.

Match policy is **exact string equality only**. Glob subsumption (\`Bash(git *)\` matching \`Bash(git status)\`) is deliberately out of scope — that's #17's territory and would make the highlight unpredictable. Cross-kind highlighting **is** in scope by design: a rule appearing in \`allow\` in one scope and \`deny\` in another is exactly the case the user wants surfaced.

## State machine

Module-level \`highlightedRule: string | null\`. Survives normal re-renders (watcher reloads keep the highlight). Auto-clears when:

1. The user toggles it off (second click on the same chip).
2. The user clicks outside the rule's UI — strict: clicking the lint badge on a highlighted chip preserves the highlight, clicking the topbar clears it.
3. The user presses Escape — deferred to other handlers via \`e.defaultPrevented\` check so a modal Escape still closes the modal first.
4. The next render finds no matching chip (e.g. the just-moved rule was the last copy on this project's grid).
5. The project switches — \`lastRenderedProjectDir\` hook.

## Wiring

- **Document-level delegation**, installed once via \`ensureRuleHighlightDelegation()\`. Survives \`innerHTML = \"\"\` rebuilds; per-element handlers would need re-attaching every render.
- \`applyRuleHighlight()\` runs at the end of every \`renderApp\` so a re-render with fresh DOM nodes still shows the highlight.

## Keyboard

**\`h\`** on a focused chip toggles the highlight. Deliberately **not** Enter — Enter/Space picks up the chip for keyboard drag-and-drop (#41, just shipped). The issue spec said Enter, but the issue itself flagged this conflict: *\"the keyboard activation pattern (Enter to pin) should be designed alongside that work.\"* \`h\` keeps both gestures cleanly separated.

\`h\` is skipped when a text input has focus so typing \`h\` in the search box still works. Escape clears.

## Visual

New \`.rule-highlight\` class: amber background tint + solid outline. Distinct from \`.col-drop-active\`, \`.col-drop-available\`, \`:focus-visible\`, and the lint \`.is-open\` pin so the cues don't smear visually. CSS variables let a future theme swap the palette.

## Tests (11 new vitest)

- Click highlights all four matching chips (Project-allow + User-deny per-scope + combined-panel allow + deny chip variants); other rules stay unhighlighted.
- Second click toggles off.
- Click on a different chip swaps.
- Combined-panel click highlights the same set as per-scope click.
- Escape clears.
- Click on the topbar clears (truly-outside).
- \`h\` on focused chip toggles, doesn't trigger \`aria-pressed\` (i.e. doesn't collide with #41's pickup gesture).
- Highlight survives a re-render with the same data.
- Highlight auto-clears when the rule disappears from the next render.
- Highlight clears on project switch even when the same string exists in the new project — context-change wins.
- \`h\` is ignored while the search input has focus (typing 'h').

**Totals:** 92 vitest passing (+11 new, no regressions). Type-check + biome clean.

## Acceptance criteria

- [x] Clicking a rule chip in any pane highlights every other chip in every pane that has the exact same rule string.
- [x] Clicking the same chip again, clicking outside any rule, or pressing Escape clears the highlight.
- [x] Highlight survives a normal re-render when the rule still exists; clears when it doesn't.
- [x] Highlight clears on project switch.
- [x] Visual is distinct from focus, lint-warning, and drop-target styling.

## Test plan

- [ ] Click a rule chip that exists in two scopes — both per-scope copies + both combined-panel kind variants light up.
- [ ] Click the same chip — highlight clears.
- [ ] Click a different chip — highlight swaps to the new string.
- [ ] Tab to a rule chip, press \`h\` — highlight on. Press \`h\` again — off.
- [ ] Tab to a chip, press Enter — keyboard pickup activates (the #41 gesture), no highlight side effect.
- [ ] Move a rule that was highlighted; if it was the last copy, the highlight clears on the post-move re-render.
- [ ] Switch projects from the dropdown — highlight clears even if the same rule string exists in the new project.
- [ ] Focus the search input and type a word containing 'h' — no chip highlight fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)