### PR TITLE
feat(ui): tool-grouping threshold as a Settings option (#115)

### DIFF
--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -31,6 +31,16 @@ pub const AUDIT_LOG_MAX_SIZE_MB_MIN: u32 = 1;
 pub const AUDIT_LOG_MAX_SIZE_MB_MAX: u32 = 1000;
 pub const AUDIT_LOG_MAX_SIZE_MB_DEFAULT: u32 = 10;
 
+/// Minimum sensible value for `group_rules_at` (#115). Two rules sharing
+/// a tool prefix is the smallest group that's visually distinct from
+/// flat presentation — any lower would either fold every single rule
+/// (n=1, meaningless) or wrap around to "never group" semantics, which
+/// `None` already expresses cleanly.
+pub const GROUP_RULES_AT_MIN: u32 = 2;
+/// Default grouping threshold — matches #68's original constant so
+/// existing users see the same UI by default.
+pub const GROUP_RULES_AT_DEFAULT: u32 = 2;
+
 /// Shape of the persisted config file. Every field carries a `#[serde(default)]`
 /// so unknown or missing keys degrade gracefully to sensible defaults — the
 /// schema can evolve without forcing a migration on every launch.
@@ -90,6 +100,18 @@ pub struct Preferences {
         deserialize_with = "deserialize_audit_log_max_size_mb"
     )]
     pub audit_log_max_size_mb: u32,
+    /// Threshold above which per-tool rule groups collapse in the tree
+    /// view (#115). `Some(n)` groups when `n` or more rules share a tool
+    /// prefix; `None` disables grouping entirely. Default `Some(2)`
+    /// matches #68's original constant, so existing users see the same
+    /// presentation. Values < [`GROUP_RULES_AT_MIN`] are coerced to the
+    /// default at load time — a hand-edited `1` is meaningless and a
+    /// hand-edited `0` would collapse every individual rule.
+    #[serde(
+        default = "default_group_rules_at",
+        deserialize_with = "deserialize_group_rules_at"
+    )]
+    pub group_rules_at: Option<u32>,
 }
 
 impl Default for Preferences {
@@ -101,6 +123,7 @@ impl Default for Preferences {
             recent_projects: Vec::new(),
             audit_log_rotate: default_audit_log_rotate(),
             audit_log_max_size_mb: default_audit_log_max_size_mb(),
+            group_rules_at: default_group_rules_at(),
         }
     }
 }
@@ -135,6 +158,28 @@ where
     } else {
         Ok(default_audit_log_max_size_mb())
     }
+}
+
+fn default_group_rules_at() -> Option<u32> {
+    Some(GROUP_RULES_AT_DEFAULT)
+}
+
+/// Coerce sub-minimum `Some(n < 2)` values back to the default. `None`
+/// is a legitimate "never group" signal and passes through unchanged.
+/// Any positive value at or above `GROUP_RULES_AT_MIN` is honored as-is
+/// — the upper bound is open-ended on purpose so a user with an
+/// exotic-allowlist project can pick "group at 5" or higher without a
+/// schema bump.
+fn deserialize_group_rules_at<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Option::<u32>::deserialize(deserializer)?;
+    Ok(match raw {
+        Some(n) if n >= GROUP_RULES_AT_MIN => Some(n),
+        Some(_) => default_group_rules_at(),
+        None => None,
+    })
 }
 
 /// Normalize a `visible_scopes` list: dedupe, reorder to match `Scope::ALL`,
@@ -352,6 +397,7 @@ mod tests {
             recent_projects: Vec::new(),
             audit_log_rotate: false,
             audit_log_max_size_mb: 25,
+            group_rules_at: Some(3),
         };
         let json = serde_json::to_string(&prefs).unwrap();
         let parsed: Preferences = serde_json::from_str(&json).unwrap();
@@ -382,6 +428,7 @@ mod tests {
                 recent_projects: Vec::new(),
                 audit_log_rotate: true,
                 audit_log_max_size_mb: AUDIT_LOG_MAX_SIZE_MB_DEFAULT,
+                group_rules_at: default_group_rules_at(),
             };
             let json = serde_json::to_string(&prefs).unwrap();
             let parsed: Preferences = serde_json::from_str(&json).unwrap();
@@ -409,6 +456,7 @@ mod tests {
             recent_projects: Vec::new(),
             audit_log_rotate: true,
             audit_log_max_size_mb: AUDIT_LOG_MAX_SIZE_MB_DEFAULT,
+            group_rules_at: default_group_rules_at(),
         };
         let json = serde_json::to_string(&prefs).unwrap();
         // The JS side reads this string verbatim — pinning the casing
@@ -488,6 +536,46 @@ mod tests {
         assert!(!prefs.audit_log_rotate);
         let json = serde_json::to_string(&prefs).unwrap();
         assert!(json.contains(r#""audit_log_rotate":false"#));
+    }
+
+    #[test]
+    fn group_rules_at_default_matches_legacy_constant() {
+        // Existing users should see the same grouping cadence #68 shipped
+        // with — Some(2). Missing-field deserializes the same way so
+        // older configs don't get a surprise on upgrade.
+        assert_eq!(Preferences::default().group_rules_at, Some(2));
+        let prefs: Preferences = serde_json::from_str("{}").unwrap();
+        assert_eq!(prefs.group_rules_at, Some(2));
+    }
+
+    #[test]
+    fn group_rules_at_null_survives_round_trip() {
+        // `None` is a legitimate "never group" signal, distinct from
+        // any positive integer. Has to round-trip cleanly so the
+        // user's choice sticks.
+        let prefs: Preferences = serde_json::from_str(r#"{"group_rules_at":null}"#).unwrap();
+        assert_eq!(prefs.group_rules_at, None);
+        let json = serde_json::to_string(&prefs).unwrap();
+        assert!(json.contains(r#""group_rules_at":null"#));
+    }
+
+    #[test]
+    fn group_rules_at_accepts_in_range_values() {
+        let prefs: Preferences = serde_json::from_str(r#"{"group_rules_at":3}"#).unwrap();
+        assert_eq!(prefs.group_rules_at, Some(3));
+        let prefs: Preferences = serde_json::from_str(r#"{"group_rules_at":7}"#).unwrap();
+        assert_eq!(prefs.group_rules_at, Some(7));
+    }
+
+    #[test]
+    fn group_rules_at_clamps_sub_minimum_to_default() {
+        // `Some(0)` would collapse every individual rule (nonsense)
+        // and `Some(1)` is no-op — both fall back to default rather
+        // than the floor, mirroring the audit-log size-cap policy.
+        let prefs: Preferences = serde_json::from_str(r#"{"group_rules_at":0}"#).unwrap();
+        assert_eq!(prefs.group_rules_at, default_group_rules_at());
+        let prefs: Preferences = serde_json::from_str(r#"{"group_rules_at":1}"#).unwrap();
+        assert_eq!(prefs.group_rules_at, default_group_rules_at());
     }
 
     #[test]
@@ -607,6 +695,7 @@ mod tests {
             recent_projects: Vec::new(),
             audit_log_rotate: true,
             audit_log_max_size_mb: AUDIT_LOG_MAX_SIZE_MB_DEFAULT,
+            group_rules_at: default_group_rules_at(),
         };
         let body = serde_json::to_vec_pretty(&first).unwrap();
         let parent = target.parent().unwrap();
@@ -625,6 +714,7 @@ mod tests {
             recent_projects: vec![PathBuf::from("/tmp/p1"), PathBuf::from("/tmp/p2")],
             audit_log_rotate: false,
             audit_log_max_size_mb: 5,
+            group_rules_at: None,
         };
         let body2 = serde_json::to_vec_pretty(&second).unwrap();
         let mut tmpfile2 = tempfile::NamedTempFile::new_in(parent).unwrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   recent_projects: [],
   audit_log_rotate: true,
   audit_log_max_size_mb: 10,
+  group_rules_at: 2,
 };
 
 const state: {
@@ -442,6 +443,11 @@ function onChangeAuditLogMaxSizeMb(mb: number): void {
   void persistPreferences({ ...state.preferences, audit_log_max_size_mb: mb });
 }
 
+function onChangeGroupRulesAt(value: number | null): void {
+  if (state.preferences.group_rules_at === value) return;
+  void persistPreferences({ ...state.preferences, group_rules_at: value });
+}
+
 function onOpenSettings(trigger?: HTMLElement): void {
   void openSettings(
     {
@@ -451,6 +457,7 @@ function onOpenSettings(trigger?: HTMLElement): void {
       onToggleBackupOnWrite,
       onToggleAuditLogRotate,
       onChangeAuditLogMaxSizeMb,
+      onChangeGroupRulesAt,
     },
     trigger,
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,6 +191,11 @@ export interface Preferences {
    *  server-side to `[1, 1000]`; out-of-range values fall back to the
    *  default rather than the nearest boundary. */
   audit_log_max_size_mb: number;
+  /** Tool-grouping threshold (#115). `null` = never group; otherwise
+   *  group when this many rules share a tool prefix. Backend coerces
+   *  `Some(n < 2)` back to the default, so anything the frontend reads
+   *  is either `null` or `>= 2`. */
+  group_rules_at: number | null;
 }
 
 /** Bounds on `Preferences.audit_log_max_size_mb`. Mirrors Rust's

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -153,13 +153,25 @@ function matchesLoweredQuery(rule: string, lowerQuery: string): boolean {
 }
 
 /**
- * Threshold above which a tool's rules collapse under a synthetic group
- * node in the per-scope tree view (#68). At 2, two rules sharing a tool
- * (e.g. `handoff(copilot *)` + `handoff(claude *)`) fold together. A future
- * Settings option (#115) will parameterize this; for now it's the single
- * compile-time knob the grouping helper reads.
+ * Default threshold above which a tool's rules collapse under a
+ * synthetic group node in the per-scope tree view (#68). Matches
+ * `Preferences.group_rules_at`'s default — the runtime value comes from
+ * the user's preference (#115) via [`resolveGroupThreshold`]. This
+ * constant is retained as the default for unit-test call sites that
+ * exercise the grouping helper directly without an `AppProps` in scope.
  */
 const TOOL_GROUP_THRESHOLD = 2;
+
+/**
+ * Resolve the user's `group_rules_at` preference to the integer
+ * threshold the grouping helper expects. `null` (= "never group" per
+ * the user's choice) is mapped to `Infinity` so the helper's
+ * `count < threshold` check never fires and every rule renders as a
+ * `Single`. Same call site contract as the default-2 constant.
+ */
+function resolveGroupThreshold(prefs: Preferences): number {
+  return prefs.group_rules_at ?? Number.POSITIVE_INFINITY;
+}
 
 /**
  * Entry in the per-kind rule list after grouping. `Single` keeps the
@@ -555,7 +567,7 @@ export function renderApp(root: HTMLElement, props: AppProps): void {
   // scopes=null first; scopes arrive on the next render).
   if (lastSeededProjectDir !== props.projectDir) {
     lastSeededProjectDir = props.projectDir;
-    seedDefaultOpenPermissions(props.scopes);
+    seedDefaultOpenPermissions(props.scopes, resolveGroupThreshold(props.preferences));
   }
 
   // Lowercase the query once per render instead of per rule; scopeGrid/
@@ -1080,7 +1092,7 @@ let lastSeededProjectDir: string | null = null;
  * `<details>.toggle` listener in `treeBranch` is the only writer of
  * `openTreeNodes`, so a manual collapse persists across re-renders.
  */
-function seedDefaultOpenPermissions(loaded: LoadedScopes): void {
+function seedDefaultOpenPermissions(loaded: LoadedScopes, threshold: number): void {
   for (const view of loaded.scopes) {
     const perms = view.values.permissions;
     if (!perms || typeof perms !== "object" || Array.isArray(perms)) continue;
@@ -1097,9 +1109,11 @@ function seedDefaultOpenPermissions(loaded: LoadedScopes): void {
         // Seed open state for tool groups (#68) so the synthetic
         // `<details>` nodes inside an already-open permissions branch
         // start expanded — users opened the kind branch to read its
-        // rules, so collapsed groups would just hide them again.
+        // rules, so collapsed groups would just hide them again. The
+        // grouping has to use the user's current threshold (#115) so
+        // we don't seed open state for groups the renderer won't form.
         const ruleStrings = arr.map((v) => (typeof v === "string" ? v : ""));
-        for (const entry of groupByToolPrefix(ruleStrings)) {
+        for (const entry of groupByToolPrefix(ruleStrings, threshold)) {
           if (entry.kind === "group") {
             openTreeNodes.add(treeKey(view.scope, [...kindPath, "__group__", entry.tool]));
           }
@@ -1558,7 +1572,12 @@ function populatePermissionList(
   // surprise than help. Keep the malformed entries inline at their
   // original index so the existing leaf renderer can flag them.
   const ruleStrings: string[] = value.map((v) => (typeof v === "string" ? v : ""));
-  const grouped = groupByToolPrefix(ruleStrings);
+  // `props` can be undefined for previews / tests that render the
+  // tree without a full AppProps; in that case fall back to the
+  // default threshold so the tree still groups the same way #68
+  // shipped with.
+  const threshold = props ? resolveGroupThreshold(props.preferences) : TOOL_GROUP_THRESHOLD;
+  const grouped = groupByToolPrefix(ruleStrings, threshold);
   for (const entry of grouped) {
     if (entry.kind === "single") {
       children.appendChild(
@@ -3173,6 +3192,9 @@ interface SettingsProps {
    *  clamps to `[1, 1000]`; the UI also enforces those bounds at the
    *  input level so the user sees the limits inline. */
   onChangeAuditLogMaxSizeMb: (mb: number) => void;
+  /** Set the tool-grouping threshold (#115). `null` = never group;
+   *  otherwise group when this many rules share a tool prefix. */
+  onChangeGroupRulesAt: (value: number | null) => void;
 }
 
 const THEME_OPTIONS: ReadonlyArray<{ value: Theme; label: string }> = [
@@ -3197,6 +3219,7 @@ export function openSettings(props: SettingsProps, trigger?: HTMLElement | null)
   const body = document.createElement("div");
   body.appendChild(settingsThemeSection(props));
   body.appendChild(settingsColumnsSection(props));
+  body.appendChild(settingsGroupRulesSection(props));
   body.appendChild(settingsBackupSection(props));
   body.appendChild(settingsAuditRotationSection(props));
 
@@ -3362,6 +3385,69 @@ function settingsBackupSection(props: SettingsProps): HTMLElement {
  * typing "2", "20", "200". `change` fires on commit (blur or Enter),
  * which lines up with how the rest of the settings dialog works.
  */
+/**
+ * Tool-grouping threshold radios (#115). Three discrete states — group
+ * at 2, group at 3, or never — chosen over a free number input because
+ * the meaningful range is small and users disagree on the right value;
+ * spelling out the three options inline makes the trade-off legible.
+ *
+ * The wire shape (`number | null`) admits values >= 4 if a future
+ * config edit asks for one; we just don't expose a UI for them. That
+ * keeps the schema forward-compatible without crowding the dialog.
+ */
+function settingsGroupRulesSection(props: SettingsProps): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "settings-section";
+
+  const heading = document.createElement("h3");
+  heading.id = "settings-group-rules-heading";
+  heading.className = "settings-heading";
+  heading.textContent = "Rule grouping";
+  section.appendChild(heading);
+
+  const hint = document.createElement("p");
+  hint.className = "settings-hint";
+  hint.textContent =
+    "When rules share a tool prefix, fold them into a collapsible group. Lower thresholds fold more aggressively; 'Never' shows every rule flat.";
+  section.appendChild(hint);
+
+  const list = document.createElement("div");
+  list.className = "settings-checklist";
+  list.setAttribute("role", "radiogroup");
+  list.setAttribute("aria-labelledby", "settings-group-rules-heading");
+  const groupName = "settings-group-rules";
+
+  const options: Array<{ value: number | null; label: string }> = [
+    { value: 2, label: "Group at 2 (most aggressive)" },
+    { value: 3, label: "Group at 3" },
+    { value: null, label: "Never group" },
+  ];
+
+  for (const opt of options) {
+    const row = document.createElement("label");
+    row.className = "settings-check";
+    const input = document.createElement("input");
+    input.type = "radio";
+    input.name = groupName;
+    // Use a sentinel string for `null` so the radio value round-trips
+    // cleanly. The click handler maps it back to `null` before
+    // dispatching.
+    input.value = opt.value === null ? "never" : String(opt.value);
+    input.checked = props.preferences.group_rules_at === opt.value;
+    input.addEventListener("change", () => {
+      if (input.checked) props.onChangeGroupRulesAt(opt.value);
+    });
+    row.appendChild(input);
+    const label = document.createElement("span");
+    label.textContent = opt.label;
+    row.appendChild(label);
+    list.appendChild(row);
+  }
+
+  section.appendChild(list);
+  return section;
+}
+
 function settingsAuditRotationSection(props: SettingsProps): HTMLElement {
   const section = document.createElement("section");
   section.className = "settings-section";

--- a/test/fixtures/loadedScopes.ts
+++ b/test/fixtures/loadedScopes.ts
@@ -158,6 +158,9 @@ export function buildPreferences(overrides: Partial<Preferences> = {}): Preferen
     recent_projects: overrides.recent_projects ?? [],
     audit_log_rotate: overrides.audit_log_rotate ?? true,
     audit_log_max_size_mb: overrides.audit_log_max_size_mb ?? 10,
+    // `??` instead of `||` so explicit `null` (= never group) is
+    // honored — `null || 2` would silently flip to 2.
+    group_rules_at: overrides.group_rules_at !== undefined ? overrides.group_rules_at : 2,
   };
 }
 

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -516,6 +516,7 @@ describe("openSettings – theme radios", () => {
       onToggleBackupOnWrite: vi.fn(),
       onToggleAuditLogRotate: vi.fn(),
       onChangeAuditLogMaxSizeMb: vi.fn(),
+      onChangeGroupRulesAt: vi.fn(),
     };
   }
 
@@ -587,6 +588,7 @@ describe("openSettings – backup toggle (#88)", () => {
         onToggleBackupOnWrite: vi.fn(),
         onToggleAuditLogRotate: vi.fn(),
         onChangeAuditLogMaxSizeMb: vi.fn(),
+        onChangeGroupRulesAt: vi.fn(),
       });
       expect(backupCheckbox().checked).toBe(enabled);
     }
@@ -601,6 +603,7 @@ describe("openSettings – backup toggle (#88)", () => {
       onToggleBackupOnWrite,
       onToggleAuditLogRotate: vi.fn(),
       onChangeAuditLogMaxSizeMb: vi.fn(),
+      onChangeGroupRulesAt: vi.fn(),
     });
     const cb = backupCheckbox();
     cb.checked = false;
@@ -650,6 +653,7 @@ describe("openSettings – audit log rotation (#127)", () => {
       onToggleBackupOnWrite: vi.fn(),
       onToggleAuditLogRotate: vi.fn(),
       onChangeAuditLogMaxSizeMb: vi.fn(),
+      onChangeGroupRulesAt: vi.fn(),
     };
   }
 
@@ -689,6 +693,7 @@ describe("openSettings – audit log rotation (#127)", () => {
       onToggleBackupOnWrite: vi.fn(),
       onToggleAuditLogRotate,
       onChangeAuditLogMaxSizeMb: vi.fn(),
+      onChangeGroupRulesAt: vi.fn(),
     });
     const t = rotationToggle();
     t.checked = false;
@@ -705,6 +710,7 @@ describe("openSettings – audit log rotation (#127)", () => {
       onToggleBackupOnWrite: vi.fn(),
       onToggleAuditLogRotate: vi.fn(),
       onChangeAuditLogMaxSizeMb,
+      onChangeGroupRulesAt: vi.fn(),
     });
     const input = sizeInput();
     input.value = "50";
@@ -721,6 +727,7 @@ describe("openSettings – audit log rotation (#127)", () => {
       onToggleBackupOnWrite: vi.fn(),
       onToggleAuditLogRotate: vi.fn(),
       onChangeAuditLogMaxSizeMb,
+      onChangeGroupRulesAt: vi.fn(),
     });
     const input = sizeInput();
     input.value = "9999";
@@ -744,6 +751,7 @@ describe("openSettings – audit log rotation (#127)", () => {
       onToggleBackupOnWrite: vi.fn(),
       onToggleAuditLogRotate: vi.fn(),
       onChangeAuditLogMaxSizeMb,
+      onChangeGroupRulesAt: vi.fn(),
     });
     const input = sizeInput();
     input.value = "";
@@ -1751,5 +1759,164 @@ describe("cross-pane rule highlight (#49)", () => {
     search?.dispatchEvent(new KeyboardEvent("keydown", { key: "h", bubbles: true }));
     // No chip is highlighted because the keystroke was for the text input.
     expect(root.querySelectorAll(".rule-highlight").length).toBe(0);
+  });
+});
+
+describe("settings: rule grouping (#115)", () => {
+  beforeEach(() => {
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+  });
+
+  afterEach(() => {
+    for (const b of Array.from(document.querySelectorAll(".modal-backdrop"))) b.remove();
+    clearBody();
+  });
+
+  function makeProps(prefs: Partial<Preferences> = {}) {
+    return {
+      preferences: buildPreferences(prefs),
+      onToggleScopeVisibility: vi.fn(),
+      onChangeTheme: vi.fn(),
+      onToggleBackupOnWrite: vi.fn(),
+      onToggleAuditLogRotate: vi.fn(),
+      onChangeAuditLogMaxSizeMb: vi.fn(),
+      onChangeGroupRulesAt: vi.fn(),
+    };
+  }
+
+  function getRadios(): HTMLInputElement[] {
+    return Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[name="settings-group-rules"]'),
+    );
+  }
+
+  it("renders three radios in the grouping section", () => {
+    openSettings(makeProps());
+    const radios = getRadios();
+    expect(radios).toHaveLength(3);
+    expect(radios.map((r) => r.value)).toEqual(["2", "3", "never"]);
+  });
+
+  it("checks the radio matching the current preference", () => {
+    for (const value of [2, 3, null] as Array<number | null>) {
+      clearBody();
+      openSettings(makeProps({ group_rules_at: value }));
+      const checked = getRadios().find((r) => r.checked);
+      expect(checked?.value).toBe(value === null ? "never" : String(value));
+    }
+  });
+
+  it("clicking 'Never' invokes onChangeGroupRulesAt with null", () => {
+    const onChangeGroupRulesAt = vi.fn();
+    openSettings({
+      preferences: buildPreferences({ group_rules_at: 2 }),
+      onToggleScopeVisibility: vi.fn(),
+      onChangeTheme: vi.fn(),
+      onToggleBackupOnWrite: vi.fn(),
+      onToggleAuditLogRotate: vi.fn(),
+      onChangeAuditLogMaxSizeMb: vi.fn(),
+      onChangeGroupRulesAt,
+    });
+    const never = getRadios().find((r) => r.value === "never");
+    expect(never).toBeDefined();
+    if (!never) return;
+    never.checked = true;
+    never.dispatchEvent(new Event("change"));
+    expect(onChangeGroupRulesAt).toHaveBeenCalledWith(null);
+  });
+
+  it("clicking 'Group at 3' invokes onChangeGroupRulesAt with 3", () => {
+    const onChangeGroupRulesAt = vi.fn();
+    openSettings({
+      preferences: buildPreferences({ group_rules_at: 2 }),
+      onToggleScopeVisibility: vi.fn(),
+      onChangeTheme: vi.fn(),
+      onToggleBackupOnWrite: vi.fn(),
+      onToggleAuditLogRotate: vi.fn(),
+      onChangeAuditLogMaxSizeMb: vi.fn(),
+      onChangeGroupRulesAt,
+    });
+    const at3 = getRadios().find((r) => r.value === "3");
+    expect(at3).toBeDefined();
+    if (!at3) return;
+    at3.checked = true;
+    at3.dispatchEvent(new Event("change"));
+    expect(onChangeGroupRulesAt).toHaveBeenCalledWith(3);
+  });
+});
+
+describe("grouping threshold drives tree rendering (#115)", () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
+
+  afterEach(() => {
+    clearBody();
+  });
+
+  function scopesWithTwoBashRules(): ReturnType<typeof buildLoadedScopes> {
+    return buildLoadedScopes({
+      project_dir: "/fake/group-threshold",
+      scopes: [
+        {
+          scope: "project",
+          permissions: { allow: ["Bash(git status)", "Bash(npm test)", "Read(**)"] },
+        },
+      ],
+    });
+  }
+
+  function bashGroupCount(): number {
+    // Synthetic tool-group nodes carry `.tree-tool-group` on the
+    // `<details>` element. The summary's `.tree-key` holds the bare
+    // tool name without a separator, so filter by both class and
+    // tool name to distinguish from any future non-Bash group.
+    return Array.from(root.querySelectorAll<HTMLElement>(".tree-tool-group")).filter(
+      (el) => (el.querySelector(":scope > summary .tree-key")?.textContent ?? "") === "Bash",
+    ).length;
+  }
+
+  it("group_rules_at=2 folds the two Bash rules into a group", () => {
+    renderApp(
+      root,
+      makeProps({
+        scopes: scopesWithTwoBashRules(),
+        preferences: buildPreferences({ group_rules_at: 2 }),
+      }),
+    );
+    expect(bashGroupCount()).toBe(1);
+  });
+
+  it("group_rules_at=3 keeps two Bash rules flat (below threshold)", () => {
+    renderApp(
+      root,
+      makeProps({
+        scopes: scopesWithTwoBashRules(),
+        preferences: buildPreferences({ group_rules_at: 3 }),
+      }),
+    );
+    expect(bashGroupCount()).toBe(0);
+    // Both rules still render — they just sit at the top level of the
+    // allow branch without a synthetic Bash group wrapper.
+    const ruleLabels = Array.from(root.querySelectorAll<HTMLElement>(".rule .rule-text"))
+      .map((el) => el.textContent)
+      .filter((s): s is string => s !== null);
+    expect(ruleLabels).toContain("Bash(git status)");
+    expect(ruleLabels).toContain("Bash(npm test)");
+  });
+
+  it("group_rules_at=null disables grouping entirely", () => {
+    renderApp(
+      root,
+      makeProps({
+        scopes: scopesWithTwoBashRules(),
+        preferences: buildPreferences({ group_rules_at: null }),
+      }),
+    );
+    expect(bashGroupCount()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Closes #115. #68 introduced the synthetic \`Tool ▸ (N)\` group node when 2+ rules share a tool prefix; the threshold has been a single compile-time constant since then. This PR exposes it as a user-configurable preference with three discrete states:

- **Group at 2** — most aggressive folding (matches the previous default, so existing users see no visual change).
- **Group at 3** — natural \"now there's enough to group\" point; two-rule clusters stay flat.
- **Never group** — for users who memorize position and don't want their visual anchor shifting when rules group.

## Backend

- \`Preferences.group_rules_at: Option<u32>\` — \`Some(n)\` groups at count >= n, \`None\` disables grouping. Constants \`GROUP_RULES_AT_MIN = 2\` and \`GROUP_RULES_AT_DEFAULT = 2\` pin the invariant in one place.
- Deserializer coerces \`Some(n < 2)\` back to the default (a hand-edited \`Some(0)\` would collapse every individual rule; \`Some(1)\` is no-op). \`None\` passes through unchanged.

## Frontend

- \`Preferences.group_rules_at: number | null\` mirrors the Rust shape.
- \`resolveGroupThreshold(prefs)\` maps \`null\` → \`Infinity\` so the grouping helper's \`< threshold\` check never fires when the user picked \"Never\".
- Threaded into both \`groupByToolPrefix\` call sites: \`seedDefaultOpenPermissions\` (now takes the threshold so seed state stays in sync with what the renderer actually groups) and \`populatePermissionList\` (props-driven, defaults to \`TOOL_GROUP_THRESHOLD\` when \`props\` is undefined in test/preview contexts).

## Settings UI

New \"Rule grouping\" section with three radios. Persist-on-click same as the rest of the dialog. \`null\` rides on the wire as a \`\"never\"\` string sentinel inside the radio's \`value\` attribute, mapped back to \`null\` in the change handler.

## Tests

**4 new Rust preferences tests:**
- Default matches legacy constant (existing users unchanged).
- Missing-field deserializes the same way (no surprise on upgrade).
- \`null\` round-trips cleanly.
- In-range values (3, 7) round-trip.
- Sub-minimum (\`0\`, \`1\`) clamps to default — not to the floor.

**4 new vitest settings tests:**
- Three radios render with values \`[\"2\", \"3\", \"never\"]\`.
- Current preference reflects on the checked radio (all three values).
- Clicking 'Never' invokes \`onChangeGroupRulesAt(null)\`.
- Clicking 'Group at 3' invokes \`onChangeGroupRulesAt(3)\`.

**3 new vitest rendering tests:**
- \`group_rules_at=2\` folds two Bash rules into a \`.tree-tool-group\`.
- \`group_rules_at=3\` keeps two Bash rules flat (below threshold) — both chips still render.
- \`group_rules_at=null\` disables grouping entirely.

**Totals:** 198 Rust tests + 99 vitest, all green. clippy / cargo fmt / biome / tsc clean.

## Test plan

- [ ] Open Settings → Rule grouping. Default radio shows \"Group at 2\".
- [ ] On a project with multiple rules sharing a tool prefix, watch the tree:
  - Pick \"Group at 3\" → groups of 2 unfold to flat rules.
  - Pick \"Group at 2\" → groups of 2 re-fold.
  - Pick \"Never\" → every rule renders flat regardless of tool.
- [ ] Re-launch ClaudeScope — the chosen radio persists.

## Out of scope (per the issue)

- Per-scope or per-kind thresholds. One number, applied uniformly.
- Per-tool exceptions (\"always group \`handoff\` but never \`Bash\`\"). Separate, bigger conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)