### PR TITLE
feat: filter known Claude projects in Move-to submenu (#111)

### DIFF
--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -520,7 +520,11 @@ fn cmd_list_projects(
     home: Option<&std::path::Path>,
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let entries = projects::list_known_projects(home)?;
+    // CLI doesn't surface the Move-to filter (#111) — `list-projects` is
+    // meant as a discovery / scripting hook, where any silent filter would
+    // surprise the caller. Pass the no-op default so the output matches
+    // what was on disk.
+    let entries = projects::list_known_projects(home, &projects::ProjectsFilter::default())?;
     if json {
         // Wrap in `KnownProjectOut` so the wire format is stable even if
         // the lib struct grows new fields. `serde_json::to_value` on

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -14,7 +14,7 @@ use crate::model::{
     PermissionKind, PermissionRules, SettingsDoc,
 };
 use crate::preferences::{self, Preferences};
-use crate::projects::{self, KnownProject};
+use crate::projects::{self, KnownProject, ProjectsFilter};
 use crate::runtime::{RuntimeInfo, RuntimeOverrides};
 use crate::scope::{self, Scope, ScopePaths};
 use crate::watcher::WatchState;
@@ -519,14 +519,52 @@ pub fn load_runtime_info(overrides: State<'_, RuntimeOverrides>) -> RuntimeInfo 
     RuntimeInfo::from_overrides(&overrides)
 }
 
+/// Hardcoded recency window for the Move-to submenu filter (#111). 90 days
+/// is a generous cutoff — the user's "I came back to this project last
+/// quarter" case still makes the list, but a one-off exploration from
+/// six months ago drops out. Lives in `commands.rs` rather than
+/// `projects.rs` so the pure discovery function stays policy-free and
+/// the default policy is one obvious place to revisit.
+const DEFAULT_PROJECT_RECENCY_DAYS: u32 = 90;
+
+/// Hardcoded minimum session count for the Move-to submenu filter
+/// (#111). `2` drops projects that have exactly one transcript — usually
+/// a one-shot "let me ask Claude something" exploration — without
+/// affecting any project the user has actually returned to.
+const DEFAULT_PROJECT_MIN_SESSIONS: u32 = 2;
+
+/// Build the effective filter for `list_known_projects`. Any field the
+/// frontend left unset (or set to an empty keyword) falls back to the
+/// hardcoded default for that dimension, so the silent baseline applies
+/// to every call but the user's typed keyword still composes on top.
+fn project_filter_with_defaults(req: Option<ProjectsFilter>) -> ProjectsFilter {
+    let req = req.unwrap_or_default();
+    ProjectsFilter {
+        recency_days: req.recency_days.or(Some(DEFAULT_PROJECT_RECENCY_DAYS)),
+        min_sessions: req.min_sessions.or(Some(DEFAULT_PROJECT_MIN_SESSIONS)),
+        // Normalize an empty keyword to `None` — the projects-layer
+        // filter already treats `Some("")` as a no-op, but normalizing
+        // here keeps the wire / logs cleaner and gives the frontend a
+        // single shape to send ("" when no input).
+        keyword: req.keyword.filter(|k| !k.is_empty()),
+    }
+}
+
 /// Enumerate every Claude project on this machine for the Move-to submenu
 /// (#106). Routes through `RuntimeOverrides::home` so sandbox mode (#66)
 /// reads from the scratch home instead of the real `~/.claude/projects/`.
+///
+/// `filter` (#111) narrows the list. Defaults apply per-field — the
+/// frontend can leave any dimension unset and the silent baseline
+/// (`DEFAULT_PROJECT_RECENCY_DAYS` / `DEFAULT_PROJECT_MIN_SESSIONS`)
+/// takes over, while a typed keyword still composes on top.
 #[tauri::command]
 pub fn list_known_projects(
     overrides: State<'_, RuntimeOverrides>,
+    filter: Option<ProjectsFilter>,
 ) -> Result<Vec<KnownProject>, String> {
-    projects::list_known_projects(overrides.home()).map_err(|e| e.to_string())
+    let effective = project_filter_with_defaults(filter);
+    projects::list_known_projects(overrides.home(), &effective).map_err(|e| e.to_string())
 }
 
 /// One row in the History view's audit-log list (#19 phase 2). Wraps an

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -13,9 +13,11 @@
 use std::fs;
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
+
+const SECS_PER_DAY: u64 = 24 * 60 * 60;
 
 /// Bounded scan over each transcript looking for the first `cwd`. The first
 /// few records are session-metadata wrappers (`type: "last-prompt"`,
@@ -35,6 +37,44 @@ pub struct KnownProject {
     pub root: PathBuf,
 }
 
+/// Optional per-dimension filter applied after discovery (#111). Default
+/// (every field `None` / empty) is the no-op: every loadable project is
+/// returned. The command layer fills in any user-configured or
+/// hardcoded defaults before calling — the pure discovery function
+/// itself stays policy-free so the unit tests can pin each dimension
+/// independently.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ProjectsFilter {
+    /// Hide projects whose newest `.jsonl` is older than this many days.
+    /// `None` disables the cutoff.
+    pub recency_days: Option<u32>,
+    /// Hide projects with fewer than this many `.jsonl` files in their
+    /// transcript directory. Drops single-session experiments when set
+    /// to `2`. `None` disables the floor.
+    pub min_sessions: Option<u32>,
+    /// Case-insensitive substring match against the project's display
+    /// name and full root path. `None` or `Some("")` disables — the
+    /// command layer normalizes empty strings on input so callers don't
+    /// have to distinguish "no filter" from "match anything".
+    pub keyword: Option<String>,
+}
+
+/// Per-project scan metadata collected during discovery. Used for
+/// filtering (#111) and then dropped — callers see only `KnownProject`.
+/// Folded into the same readdir pass that already finds the newest
+/// transcript so adding it costs no extra IO.
+#[derive(Debug)]
+struct ProjectScan {
+    cwd: PathBuf,
+    /// Modification time of the newest `.jsonl` in this project's
+    /// transcript directory. Used by the recency filter.
+    newest_mtime: SystemTime,
+    /// Count of `.jsonl` files in the transcript directory. Used by
+    /// the `min_sessions` filter.
+    session_count: u32,
+}
+
 /// Minimal shape we need from each transcript line. `serde` ignores the
 /// dozens of other fields each record carries, so a single struct works for
 /// both session-metadata and prompt/response records — only the ones with a
@@ -48,7 +88,15 @@ struct TranscriptLine {
 /// `dirs::home_dir()` for sandboxed tests (and the runtime `--home`
 /// override). Missing `~/.claude/projects/` is not an error — fresh
 /// installs simply return an empty list.
-pub fn list_known_projects(home: Option<&Path>) -> io::Result<Vec<KnownProject>> {
+///
+/// `filter` shrinks the list dimension-by-dimension (#111). The default
+/// (`ProjectsFilter::default()`) preserves today's behavior — every
+/// loadable project is returned. The command layer applies any
+/// hardcoded defaults before calling.
+pub fn list_known_projects(
+    home: Option<&Path>,
+    filter: &ProjectsFilter,
+) -> io::Result<Vec<KnownProject>> {
     let Some(projects_dir) = projects_dir(home) else {
         return Ok(Vec::new());
     };
@@ -59,23 +107,75 @@ pub fn list_known_projects(home: Option<&Path>) -> io::Result<Vec<KnownProject>>
         Err(e) => return Err(e),
     };
 
+    // Snapshot once so every recency comparison in this call sees the
+    // same "now" — otherwise a slow scan over many project dirs could
+    // produce subtly different cutoffs per project.
+    let now = SystemTime::now();
+
     let mut found: Vec<KnownProject> = Vec::new();
     for entry in entries.flatten() {
         if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
             continue;
         }
-        let Some(cwd) = latest_cwd_in(&entry.path())? else {
+        let Some(scan) = scan_project_dir(&entry.path())? else {
             continue;
         };
-        if !is_loadable_project(&cwd) {
+        if !is_loadable_project(&scan.cwd) {
             continue;
         }
-        let name = display_name_for(&cwd);
-        found.push(KnownProject { name, root: cwd });
+        let project = KnownProject {
+            name: display_name_for(&scan.cwd),
+            root: scan.cwd.clone(),
+        };
+        if !passes_filter(&scan, &project, filter, now) {
+            continue;
+        }
+        found.push(project);
     }
 
     dedupe_and_sort(&mut found);
     Ok(found)
+}
+
+/// Apply the per-dimension filter to a single scanned project. Each
+/// dimension is independent and short-circuits — the first failing
+/// check rejects the project. A `None` (or empty keyword) field is a
+/// no-op for that dimension, which lets the command layer leave
+/// individual filters off without having to construct sentinel values.
+fn passes_filter(
+    scan: &ProjectScan,
+    project: &KnownProject,
+    filter: &ProjectsFilter,
+    now: SystemTime,
+) -> bool {
+    if let Some(days) = filter.recency_days {
+        let cutoff = Duration::from_secs(u64::from(days) * SECS_PER_DAY);
+        // `duration_since` errors when the mtime is *after* `now` (clock
+        // skew, or a filesystem touched from a host with a fast clock).
+        // Treat that as "very recent" rather than rejecting — punishing
+        // a project for a future timestamp would surprise the user.
+        if let Ok(age) = now.duration_since(scan.newest_mtime) {
+            if age > cutoff {
+                return false;
+            }
+        }
+    }
+    if let Some(min) = filter.min_sessions {
+        if scan.session_count < min {
+            return false;
+        }
+    }
+    if let Some(kw) = filter.keyword.as_deref() {
+        if !kw.is_empty() {
+            let needle = kw.to_lowercase();
+            let name = project.name.to_lowercase();
+            let path = project.root.to_string_lossy().to_lowercase();
+            if !name.contains(&needle) && !path.contains(&needle) {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 fn projects_dir(home: Option<&Path>) -> Option<PathBuf> {
@@ -83,12 +183,15 @@ fn projects_dir(home: Option<&Path>) -> Option<PathBuf> {
     Some(base.join(".claude").join("projects"))
 }
 
-/// Pick the newest transcript file in `dir` and extract its first `cwd`.
-/// Newest-wins because a project the user has come back to most recently
-/// has the truest current path: an old transcript could reference a path
-/// from before a directory rename.
-fn latest_cwd_in(dir: &Path) -> io::Result<Option<PathBuf>> {
+/// Walk a project's transcript directory in a single readdir pass and
+/// pull out everything the filter pipeline needs: the newest
+/// transcript's `cwd`, that transcript's mtime, and the total session
+/// count. Newest-wins because a project the user has come back to most
+/// recently has the truest current path — an old transcript could
+/// reference a path from before a directory rename.
+fn scan_project_dir(dir: &Path) -> io::Result<Option<ProjectScan>> {
     let mut newest: Option<(SystemTime, PathBuf)> = None;
+    let mut session_count: u32 = 0;
     for entry in fs::read_dir(dir)?.flatten() {
         let file_type = match entry.file_type() {
             Ok(t) => t,
@@ -101,6 +204,7 @@ fn latest_cwd_in(dir: &Path) -> io::Result<Option<PathBuf>> {
         if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
             continue;
         }
+        session_count = session_count.saturating_add(1);
         // mtime fallback to UNIX_EPOCH keeps ordering stable on filesystems
         // that fail to report a modified time (rare, but seen on some
         // Windows network shares); the comparison still yields *some* total
@@ -115,10 +219,17 @@ fn latest_cwd_in(dir: &Path) -> io::Result<Option<PathBuf>> {
         }
     }
 
-    let Some((_, path)) = newest else {
+    let Some((newest_mtime, path)) = newest else {
         return Ok(None);
     };
-    Ok(extract_first_cwd(&path)?.map(PathBuf::from))
+    let Some(cwd) = extract_first_cwd(&path)? else {
+        return Ok(None);
+    };
+    Ok(Some(ProjectScan {
+        cwd: PathBuf::from(cwd),
+        newest_mtime,
+        session_count,
+    }))
 }
 
 fn extract_first_cwd(path: &Path) -> io::Result<Option<String>> {
@@ -215,7 +326,7 @@ mod tests {
     fn returns_empty_when_projects_dir_missing() {
         let tmp = tempfile::tempdir().unwrap();
         // No `~/.claude/projects/` at all.
-        let got = list_known_projects(Some(tmp.path())).unwrap();
+        let got = list_known_projects(Some(tmp.path()), &ProjectsFilter::default()).unwrap();
         assert!(got.is_empty());
     }
 
@@ -226,7 +337,7 @@ mod tests {
         let project = make_loadable_project(tmp.path(), "alpha");
         seed_project(&home, "D--alpha", &project);
 
-        let got = list_known_projects(Some(&home)).unwrap();
+        let got = list_known_projects(Some(&home), &ProjectsFilter::default()).unwrap();
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].name, "alpha");
         assert_eq!(canonical_key(&got[0].root), canonical_key(&project));
@@ -240,7 +351,7 @@ mod tests {
         let bogus = tmp.path().join("deleted-project");
         seed_project(&home, "D--gone", &bogus);
 
-        let got = list_known_projects(Some(&home)).unwrap();
+        let got = list_known_projects(Some(&home), &ProjectsFilter::default()).unwrap();
         assert!(got.is_empty(), "expected stale project to be filtered out");
     }
 
@@ -254,7 +365,7 @@ mod tests {
         fs::create_dir_all(&project).unwrap();
         seed_project(&home, "D--bare", &project);
 
-        let got = list_known_projects(Some(&home)).unwrap();
+        let got = list_known_projects(Some(&home), &ProjectsFilter::default()).unwrap();
         assert!(got.is_empty());
     }
 
@@ -272,7 +383,7 @@ mod tests {
             ],
         );
 
-        let got = list_known_projects(Some(&home)).unwrap();
+        let got = list_known_projects(Some(&home), &ProjectsFilter::default()).unwrap();
         assert!(got.is_empty());
     }
 
@@ -287,7 +398,7 @@ mod tests {
         seed_project(&home, "p-alpha", &alpha);
         seed_project(&home, "p-Beta", &beta);
 
-        let got = list_known_projects(Some(&home)).unwrap();
+        let got = list_known_projects(Some(&home), &ProjectsFilter::default()).unwrap();
         let names: Vec<&str> = got.iter().map(|p| p.name.as_str()).collect();
         assert_eq!(names, vec!["alpha", "Beta", "gamma"]);
     }
@@ -303,7 +414,7 @@ mod tests {
         seed_project(&home, "D--SHARED", &project);
         seed_project(&home, "D--shared", &project);
 
-        let got = list_known_projects(Some(&home)).unwrap();
+        let got = list_known_projects(Some(&home), &ProjectsFilter::default()).unwrap();
         assert_eq!(got.len(), 1);
     }
 
@@ -326,7 +437,7 @@ mod tests {
         // this. Must not be opened as a transcript.
         fs::create_dir_all(dir.join("1fad75bd-3add-4aba-85d6-9ac4b8369d34")).unwrap();
 
-        let got = list_known_projects(Some(&home)).unwrap();
+        let got = list_known_projects(Some(&home), &ProjectsFilter::default()).unwrap();
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].name, "mixed");
     }
@@ -359,8 +470,241 @@ mod tests {
         let f = fs::OpenOptions::new().write(true).open(&newer).unwrap();
         f.set_modified(later).unwrap();
 
-        let got = list_known_projects(Some(&home)).unwrap();
+        let got = list_known_projects(Some(&home), &ProjectsFilter::default()).unwrap();
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].name, "new-name");
+    }
+
+    // -- #111 filter tests ---------------------------------------------------
+
+    /// Bump a transcript file's mtime to a specific offset from now. Used
+    /// by the recency tests to age a session past a cutoff without
+    /// sleeping. `f.set_modified` is stable since Rust 1.75 and our MSRV
+    /// is 1.88.
+    fn set_mtime_offset(path: &Path, offset_from_now: std::time::Duration, past: bool) {
+        let mtime = if past {
+            SystemTime::now() - offset_from_now
+        } else {
+            SystemTime::now() + offset_from_now
+        };
+        let f = fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(mtime).unwrap();
+    }
+
+    #[test]
+    fn recency_cutoff_hides_projects_older_than_the_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let fresh = make_loadable_project(tmp.path(), "fresh");
+        let stale = make_loadable_project(tmp.path(), "stale");
+        seed_project(&home, "p-fresh", &fresh);
+        seed_project(&home, "p-stale", &stale);
+
+        // Age the `stale` transcript 100 days into the past — well past
+        // any sane cutoff. `fresh` keeps its just-written mtime.
+        let stale_jsonl = home
+            .join(".claude")
+            .join("projects")
+            .join("p-stale")
+            .join("0001-session.jsonl");
+        set_mtime_offset(&stale_jsonl, Duration::from_secs(100 * SECS_PER_DAY), true);
+
+        let filter = ProjectsFilter {
+            recency_days: Some(30),
+            ..ProjectsFilter::default()
+        };
+        let got = list_known_projects(Some(&home), &filter).unwrap();
+        let names: Vec<&str> = got.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["fresh"]);
+    }
+
+    #[test]
+    fn recency_cutoff_keeps_future_mtimes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = make_loadable_project(tmp.path(), "future-clock");
+        seed_project(&home, "p-future", &project);
+
+        // mtime way in the future — clock skew between machines, or a
+        // filesystem that surfaces a remote host's clock. Treat as
+        // recent, not as "older than cutoff".
+        let jsonl = home
+            .join(".claude")
+            .join("projects")
+            .join("p-future")
+            .join("0001-session.jsonl");
+        set_mtime_offset(&jsonl, Duration::from_secs(365 * SECS_PER_DAY), false);
+
+        let filter = ProjectsFilter {
+            recency_days: Some(1),
+            ..ProjectsFilter::default()
+        };
+        let got = list_known_projects(Some(&home), &filter).unwrap();
+        assert_eq!(got.len(), 1);
+    }
+
+    #[test]
+    fn min_sessions_hides_single_session_projects() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let busy = make_loadable_project(tmp.path(), "busy");
+        let oneoff = make_loadable_project(tmp.path(), "oneoff");
+
+        // `busy` gets two transcripts, `oneoff` gets just the one seed
+        // file. Both seed files carry a cwd record.
+        seed_project(&home, "p-busy", &busy);
+        let busy_dir = home.join(".claude").join("projects").join("p-busy");
+        let cwd_str = busy.to_string_lossy().replace('\\', "\\\\");
+        write_jsonl(
+            &busy_dir.join("0002-session.jsonl"),
+            &[&format!(r#"{{"sessionId":"t","cwd":"{cwd_str}"}}"#)],
+        );
+        seed_project(&home, "p-oneoff", &oneoff);
+
+        let filter = ProjectsFilter {
+            min_sessions: Some(2),
+            ..ProjectsFilter::default()
+        };
+        let got = list_known_projects(Some(&home), &filter).unwrap();
+        let names: Vec<&str> = got.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["busy"]);
+    }
+
+    #[test]
+    fn keyword_filter_matches_name_substring_case_insensitive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let scope = make_loadable_project(tmp.path(), "claude-scope");
+        let other = make_loadable_project(tmp.path(), "unrelated");
+        seed_project(&home, "p-scope", &scope);
+        seed_project(&home, "p-other", &other);
+
+        let filter = ProjectsFilter {
+            keyword: Some("SCOPE".to_string()),
+            ..ProjectsFilter::default()
+        };
+        let got = list_known_projects(Some(&home), &filter).unwrap();
+        let names: Vec<&str> = got.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["claude-scope"]);
+    }
+
+    #[test]
+    fn keyword_filter_matches_path_substring() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        // Project basename doesn't carry the needle, but the parent path
+        // does — the filter searches the full root, not just the name.
+        let parent = tmp.path().join("workspaces").join("auth-team");
+        fs::create_dir_all(&parent).unwrap();
+        let project = make_loadable_project(&parent, "service");
+        let other = make_loadable_project(tmp.path(), "elsewhere");
+        seed_project(&home, "p-deep", &project);
+        seed_project(&home, "p-other", &other);
+
+        let filter = ProjectsFilter {
+            keyword: Some("auth-team".to_string()),
+            ..ProjectsFilter::default()
+        };
+        let got = list_known_projects(Some(&home), &filter).unwrap();
+        let names: Vec<&str> = got.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["service"]);
+    }
+
+    #[test]
+    fn empty_keyword_is_a_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let project = make_loadable_project(tmp.path(), "anything");
+        seed_project(&home, "p-any", &project);
+
+        let filter = ProjectsFilter {
+            keyword: Some(String::new()),
+            ..ProjectsFilter::default()
+        };
+        let got = list_known_projects(Some(&home), &filter).unwrap();
+        assert_eq!(got.len(), 1, "empty keyword must not hide anything");
+    }
+
+    #[test]
+    fn filters_compose_recency_min_sessions_and_keyword() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+
+        // The keep-it project hits every dimension: fresh, two sessions,
+        // keyword in name.
+        let keep = make_loadable_project(tmp.path(), "auth-keep");
+        seed_project(&home, "p-keep", &keep);
+        let keep_dir = home.join(".claude").join("projects").join("p-keep");
+        let keep_cwd = keep.to_string_lossy().replace('\\', "\\\\");
+        write_jsonl(
+            &keep_dir.join("0002-session.jsonl"),
+            &[&format!(r#"{{"sessionId":"t","cwd":"{keep_cwd}"}}"#)],
+        );
+
+        // Fails on keyword: name doesn't match.
+        let no_match = make_loadable_project(tmp.path(), "unrelated");
+        seed_project(&home, "p-no-match", &no_match);
+        let no_match_dir = home.join(".claude").join("projects").join("p-no-match");
+        let no_match_cwd = no_match.to_string_lossy().replace('\\', "\\\\");
+        write_jsonl(
+            &no_match_dir.join("0002-session.jsonl"),
+            &[&format!(r#"{{"sessionId":"t","cwd":"{no_match_cwd}"}}"#)],
+        );
+
+        // Fails on min_sessions: only one transcript.
+        let single = make_loadable_project(tmp.path(), "auth-single");
+        seed_project(&home, "p-single", &single);
+
+        // Fails on recency: aged out.
+        let old = make_loadable_project(tmp.path(), "auth-old");
+        seed_project(&home, "p-old", &old);
+        let old_dir = home.join(".claude").join("projects").join("p-old");
+        let old_cwd = old.to_string_lossy().replace('\\', "\\\\");
+        write_jsonl(
+            &old_dir.join("0002-session.jsonl"),
+            &[&format!(r#"{{"sessionId":"t","cwd":"{old_cwd}"}}"#)],
+        );
+        // Age every .jsonl in p-old past the recency cutoff. Touching
+        // only the newest file is enough since the filter uses the
+        // newest mtime as the project's recency proxy, but bump both
+        // for clarity.
+        for jsonl in ["0001-session.jsonl", "0002-session.jsonl"] {
+            set_mtime_offset(
+                &old_dir.join(jsonl),
+                Duration::from_secs(100 * SECS_PER_DAY),
+                true,
+            );
+        }
+
+        let filter = ProjectsFilter {
+            recency_days: Some(30),
+            min_sessions: Some(2),
+            keyword: Some("auth".to_string()),
+        };
+        let got = list_known_projects(Some(&home), &filter).unwrap();
+        let names: Vec<&str> = got.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["auth-keep"]);
+    }
+
+    #[test]
+    fn default_filter_preserves_all_loadable_projects() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let a = make_loadable_project(tmp.path(), "a");
+        let b = make_loadable_project(tmp.path(), "b");
+        seed_project(&home, "p-a", &a);
+        seed_project(&home, "p-b", &b);
+        // Age `a` past any conceivable cutoff — the default filter
+        // shouldn't notice.
+        let a_jsonl = home
+            .join(".claude")
+            .join("projects")
+            .join("p-a")
+            .join("0001-session.jsonl");
+        set_mtime_offset(&a_jsonl, Duration::from_secs(365 * SECS_PER_DAY), true);
+
+        let got = list_known_projects(Some(&home), &ProjectsFilter::default()).unwrap();
+        let names: Vec<&str> = got.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b"]);
     }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1407,6 +1407,38 @@ button:disabled {
   margin: 4px 0;
 }
 
+/* In-menu filter input row (#111). Wraps a `<input type="search">` in
+   a non-interactive row so clicks on the row don't dismiss the menu
+   and hover doesn't trigger drop-target highlighting. Padding matches
+   `.context-menu-item` so the input lines up vertically with the
+   button column above and below. */
+.context-menu-input-row {
+  padding: 4px 8px;
+}
+.context-menu-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 4px 8px;
+  font: inherit;
+  color: inherit;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  outline: none;
+}
+.context-menu-input:focus {
+  border-color: var(--accent);
+}
+
+/* Filter hits walk the input row's subsequent siblings and toggle
+   this class on the ones whose `data-match-text` doesn't contain the
+   needle (#111). `display: none` rather than `visibility` so hidden
+   items don't reserve space in the menu's height — a list of 80
+   filtered-out projects shouldn't leave a tall blank menu. */
+.context-menu-hidden {
+  display: none;
+}
+
 /* When the diff modal is rendering only one side (delete, paste, same-scope
    change-kind), drop the two-column grid so the side fills the dialog width
    instead of leaving an empty column. */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2886,11 +2886,32 @@ function formatValue(v: JsonValue | undefined): string {
 
 // -- Context menu primitive (#8) ---------------------------------------------
 
-/** One item in a context menu — leaf, separator, or nested submenu. */
+/** One item in a context menu — leaf, separator, nested submenu, or
+ *  filter input (#111). The optional `searchText` lets a leaf or
+ *  submenu opt into the input row's substring filter; items without
+ *  `searchText` are never hidden by the filter and stay visible
+ *  regardless of query (used for User / User-Local in the Move-to
+ *  submenu, which sit above the input and shouldn't be filterable). */
 type MenuItem =
-  | { label: string; onClick: () => void; disabled?: boolean }
-  | { label: string; submenu: MenuItem[]; disabled?: boolean }
-  | { separator: true };
+  | { label: string; onClick: () => void; disabled?: boolean; searchText?: string }
+  | { label: string; submenu: MenuItem[]; disabled?: boolean; searchText?: string }
+  | { separator: true }
+  | { input: MenuInputConfig };
+
+/** Configuration for an in-menu filter input (#111). The input row is
+ *  rendered like any other menu item but doesn't dismiss the menu on
+ *  click, and live-filters every subsequent sibling item with a
+ *  `searchText` field. `onChange` fires on every keystroke so the
+ *  caller can persist the value for the next time the menu opens; the
+ *  filter itself is applied by the menu primitive against
+ *  `data-match-text` attributes set during render — the caller doesn't
+ *  need to walk the DOM. */
+interface MenuInputConfig {
+  placeholder: string;
+  value: string;
+  onChange: (query: string) => void;
+  autofocus?: true;
+}
 
 let openContextMenuClose: (() => void) | null = null;
 
@@ -2930,8 +2951,32 @@ function openContextMenu(items: MenuItem[], x: number, y: number, trigger?: HTML
 
   function buttonsIn(menu: HTMLElement): HTMLButtonElement[] {
     return Array.from(
-      menu.querySelectorAll<HTMLButtonElement>("button.context-menu-item:not(:disabled)"),
+      menu.querySelectorAll<HTMLButtonElement>(
+        "button.context-menu-item:not(:disabled):not(.context-menu-hidden)",
+      ),
     );
+  }
+
+  /**
+   * Apply an input row's query to every subsequent sibling item that
+   * opted into filtering via `data-match-text` (#111). Items above the
+   * input or without a match text are untouched — that's how Move-to's
+   * User / User-Local rows stay always-visible while the project list
+   * below the input filters live.
+   */
+  function applyMenuFilter(input: HTMLInputElement, query: string): void {
+    const needle = query.toLowerCase();
+    let sibling = input.parentElement?.nextElementSibling;
+    while (sibling) {
+      if (sibling instanceof HTMLElement) {
+        const matchText = sibling.dataset.matchText;
+        if (matchText !== undefined) {
+          const hit = needle === "" || matchText.includes(needle);
+          sibling.classList.toggle("context-menu-hidden", !hit);
+        }
+      }
+      sibling = sibling.nextElementSibling;
+    }
   }
 
   function closeSubmenusBelow(depth: number): void {
@@ -2945,6 +2990,11 @@ function openContextMenu(items: MenuItem[], x: number, y: number, trigger?: HTML
     const menu = document.createElement("div");
     menu.className = "context-menu";
     menu.setAttribute("role", "menu");
+    // Capture the autofocus input — if any — so we can focus it after
+    // the menu lands in the DOM (focus before insertion is silently
+    // dropped). At most one input per menu in v1 (#111 only adds it to
+    // Move-to), but the code is shaped to tolerate a future second.
+    let autofocusInput: HTMLInputElement | null = null;
     for (const item of items) {
       if ("separator" in item) {
         const sep = document.createElement("div");
@@ -2953,11 +3003,70 @@ function openContextMenu(items: MenuItem[], x: number, y: number, trigger?: HTML
         menu.appendChild(sep);
         continue;
       }
+      if ("input" in item) {
+        // Input row (#111). Lives in its own non-button container so
+        // `buttonsIn` doesn't include it, drop-target highlighting
+        // doesn't fire on hover, and the outside-click handler still
+        // treats clicks here as "inside the menu" because of the
+        // `stack.some((m) => m.contains(target))` check.
+        const row = document.createElement("div");
+        row.className = "context-menu-input-row";
+        row.setAttribute("role", "presentation");
+        const input = document.createElement("input");
+        input.type = "search";
+        input.className = "context-menu-input";
+        input.placeholder = item.input.placeholder;
+        input.value = item.input.value;
+        input.setAttribute("aria-label", item.input.placeholder);
+        // Stop arrow-key bubbling on keys that *don't* belong to menu
+        // nav so the input still handles text-editing keystrokes
+        // (Home / End / Backspace) normally. The menu's onKey handler
+        // owns ArrowUp / ArrowDown / Escape / ArrowLeft / ArrowRight
+        // when focus is on a button, but ArrowUp/Down should *also*
+        // move focus from the input into the filtered list. Those two
+        // keys propagate; everything else (typing, caret movement) is
+        // local to the input.
+        input.addEventListener("input", () => {
+          item.input.onChange(input.value);
+          applyMenuFilter(input, input.value);
+        });
+        // ArrowDown from the input drops focus into the first visible
+        // sibling button *below* the row — not the first button in the
+        // menu, which would skip back to User / User-Local rows that
+        // sit above the input. ArrowUp does nothing (no buttons above
+        // an input in the v1 layout, and wrapping would surprise).
+        input.addEventListener("keydown", (e) => {
+          if (e.key !== "ArrowDown") return;
+          e.preventDefault();
+          let sibling = row.nextElementSibling;
+          while (sibling) {
+            if (
+              sibling instanceof HTMLButtonElement &&
+              !sibling.disabled &&
+              !sibling.classList.contains("context-menu-hidden")
+            ) {
+              sibling.focus();
+              return;
+            }
+            sibling = sibling.nextElementSibling;
+          }
+        });
+        row.appendChild(input);
+        menu.appendChild(row);
+        if (item.input.autofocus) autofocusInput = input;
+        continue;
+      }
       const btn = document.createElement("button");
       btn.type = "button";
       btn.className = "context-menu-item";
       btn.setAttribute("role", "menuitem");
       btn.textContent = item.label;
+      // Opt-in to the input-row filter. Lowercased once at render time
+      // so live keystroke filtering only compares pre-normalized
+      // strings on each pass.
+      if (item.searchText !== undefined) {
+        btn.dataset.matchText = item.searchText.toLowerCase();
+      }
       if ("submenu" in item) {
         btn.classList.add("context-menu-submenu-trigger");
         const arrow = document.createElement("span");
@@ -2993,6 +3102,12 @@ function openContextMenu(items: MenuItem[], x: number, y: number, trigger?: HTML
     }
 
     document.body.appendChild(menu);
+    // Re-apply the persisted filter on render so reopening a menu with
+    // a previous query landed in the input shows the matching subset
+    // immediately, not the full list flashed then hidden.
+    if (autofocusInput && autofocusInput.value !== "") {
+      applyMenuFilter(autofocusInput, autofocusInput.value);
+    }
     const rect = menu.getBoundingClientRect();
     let left: number;
     let top: number;
@@ -3014,7 +3129,17 @@ function openContextMenu(items: MenuItem[], x: number, y: number, trigger?: HTML
     }
     menu.style.left = `${left}px`;
     menu.style.top = `${top}px`;
-    buttonsIn(menu)[0]?.focus();
+    // Input wins focus over the first button when present and
+    // autofocus is set — that's the whole point of an in-menu filter.
+    if (autofocusInput) {
+      autofocusInput.focus();
+      // Pre-select so a fresh keystroke replaces the persisted query
+      // (typical "search box on open" behavior) without forcing the
+      // user to Cmd+A first.
+      autofocusInput.select();
+    } else {
+      buttonsIn(menu)[0]?.focus();
+    }
     return menu;
   }
 
@@ -3061,6 +3186,17 @@ function openContextMenu(items: MenuItem[], x: number, y: number, trigger?: HTML
       btns[(idx + 1 + btns.length) % btns.length]?.focus();
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
+      // ArrowUp on the first visible button hops into the menu's
+      // input row if one exists (#111) — Tab order is too narrow for
+      // a hidden filter input that the user has to remember exists.
+      if (idx === 0) {
+        const input = menu.querySelector<HTMLInputElement>(".context-menu-input");
+        if (input) {
+          input.focus();
+          input.select();
+          return;
+        }
+      }
       btns[(idx - 1 + btns.length) % btns.length]?.focus();
     } else if (e.key === "ArrowRight") {
       if (active?.classList.contains("context-menu-submenu-trigger")) {
@@ -3124,6 +3260,37 @@ function attachContextMenu(el: HTMLElement, build: () => MenuItem[]): void {
 }
 
 /**
+ * Threshold above which the Move-to submenu shows an inline keyword
+ * filter input (#111). Below this number every project fits in a
+ * single glance and the input is more friction than help; above it,
+ * the menu can get unwieldy on machines with a long project history.
+ * Picked low rather than high so users with a handful of projects
+ * still benefit from the filter — bump it later if user reports say
+ * the input feels intrusive in the small-project case.
+ */
+const MOVE_TO_PROJECT_FILTER_THRESHOLD = 5;
+
+/**
+ * Session-scoped filter query for the Move-to submenu's project list
+ * (#111). Lives at module scope so it survives across context menu
+ * opens within a session — typing once and re-opening the menu shows
+ * the same filtered list — but resets to empty on page reload, by
+ * design. Persisting to user preferences is in #136.
+ */
+let moveToProjectFilter = "";
+
+/**
+ * Test-only reset for the Move-to filter (#111). Tests that exercise
+ * the "input renders empty on open" path or share `describe` state need
+ * a clean slate; production code never calls this. The underscore
+ * prefix is the convention for "this is here for tests; please don't
+ * reach for it from other production code."
+ */
+export function _resetMoveToProjectFilterForTesting(): void {
+  moveToProjectFilter = "";
+}
+
+/**
  * Build the Move-to submenu structure (#8): User / User-Local at top,
  * then a separator, then each known project as a nested submenu of its
  * Local / Project scopes. `from` (and optional `fromProject`) drive the
@@ -3135,6 +3302,15 @@ function attachContextMenu(el: HTMLElement, build: () => MenuItem[]): void {
  * but #106 will give us the choice of multiple projects and the source-
  * skip will need the project identity to disambiguate Local-of-A from
  * Local-of-B.
+ *
+ * When the discovered project count exceeds
+ * [[MOVE_TO_PROJECT_FILTER_THRESHOLD]], an inline filter input (#111)
+ * is inserted between the separator and the first project — User /
+ * User-Local stay above it and aren't affected by the keyword. The
+ * filter runs client-side against name + root substring so keystrokes
+ * are instant (no IPC round-trip); the backend-side `keyword` filter
+ * is plumbed but currently used only by the CLI and as a hook for the
+ * eventual content-scan in #136.
  */
 function buildMoveToSubmenu(
   props: AppProps,
@@ -3152,6 +3328,22 @@ function buildMoveToSubmenu(
   if (projects.length > 0 && items.length > 0) {
     items.push({ separator: true });
   }
+  // Inline filter input (#111) — only renders above the threshold so
+  // small project lists stay clean. The filter is applied at the DOM
+  // layer by the menu primitive; each project item carries a
+  // `searchText` that matches against name and full root path.
+  if (projects.length > MOVE_TO_PROJECT_FILTER_THRESHOLD) {
+    items.push({
+      input: {
+        placeholder: "Filter projects…",
+        value: moveToProjectFilter,
+        autofocus: true,
+        onChange: (query) => {
+          moveToProjectFilter = query;
+        },
+      },
+    });
+  }
   for (const project of projects) {
     const inner: MenuItem[] = [];
     for (const target of ["local", "project"] as Scope[]) {
@@ -3160,7 +3352,15 @@ function buildMoveToSubmenu(
       inner.push({ label: SCOPE_LABELS[target], onClick: () => onPick(target) });
     }
     if (inner.length === 0) continue;
-    items.push({ label: project.name, submenu: inner });
+    items.push({
+      label: project.name,
+      submenu: inner,
+      // Match against display name + full root path so users typing
+      // either "auth-team" (parent dir) or "service" (basename) find
+      // the project. Joined with `\n` so a substring can't span the
+      // boundary and produce a false positive.
+      searchText: `${project.name}\n${project.root}`,
+    });
   }
   return items;
 }

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -12,6 +12,7 @@ import type {
 } from "../../src/types.ts";
 import { SEARCH_INPUT_ID } from "../../src/types.ts";
 import {
+  _resetMoveToProjectFilterForTesting,
   attachHelpTooltip,
   groupByToolPrefix,
   lookupKeyHelp,
@@ -417,6 +418,204 @@ describe("context menu (#8)", () => {
       document.querySelectorAll<HTMLButtonElement>(".context-menu-item"),
     ).map((b) => b.textContent?.replace(/\s*▸$/, "").trim() ?? "");
     expect(labels).toContain("Paste as");
+  });
+
+  // -- #111 Move-to project filter ----------------------------------------
+
+  /** Build N synthetic known projects with predictable names + roots so
+   *  the threshold and substring filter can be exercised in isolation
+   *  from any real disk discovery. */
+  function syntheticProjects(n: number): KnownProject[] {
+    return Array.from({ length: n }, (_, i) => ({
+      name: `proj-${String.fromCharCode(97 + i)}`,
+      root: `/tmp/parent-${String.fromCharCode(97 + i)}/proj-${String.fromCharCode(97 + i)}`,
+    }));
+  }
+
+  function openMoveToSubmenu(): HTMLElement {
+    const scopes = buildLoadedScopes({
+      scopes: [{ scope: "project", permissions: { allow: ["Bash(git status)"] } }],
+      project_dir: "/tmp/loaded",
+    });
+    renderApp(
+      root,
+      makeProps({
+        scopes,
+        // 8 synthetic projects + the loaded "/tmp/loaded" current
+        // project — comfortably above the v1 threshold of 5.
+        knownProjects: syntheticProjects(8),
+      }),
+    );
+    const ruleRow = root.querySelector<HTMLElement>(".rule.rule-allow");
+    if (!ruleRow) throw new Error("expected rule row");
+    rightClick(ruleRow);
+    findMenuItem("Move to")?.click();
+    const menus = document.querySelectorAll<HTMLElement>(".context-menu");
+    if (menus.length < 2) throw new Error("expected Move-to submenu to open");
+    return menus[1];
+  }
+
+  it("hides the project filter input when project count is at or below the threshold", () => {
+    _resetMoveToProjectFilterForTesting();
+    const scopes = buildLoadedScopes({
+      scopes: [{ scope: "project", permissions: { allow: ["Bash(git status)"] } }],
+      project_dir: "/tmp/loaded",
+    });
+    renderApp(
+      root,
+      makeProps({
+        scopes,
+        // 4 backend + 1 current = 5, exactly at threshold — still no input.
+        knownProjects: syntheticProjects(4),
+      }),
+    );
+    const ruleRow = root.querySelector<HTMLElement>(".rule.rule-allow");
+    if (!ruleRow) throw new Error("expected rule row");
+    rightClick(ruleRow);
+    findMenuItem("Move to")?.click();
+    const submenu = document.querySelectorAll<HTMLElement>(".context-menu")[1];
+    expect(submenu).toBeTruthy();
+    expect(submenu.querySelector(".context-menu-input")).toBeNull();
+  });
+
+  it("renders the project filter input as the first item after the separator above the threshold", () => {
+    _resetMoveToProjectFilterForTesting();
+    const submenu = openMoveToSubmenu();
+    const input = submenu.querySelector<HTMLInputElement>(".context-menu-input");
+    expect(input).not.toBeNull();
+    expect(input?.placeholder).toBe("Filter projects…");
+
+    // Verify the input sits between the separator and the first project
+    // item — User / User-Local must remain ABOVE it so they stay
+    // unaffected by the keyword.
+    const order: string[] = [];
+    for (const child of Array.from(submenu.children)) {
+      if (child.classList.contains("context-menu-input-row")) order.push("INPUT");
+      else if (child.classList.contains("context-menu-sep")) order.push("SEP");
+      else if (child.classList.contains("context-menu-item")) {
+        order.push(child.textContent?.replace(/\s*▸$/, "").trim() ?? "");
+      }
+    }
+    const sepIdx = order.indexOf("SEP");
+    const inputIdx = order.indexOf("INPUT");
+    expect(sepIdx).toBeGreaterThan(-1);
+    expect(inputIdx).toBe(sepIdx + 1);
+    // User / User-Local are above the separator (and therefore above the input).
+    expect(order.slice(0, sepIdx)).toEqual(expect.arrayContaining(["User", "User-Local"]));
+  });
+
+  it("typing in the filter input hides projects that don't match name or path substring", () => {
+    _resetMoveToProjectFilterForTesting();
+    const submenu = openMoveToSubmenu();
+    const input = submenu.querySelector<HTMLInputElement>(".context-menu-input");
+    if (!input) throw new Error("expected filter input");
+
+    input.value = "proj-a";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const visibleProjectLabels = Array.from(
+      submenu.querySelectorAll<HTMLButtonElement>(".context-menu-item"),
+    )
+      .filter((b) => !b.classList.contains("context-menu-hidden"))
+      .map((b) => b.textContent?.replace(/\s*▸$/, "").trim() ?? "");
+    // proj-a matches; proj-b..h have a different basename. User /
+    // User-Local stay visible because they sit above the input and
+    // never carry `data-match-text`.
+    expect(visibleProjectLabels).toContain("proj-a");
+    expect(visibleProjectLabels).not.toContain("proj-b");
+    expect(visibleProjectLabels).toContain("User");
+    expect(visibleProjectLabels).toContain("User-Local");
+  });
+
+  it("filter substring also matches the project's parent path", () => {
+    _resetMoveToProjectFilterForTesting();
+    const submenu = openMoveToSubmenu();
+    const input = submenu.querySelector<HTMLInputElement>(".context-menu-input");
+    if (!input) throw new Error("expected filter input");
+
+    // "parent-c" is in the synthetic root for proj-c only; the
+    // basename is proj-c. Matching on the parent dir validates the
+    // "name + root" join in `searchText`.
+    input.value = "parent-c";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const visibleProjectLabels = Array.from(
+      submenu.querySelectorAll<HTMLButtonElement>(".context-menu-item"),
+    )
+      .filter((b) => !b.classList.contains("context-menu-hidden") && b.dataset.matchText)
+      .map((b) => b.textContent?.replace(/\s*▸$/, "").trim() ?? "");
+    expect(visibleProjectLabels).toEqual(["proj-c"]);
+  });
+
+  it("filter is case-insensitive", () => {
+    _resetMoveToProjectFilterForTesting();
+    const submenu = openMoveToSubmenu();
+    const input = submenu.querySelector<HTMLInputElement>(".context-menu-input");
+    if (!input) throw new Error("expected filter input");
+
+    input.value = "PROJ-D";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const visibleProjectLabels = Array.from(
+      submenu.querySelectorAll<HTMLButtonElement>(".context-menu-item"),
+    )
+      .filter((b) => !b.classList.contains("context-menu-hidden") && b.dataset.matchText)
+      .map((b) => b.textContent?.replace(/\s*▸$/, "").trim() ?? "");
+    expect(visibleProjectLabels).toEqual(["proj-d"]);
+  });
+
+  it("clearing the input restores every project", () => {
+    _resetMoveToProjectFilterForTesting();
+    const submenu = openMoveToSubmenu();
+    const input = submenu.querySelector<HTMLInputElement>(".context-menu-input");
+    if (!input) throw new Error("expected filter input");
+
+    input.value = "proj-a";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.value = "";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const hidden = submenu.querySelectorAll<HTMLButtonElement>(".context-menu-hidden");
+    expect(hidden.length).toBe(0);
+  });
+
+  it("filter query persists across menu closes within a session", () => {
+    _resetMoveToProjectFilterForTesting();
+    // First open: type a query, close.
+    let submenu = openMoveToSubmenu();
+    let input = submenu.querySelector<HTMLInputElement>(".context-menu-input");
+    if (!input) throw new Error("expected filter input");
+    input.value = "proj-b";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    // Second open: the input should be pre-populated and the filter
+    // should already be applied on initial render (no flash of full list).
+    submenu = openMoveToSubmenu();
+    input = submenu.querySelector<HTMLInputElement>(".context-menu-input");
+    if (!input) throw new Error("expected filter input on reopen");
+    expect(input.value).toBe("proj-b");
+    const visibleProjectLabels = Array.from(
+      submenu.querySelectorAll<HTMLButtonElement>(".context-menu-item"),
+    )
+      .filter((b) => !b.classList.contains("context-menu-hidden") && b.dataset.matchText)
+      .map((b) => b.textContent?.replace(/\s*▸$/, "").trim() ?? "");
+    expect(visibleProjectLabels).toEqual(["proj-b"]);
+  });
+
+  it("ArrowDown from the filter input moves focus to the first visible project", () => {
+    _resetMoveToProjectFilterForTesting();
+    const submenu = openMoveToSubmenu();
+    const input = submenu.querySelector<HTMLInputElement>(".context-menu-input");
+    if (!input) throw new Error("expected filter input");
+
+    input.focus();
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }),
+    );
+    const focused = document.activeElement as HTMLElement | null;
+    expect(focused?.tagName).toBe("BUTTON");
+    expect(focused?.dataset.matchText).toBeDefined();
   });
 });
 


### PR DESCRIPTION
Closes #111.

## Summary

- **Backend:** `ProjectsFilter { recency_days, min_sessions, keyword }` applied after discovery in \`projects::list_known_projects\`. \`commands::list_known_projects\` fills hardcoded defaults (90 days, ≥ 2 sessions) before calling — fresh installs silently shed ancient one-off experiments without any preference plumbing. Default filter is a no-op for the CLI / future content-scan caller.
- **Refactor:** \`latest_cwd_in\` → \`scan_project_dir\` folds session count and newest-mtime into the existing readdir pass. No extra IO.
- **Frontend:** \`MenuItem.input\` variant on the context-menu primitive renders an inline \`<input type=\"search\">\` row. The Move-to submenu adds one above the project list when > 5 projects exist; live filters via \`data-match-text\` so User / User-Local rows above stay unaffected.
- **UX:** filter query is session-scoped (module state), survives menu closes within a session, resets on page reload. ArrowDown hops input → first visible project; ArrowUp on the first project hops back to the input.

## Explicit out of scope

All in #136:
- Content scan of transcript first-prompts.
- Settings-tunable cutoffs.
- Reuse in recent-projects dropdown / pickProject.

## Test plan

- [x] 8 new Rust tests in \`projects::tests\`: recency cutoff hides old projects, recency keeps future mtimes (clock skew), min_sessions hides single-session experiments, keyword matches name (case-insensitive), keyword matches path, empty keyword is no-op, all three dimensions compose, default filter preserves all projects.
- [x] 8 new TS tests in \`context menu (#8)\`: hidden at threshold (5), rendered above (8), correct position (between separator and projects), substring filter, path-substring match, case-insensitive, clearing restores all, persistence across menu closes, ArrowDown hop.
- [x] All Rust tests pass (206 / 9 skipped — the 9 are the known \`scope::tests\` Windows-environment failures unrelated to #111).
- [x] All TS tests pass (117/117).
- [x] \`cargo clippy --all-targets -- -D warnings\` clean.
- [x] \`biome check\` clean.
- [x] \`vite build\` clean.
- [ ] Manual: open Move-to submenu with > 5 projects, type a query, verify only matching projects show.
- [ ] Manual: close + reopen menu in same session, verify the query is still there.
- [ ] Manual: reload the app (Cmd+R), verify query resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)