### PR TITLE
feat(ui): move project path to its own header row (#40)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -96,12 +96,29 @@ body {
 
 .topbar {
   display: flex;
-  align-items: center;
-  gap: 16px;
+  flex-direction: column;
+  gap: 8px;
   padding: 12px 16px;
   background: var(--panel);
   border-bottom: 1px solid var(--border);
+}
+
+/* Row 1 of the header: title on the left, search + actions pushed to
+   the right. `flex-wrap` lets the search box and action buttons drop
+   to a new line on narrow windows instead of overflowing. */
+.topbar-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
   flex-wrap: wrap;
+}
+
+/* Row 2: the project-path dropdown on its own line (#40). Was
+   previously wedged between the title and the action buttons in the
+   single-row header, where it read as an afterthought. */
+.topbar-project {
+  display: flex;
+  min-width: 0;
 }
 
 /* Sandbox banner — only rendered when --home / --project (or env-var
@@ -132,6 +149,12 @@ body {
   position: relative;
   flex: 0 1 320px;
   min-width: 180px;
+  /* Push the search box and the action buttons after it to the right
+     edge of the header row — the title stays left. Previously the
+     project-path element carried `flex: 1` and did this spacing job;
+     now that it has moved to its own row (#40), the search box owns
+     the leftward shove. */
+  margin-left: auto;
 }
 
 .search-input {
@@ -221,7 +244,11 @@ body {
 }
 
 .project-dir {
-  flex: 1;
+  /* No `flex: 1` anymore — the project path has its own header row
+     (#40) instead of stretching to fill space in the title row.
+     `max-width: 100%` keeps the ellipsis working: a long path is
+     truncated at the header edge rather than overflowing it. */
+  max-width: 100%;
   color: var(--muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -746,15 +746,19 @@ function header(props: AppProps): HTMLElement {
   const bar = document.createElement("header");
   bar.className = "topbar";
 
+  // Row 1: title + search + actions. The project path used to be wedged
+  // in here between the title and the buttons, where it read as an
+  // afterthought (#40); it now gets its own row below.
+  const mainRow = document.createElement("div");
+  mainRow.className = "topbar-row";
+
   const title = document.createElement("div");
   title.className = "title";
   title.innerHTML =
     "<strong>ClaudeScope</strong><span class='subtitle'>Promote Claude Code settings between scopes</span>";
-  bar.appendChild(title);
+  mainRow.appendChild(title);
 
-  bar.appendChild(projectDirDropdown(props));
-
-  bar.appendChild(searchBox(props));
+  mainRow.appendChild(searchBox(props));
 
   const actions = document.createElement("div");
   actions.className = "actions";
@@ -789,7 +793,16 @@ function header(props: AppProps): HTMLElement {
   about.onclick = (e) => props.onOpenAbout(e.currentTarget as HTMLElement);
   actions.appendChild(about);
 
-  bar.appendChild(actions);
+  mainRow.appendChild(actions);
+  bar.appendChild(mainRow);
+
+  // Row 2: the project path dropdown, full-width on its own line so it
+  // reads as "you are here" rather than an afterthought (#40).
+  const projectRow = document.createElement("div");
+  projectRow.className = "topbar-project";
+  projectRow.appendChild(projectDirDropdown(props));
+  bar.appendChild(projectRow);
+
   return bar;
 }
 

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -1415,6 +1415,54 @@ describe("project-dir dropdown (#47)", () => {
   });
 });
 
+describe("header layout (#40)", () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
+
+  afterEach(() => {
+    clearBody();
+  });
+
+  it("puts the project path on its own row, below the title/search/actions row", () => {
+    renderApp(root, makeProps({ scopes: buildLoadedScopes({ project_dir: "/work/here" }) }));
+    const topbar = root.querySelector<HTMLElement>(".topbar");
+    if (!topbar) throw new Error("expected .topbar");
+
+    const mainRow = topbar.querySelector<HTMLElement>(".topbar-row");
+    const projectRow = topbar.querySelector<HTMLElement>(".topbar-project");
+    expect(mainRow).not.toBeNull();
+    expect(projectRow).not.toBeNull();
+
+    // Project row comes after the main row in document order — "under
+    // the title" per the issue.
+    const children = Array.from(topbar.children);
+    expect(children.indexOf(mainRow as HTMLElement)).toBeLessThan(
+      children.indexOf(projectRow as HTMLElement),
+    );
+  });
+
+  it("keeps title, search, and actions in the main row — not the project row", () => {
+    renderApp(root, makeProps({ scopes: buildLoadedScopes({ project_dir: "/work/here" }) }));
+    const mainRow = root.querySelector<HTMLElement>(".topbar-row");
+    if (!mainRow) throw new Error("expected .topbar-row");
+    expect(mainRow.querySelector(".title")).not.toBeNull();
+    expect(mainRow.querySelector(".search")).not.toBeNull();
+    expect(mainRow.querySelector(".actions")).not.toBeNull();
+    // The project dropdown is NOT in the main row anymore.
+    expect(mainRow.querySelector(".project-dir-trigger")).toBeNull();
+  });
+
+  it("nests the project dropdown inside the dedicated project row", () => {
+    renderApp(root, makeProps({ scopes: buildLoadedScopes({ project_dir: "/work/here" }) }));
+    const projectRow = root.querySelector<HTMLElement>(".topbar-project");
+    if (!projectRow) throw new Error("expected .topbar-project");
+    expect(projectRow.querySelector(".project-dir-trigger")).not.toBeNull();
+  });
+});
+
 describe("History dialog (#19 phase 2)", () => {
   beforeEach(() => {
     // Drain any leaked modal Escape listeners from earlier tests in the


### PR DESCRIPTION
Closes #40.

## Summary

- The project-path dropdown was wedged between the app title and the action buttons in the single-row header — it read as an afterthought.
- The header is now a two-row flex column: **row 1** title + search + actions, **row 2** the project path on its own full-width line.
- `.search` picks up `margin-left: auto` to keep itself + the action buttons pinned right — that spacing job previously belonged to the project path's `flex: 1`.
- `.project-dir` drops `flex: 1`, gains `max-width: 100%` so a long path still ellipsis-truncates at the header edge.

Went with "own row under the title" (vs. a separate banner) so the header chrome stays cohesive and there's no second banner competing with the sandbox-mode banner.

## Test plan

- [x] 3 new tests in `header layout (#40)`: project row sits after the main row, title/search/actions stay in the main row (project dropdown is not), project dropdown nests in the dedicated row.
- [x] All TS tests pass (120/120).
- [x] `tsc`, `biome`, `vite build` clean.
- [ ] Manual: confirm the path renders on its own line and ellipsis-truncates a long path at the header edge.
- [ ] Manual: narrow the window — search + actions wrap gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)