### PR TITLE
feat(audit): undo / redo / restore-to-point (v0.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Claude Code reads settings from JSON files at several scopes. Moving a permissio
 - **Rule search / filter** — press `/` anywhere to focus, case-insensitive substring, `m/n` match counts per group
 - **Auto-reload** — `notify`-based file watcher picks up external edits (hand-edited JSON, another editor, etc.) and refreshes the UI without losing state
 - **Heuristic shape lint** — subtle ⚠ badge on rules that don't match the shapes this UI knows (`Bash(...)`, `WebFetch(domain:...)`, `mcp__server__tool`, etc.). Best-effort only: Claude Code's full rule grammar isn't publicly documented, so flagged rules may still work — the popover names the specific heuristic that tripped and disclaims its scope.
+- **Audit log with undo / redo / restore** — every move / add / delete is appended to `~/.claude/claude-scope/audit.jsonl`. A **History** dialog lists them newest-first; `Ctrl`/`Cmd`+`Z` and `Ctrl`/`Cmd`+`Shift`+`Z` step backward and forward through the diff-confirm modal; and any History row can roll the affected files back to their state before that entry. `claude-scope-cli undo / redo / restore` mirror it from the shell.
 
 ### Write strategy
 
@@ -166,6 +167,8 @@ npm run tauri build
 | Key | Action |
 | --- | --- |
 | `/` | Focus the rule search input |
+| `Ctrl`/`Cmd`+`Z` | Undo the last change |
+| `Ctrl`/`Cmd`+`Shift`+`Z` | Redo |
 | `Esc` (in search) | Clear the filter |
 | `Esc` (in diff modal) | Cancel the move |
 | `Enter` (in diff modal) | Activate the focused button (Apply is the default focus) |

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -128,6 +128,32 @@ reviewer.
       one. The final remaining checkbox refuses to uncheck (the grid would
       otherwise render empty with no recovery from inside the dialog).
 
+## Audit log: History, undo, redo (non-sandbox runs only)
+
+Undo / redo and the History dialog read
+`~/.claude/claude-scope/audit.jsonl`, which ClaudeScope writes only in
+**non-sandbox** runs — a `--home` sandbox deliberately skips audit
+logging. Exercise this section only when you set up via the
+"Alternative (no sandbox)" path. In a sandbox run, just confirm the
+History dialog opens empty and **Undo** / **Redo** stay disabled, then
+skip the rest.
+
+- [ ] **History dialog.** Click **History** → the moves you made above
+      appear newest-first, each with a verb, timestamp, scope arrow, and
+      rule string.
+- [ ] **Undo.** After a move, the topbar **Undo** button is enabled and
+      its tooltip names the move. Click it → restore-confirm modal with a
+      per-file before/after → confirm → the rule returns to its original
+      scope, and History shows a new `Undo` entry.
+- [ ] **Redo.** `Redo` is now enabled. Click it → the move re-applies.
+- [ ] **`Ctrl`/`Cmd`+`Z`.** Behaves like the Undo button; ignored while a
+      text input or a modal has focus.
+- [ ] **Sequence break.** Undo, then make a fresh move. `Redo` greys out
+      and its tooltip explains a change was made after the last undo.
+- [ ] **Restore to before this.** In **History**, click a row's
+      **Restore** button → the confirm modal lists every affected file and
+      "Restoring to N ops back" → confirm → all spanned files revert.
+
 ## Side-effect verification
 
 After exercising the moves above, in the throwaway `.claude/` dir:

--- a/docs/src/architecture/audit-log.md
+++ b/docs/src/architecture/audit-log.md
@@ -9,17 +9,18 @@ lives at
 ## Record shape
 
 Each line is a self-contained JSON record. Phase 1 (#122) pinned the
-schema; phases 3-5 (#124 / #125 / #126) extend the consumer surface
-but don't break it.
+schema; phases 3-5 (#124 / #125 / #126) added one optional field —
+`restore` — for undo/redo/restore meta-entries, leaving every older
+record valid.
 
 ```jsonc
 {
   "id": "01HF...",                   // ULID (Crockford base32). Lex-sort = chrono-sort.
-  "kind": "move",                    // move | add | delete | change_kind | restore (Phase 3+)
+  "kind": "move",                    // move | add | delete | change_kind | restore
   "leaf_kind": "permission_rule",    // permission_rule | permission_list | top_level_key
-  "actor": "gui",                    // gui | cli | skill | restore
+  "actor": "gui",                    // gui | cli | skill — who triggered it
   "project_dir": "/work/proj",       // optional — user-scope-only ops omit
-  "from": {                          // optional — Add omits, top-level Restore omits
+  "from": {                          // optional — Add omits; every restore omits
     "scope": "project",
     "file_path": "/work/proj/.claude/settings.json",
     "top_level_key": "permissions",
@@ -41,9 +42,46 @@ but don't break it.
 
 The **affected top-level key** (`permissions` for permission ops, the
 moved key for top-level moves) is snapshotted before AND after on
-each side. That's the minimum needed for restore (Phase 4) to invert
-any logged op without re-reading history, while staying narrower than
-the whole file.
+each side. That's the minimum needed for an undo to invert any logged
+op without re-reading history, while staying narrower than the whole
+file.
+
+## Restore entries
+
+An undo, redo, or restore-to-point appends a record with
+`kind: "restore"`. Instead of `from` / `to` it carries a `restore`
+object — a restore can touch more than two files, so two fixed sides
+aren't enough:
+
+```jsonc
+"restore": {
+  "target_id": "01HF...",            // the entry undone / redone / restored-to
+  "direction": "undo",               // undo | redo | to_point
+  "files": [                         // one Side per file the restore rewrote
+    {
+      "scope": "project",
+      "file_path": "/work/proj/.claude/settings.json",
+      "top_level_key": "permissions",
+      "key_before": { "allow": ["Read(**)"] },
+      "key_after":  { "allow": ["Bash(ls)", "Read(**)"] }
+    }
+  ]
+}
+```
+
+Because each `files` entry snapshots before AND after, a restore is
+itself invertible — undoing an undo is just another restore. The
+undo/redo cursor is never stored: it's reconstructed on demand by
+replaying the `direction` of every `restore` entry over the ordered
+list of ops (`audit::undo_redo_state`). A write appended after an undo
+latches a *sequence break*, which withholds redo rather than
+discarding the forward stack.
+
+Snapshot-restore — writing a file back to a `key_before` the log
+already captured — is how undo stays faithful. Synthesizing a reverse
+move/add/delete instead would mishandle a move into a scope that
+already shared the rule (the reverse move would wrongly strip the
+destination's own copy); writing the captured snapshot back cannot.
 
 ## Why ULID, not timestamps
 
@@ -95,8 +133,9 @@ suffixes.
 
 The reader **only scans the active file**. Archives are archival —
 the History dialog and `claude-scope-cli history` don't surface
-them. Future restore-to-point work (#125) is similarly bounded to
-the active log; cross-archive restore would be a separate feature.
+them. Undo / redo and restore-to-point are bounded to the active log
+for the same reason; restoring across an archive boundary would be a
+separate feature.
 
 ## Sandbox
 

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -92,22 +92,48 @@ claude-scope-cli history [--since <DURATION>] [--limit <N>] [--kind <KIND>]... [
 - `--since` accepts `s` / `m` / `h` / `d` / `ms` suffixes. Bare
   numbers are rejected — the parser refuses to guess units.
 - `--limit` defaults to 20; `0` is unlimited.
-- `--kind` is repeatable: `move` / `add` / `delete` / `change-kind`.
-  OR semantics when multiple flags are passed.
+- `--kind` is repeatable: `move` / `add` / `delete` / `change-kind` /
+  `restore`. OR semantics when multiple flags are passed.
 - `--json` emits the same `AuditLogPage` wire shape the GUI's
   `list_audit_records` IPC returns.
 
 Human output: tab-separated `ULID  ts  verb  scope-arrow  rule`,
 newest-first.
 
-## Pending subcommands
+### `undo` / `redo`
 
-These wait on the audit-log work in
-[#19](https://github.com/bminier/claude-scope/issues/19) phases 3 and 4:
+Step backward / forward through the audit log one operation at a
+time, mirroring the GUI's Undo / Redo buttons.
 
-- `claude-scope-cli undo` — invert the most recent non-restore entry.
-- `claude-scope-cli redo` — re-apply the most recent undone op.
-- `claude-scope-cli restore <entry-id>` — multi-step rollback to
-  before a chosen log entry.
+```sh
+claude-scope-cli undo [--dry-run] [--yes] [--json]
+claude-scope-cli redo [--dry-run] [--yes] [--json]
+```
 
-Tracked in [#126](https://github.com/bminier/claude-scope/issues/126).
+`undo` reverts the most recent operation by writing the affected
+files back to the snapshots in the log; `redo` re-applies the most
+recently undone one. `redo` exits non-zero after a *sequence break*
+(a change made since the last undo) — the forward stack is then
+ambiguous, same rule as the greyed-out GUI button.
+
+Both print the planned restore and prompt `Apply? [y/N]` unless
+`--yes` is passed. `--dry-run` prints the plan and writes nothing.
+Each successful run appends a `restore` entry with `actor: cli`.
+
+### `restore`
+
+Restore every file affected by a logged entry — and the entries after
+it — back to its state before that entry.
+
+```sh
+claude-scope-cli restore <ENTRY-ID> [--dry-run] [--yes] [--json]
+```
+
+`<ENTRY-ID>` is a full ULID or any unique prefix; an ambiguous prefix
+prints the candidates and exits non-zero. Same `--dry-run` / `--yes`
+flags as `undo`.
+
+For `undo` / `redo` / `restore`, `--json` emits the `RestorePreview`
+for a `--dry-run` and the resulting `restore` entry (as an
+`AuditRecordView`, the same shape `history --json` produces) once
+applied.

--- a/docs/src/user-guide/undo-redo.md
+++ b/docs/src/user-guide/undo-redo.md
@@ -14,12 +14,13 @@ the single-slot `.bak` model can't:
 |---|---|---|
 | 1 | JSONL audit log at `~/.claude/claude-scope/audit.jsonl` | Shipped ([#19](https://github.com/bminier/claude-scope/issues/19) phase 1) |
 | 2 | Read-only **History** dialog (topbar button) listing entries newest-first | Shipped (#19 phase 2) |
-| 3 | `Ctrl+Z` / `Cmd+Z` undo via the diff-confirm modal | Tracked in [#124](https://github.com/bminier/claude-scope/issues/124) |
-| 4 | "Restore to before this" — multi-step rollback from a History row | Tracked in [#125](https://github.com/bminier/claude-scope/issues/125) |
-| 5 | CLI parity (`claude-scope-cli history` shipped; `undo / redo / restore` pending) | Tracked in [#126](https://github.com/bminier/claude-scope/issues/126) |
+| 3 | Undo / redo via the diff-confirm modal, `Ctrl`/`Cmd`+`Z` shortcuts | Shipped ([#124](https://github.com/bminier/claude-scope/issues/124)) |
+| 4 | "Restore to before this" — multi-step rollback from a History row | Shipped ([#125](https://github.com/bminier/claude-scope/issues/125)) |
+| 5 | CLI parity — `claude-scope-cli history / undo / redo / restore` | Shipped ([#126](https://github.com/bminier/claude-scope/issues/126)) |
 
-The on-disk schema is stable as of phase 1, so phases 3-5 don't break
-existing log entries. See
+The on-disk schema is stable as of phase 1; phases 3-5 added an
+optional `restore` field for undo/redo/restore meta-entries without
+breaking older log entries. See
 [Architecture → Audit log](../architecture/audit-log.md) for the
 record format.
 
@@ -37,9 +38,51 @@ Click **History** in the topbar. Entries appear newest-first, with:
 - The affected rule string, recovered by diffing the before/after
   snapshots in the record.
 
+A `restore` entry (the result of an undo / redo / restore-to-point)
+shows as `Undo` / `Redo` / `Restore to point`, names the entry it
+acted on, and lists the scopes it touched.
+
 The bottom of the list surfaces a count of any malformed entries the
 reader skipped — useful if `audit.jsonl` was hand-edited or partially
 written during a crash.
+
+## Undo and redo
+
+The topbar's **Undo** and **Redo** buttons — and `Ctrl`/`Cmd`+`Z` /
+`Ctrl`/`Cmd`+`Shift`+`Z` — step backward and forward through the log
+one operation at a time. Each button's tooltip names exactly what the
+next step would do (e.g. *"Undo: Move permission rule Bash(ls)
+(3 min ago)"*).
+
+Every undo and redo previews before it writes: it routes through the
+same diff-confirm modal a move does, so you see the per-file
+before/after and confirm. Confirming appends a new `restore` entry —
+the log is append-only, so an undo is itself recorded and can be
+redone.
+
+**Sequence break.** If you make a fresh change after an undo, the
+redo stack is ambiguous — Redo greys out and its tooltip explains
+why, rather than silently discarding the forward history.
+
+**External edits.** Undo writes a file back to the snapshot the log
+captured. If the file was hand-edited since (so its current contents
+differ from what the log expected), the confirm modal shows a warning
+band — you can still proceed, but you'll be overwriting that edit.
+
+## Restore to before an entry
+
+Single-step undo walks back one operation at a time. To jump back
+multiple operations at once — *"take me back to before I imported
+that preset"* — open **History** and click the **Restore** button on
+the target row.
+
+That reverts the targeted entry **and every entry logged after it**:
+ClaudeScope walks the log forward, computes the net per-file delta,
+and writes each affected file back to its state before the target.
+The confirm modal lists every file that will change and how many
+operations are being reverted (*"Restoring to 4 ops back"*). A
+restore-to-point is itself a single log entry, so it can be undone
+like any other operation.
 
 ## Rotation
 
@@ -51,20 +94,26 @@ rotation**.
 
 ## CLI
 
-`claude-scope-cli history` mirrors the GUI dialog from a shell:
+`claude-scope-cli` mirrors the History dialog and the undo / redo /
+restore actions from a shell:
 
 ```sh
 # Last 20 entries, newest first.
 claude-scope-cli history
 
-# Just deletes in the last hour, JSON.
-claude-scope-cli history --since 1h --kind delete --json
+# Undo the most recent change — previews, then prompts.
+claude-scope-cli undo
 
-# Everything in the active log (no cap).
-claude-scope-cli history --limit 0
+# Redo it, no prompt.
+claude-scope-cli redo --yes
+
+# Preview a restore-to-point without writing.
+claude-scope-cli restore 01JABC --dry-run
 ```
 
-`--json` emits the same `AuditLogPage` wire format the GUI uses, so a
-[Claude Code skill (#13)](https://github.com/bminier/claude-scope/issues/13)
-can consume CLI output and IPC payloads through one shared type once
-that lands.
+The entry id passed to `restore` is a full ULID or any unique prefix.
+`--dry-run` prints the planned restore and writes nothing; `--yes`
+skips the confirm prompt; `--json` emits machine-readable output. CLI
+restores log a `restore` entry with `actor: cli`, so a GUI session
+sees them in its History. See [CLI reference](../reference/cli.md)
+for the full subcommand surface.

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -72,19 +72,21 @@ pub struct Record {
     /// readable as `(verb, leaf_kind)` instead of a fused
     /// `move_permission_rule` string.
     pub leaf_kind: LeafKind,
-    /// Who triggered the op. Always `Gui` in Phase 1; `Cli` and `Restore`
-    /// land with the CLI (#13) and undo (#19 Phase 3) work respectively.
+    /// Who triggered the op — `Gui`, `Cli`, or `Skill`. Orthogonal to
+    /// [`Kind`]: an undo run from the CLI is `actor: Cli`, `kind: Restore`.
     pub actor: Actor,
     /// Project root that scoped the operation. `None` for user-scope-only
     /// ops (e.g. moving a rule into User scope from another user-level
     /// scope — there is no project context).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project_dir: Option<PathBuf>,
-    /// Source side. `None` for [`Kind::Add`] (no source) and for top-level
-    /// `Restore` entries that target multiple files (Phase 3+).
+    /// Source side. `None` for [`Kind::Add`] (no source) and for every
+    /// [`Kind::Restore`] entry — restores carry their per-file snapshots in
+    /// [`Record::restore`] instead, since they can touch more than two files.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub from: Option<Side>,
-    /// Destination side. `None` for [`Kind::Delete`].
+    /// Destination side. `None` for [`Kind::Delete`] and every
+    /// [`Kind::Restore`] entry (see [`Record::from`]).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub to: Option<Side>,
     /// JSON path of the affected leaf, e.g.
@@ -98,6 +100,13 @@ pub struct Record {
     /// rather than "move".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub to_kind: Option<PermissionKind>,
+    /// Set on — and only on — [`Kind::Restore`] entries. Carries the
+    /// undo / redo / restore-to-point payload (#19 Phases 3-4): the id of
+    /// the entry acted on, the direction, and a per-file before/after
+    /// snapshot. Absent on the wire for every non-restore record, so the
+    /// field is backwards-compatible with Phase 1-2 logs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restore: Option<RestoreMeta>,
     /// Build that wrote this record. See [`current_version`].
     pub claude_scope_version: String,
 }
@@ -122,6 +131,12 @@ pub enum Kind {
     Add,
     /// `apply_delete_leaf`. Removed a leaf from the `from` side.
     Delete,
+    /// A meta-entry recording an undo, redo, or restore-to-point (#19
+    /// Phases 3-4). Its payload lives in [`Record::restore`]; `from` / `to`
+    /// stay `None`. The undo/redo state machine reads [`RestoreMeta`] to
+    /// reconstruct the cursor — `Undo` / `Redo` restores are cursor moves,
+    /// a `ToPoint` restore is itself an ordinary undoable op.
+    Restore,
 }
 
 /// What shape of leaf the record's `path` targets. Mirrors `MoveLeafKind`
@@ -136,16 +151,16 @@ pub enum LeafKind {
     PermissionRule,
 }
 
-/// Who triggered the op. Phase 1 only emits `Gui`; the other variants
-/// reserve wire-format slots so a CLI (#13) or undo (#19 Phase 3) write
-/// doesn't force a breaking change.
+/// Who triggered the op. Phase 1 only emits `Gui`; `Cli` reserves a
+/// wire-format slot for the CLI (#13) and `Skill` for a future Claude Code
+/// skill. Orthogonal to [`Kind`]: an undo is `kind: Restore` whatever the
+/// actor, so there is deliberately no `Restore` actor variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Actor {
     Gui,
     Cli,
     Skill,
-    Restore,
 }
 
 /// One side of a write — the source or destination, depending on the kind.
@@ -170,6 +185,42 @@ pub struct Side {
     /// Same shape as `key_before`, captured after the op completed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key_after: Option<serde_json::Value>,
+}
+
+/// Direction of a [`Kind::Restore`] entry. The undo/redo state machine
+/// (`commands::audit_undo`) treats `Undo` / `Redo` as cursor moves and
+/// `ToPoint` as an ordinary op that can itself be undone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RestoreDirection {
+    /// Inverted the most recent applied op (#19 Phase 3).
+    Undo,
+    /// Re-applied the most recently undone op (#19 Phase 3).
+    Redo,
+    /// Rolled the affected files back to their state before a chosen
+    /// history entry (#19 Phase 4).
+    ToPoint,
+}
+
+/// Payload of a [`Kind::Restore`] record. Carries the id of the entry the
+/// restore acted on, the direction, and a per-file before/after snapshot of
+/// everything the restore wrote — the snapshot is what lets a *later* undo
+/// invert the restore itself.
+///
+/// `Undo` / `Redo` restores touch one or two files (a single inverted op);
+/// a `ToPoint` restore may touch up to four. Either way the affected sides
+/// live in `files` rather than in [`Record::from`] / [`Record::to`], which
+/// only have room for two.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RestoreMeta {
+    /// The entry this restore inverted (`Undo`), re-applied (`Redo`), or
+    /// rolled back to (`ToPoint`).
+    pub target_id: Ulid,
+    /// Which of undo / redo / restore-to-point produced this entry.
+    pub direction: RestoreDirection,
+    /// One [`Side`] per file the restore rewrote, each with its
+    /// `key_before` / `key_after` snapshot.
+    pub files: Vec<Side>,
 }
 
 impl Record {
@@ -202,6 +253,35 @@ impl Record {
             to,
             path,
             to_kind,
+            restore: None,
+            claude_scope_version: current_version(),
+        }
+    }
+
+    /// Construct a [`Kind::Restore`] record for an undo / redo /
+    /// restore-to-point op (#19 Phases 3-4). `from` / `to` / `to_kind` are
+    /// always `None` on a restore record — the affected sides live in
+    /// `restore.files` — so this constructor takes only the fields a
+    /// restore actually carries. `leaf_kind` echoes the leaf kind of the
+    /// entry being restored so the History view can label the row.
+    pub fn new_restore(
+        leaf_kind: LeafKind,
+        actor: Actor,
+        project_dir: Option<PathBuf>,
+        path: Vec<PathSeg>,
+        restore: RestoreMeta,
+    ) -> Self {
+        Self {
+            id: Ulid::new(),
+            kind: Kind::Restore,
+            leaf_kind,
+            actor,
+            project_dir,
+            from: None,
+            to: None,
+            path,
+            to_kind: None,
+            restore: Some(restore),
             claude_scope_version: current_version(),
         }
     }
@@ -301,6 +381,127 @@ pub fn read_all(home: Option<&Path>) -> io::Result<(Vec<Record>, usize)> {
         }
     }
     Ok((records, skipped))
+}
+
+/// Undo / redo availability, reconstructed from the append-only log by
+/// [`undo_redo_state`]. The log is the single source of truth — there is no
+/// mutable cursor on disk — so every undo / redo decision is a fresh replay
+/// of the records.
+#[derive(Debug, Clone, Default)]
+pub struct UndoRedoState {
+    /// The op the next undo would invert. `None` when nothing is undoable
+    /// (empty log, or every op already undone).
+    pub undoable: Option<Record>,
+    /// The op the next redo would re-apply. `None` when there is nothing to
+    /// redo, or when `sequence_break` has stranded the redo stack.
+    pub redoable: Option<Record>,
+    /// True when a fresh write landed while undone ops were pending,
+    /// stranding the redo stack (#124). Redo is disabled and `redoable` is
+    /// `None`; the flag lets the UI explain *why* in a tooltip rather than
+    /// silently discarding the forward stack.
+    pub sequence_break: bool,
+}
+
+/// How a log entry participates in the undo/redo replay.
+enum ReplayRole {
+    /// An ordinary undoable op: a `move` / `add` / `delete` / `change_kind`,
+    /// or a restore-to-point (which is itself undoable).
+    Op,
+    /// An `undo` restore — a cursor move back, carrying the target op id.
+    Undo(Ulid),
+    /// A `redo` restore — a cursor move forward, carrying the target op id.
+    Redo(Ulid),
+    /// A malformed restore record (no payload). Left out of the replay
+    /// entirely rather than allowed to perturb the cursor.
+    Ignore,
+}
+
+fn replay_role(rec: &Record) -> ReplayRole {
+    match rec.kind {
+        Kind::Move | Kind::ChangeKind | Kind::Add | Kind::Delete => ReplayRole::Op,
+        Kind::Restore => match rec.restore.as_ref() {
+            Some(meta) => match meta.direction {
+                // Restore-to-point is a forward write, not a cursor move:
+                // it can be undone like any other op.
+                RestoreDirection::ToPoint => ReplayRole::Op,
+                RestoreDirection::Undo => ReplayRole::Undo(meta.target_id),
+                RestoreDirection::Redo => ReplayRole::Redo(meta.target_id),
+            },
+            None => ReplayRole::Ignore,
+        },
+    }
+}
+
+/// Reconstruct undo/redo state from `records` (the full log in file order,
+/// as returned by [`read_all`]).
+///
+/// The replay walks the log once, building the list of undoable ops, a
+/// per-op "currently undone" flag, and a redo stack. `undo` / `redo`
+/// restores move the cursor; every other entry — including a
+/// restore-to-point — is an op. A write appended while the redo stack is
+/// non-empty latches `sequence_break`: the redo stack is now ambiguous, so
+/// redo is withheld (but the entries are kept, not discarded — see #124).
+pub fn undo_redo_state(records: &[Record]) -> UndoRedoState {
+    // `ops` holds indices into `records`; `undone` is parallel to it;
+    // `redo_stack` holds indices into `ops` (top = next op to redo).
+    let mut ops: Vec<usize> = Vec::new();
+    let mut undone: Vec<bool> = Vec::new();
+    let mut redo_stack: Vec<usize> = Vec::new();
+    let mut sequence_break = false;
+
+    for (i, rec) in records.iter().enumerate() {
+        match replay_role(rec) {
+            ReplayRole::Op => {
+                if !redo_stack.is_empty() {
+                    sequence_break = true;
+                }
+                ops.push(i);
+                undone.push(false);
+            }
+            ReplayRole::Undo(target) => {
+                if let Some(op_ix) = ops.iter().position(|&r| records[r].id == target) {
+                    // Guard against a double-undo of the same op via two
+                    // log entries (a corrupt log, or two racing writers).
+                    if !undone[op_ix] {
+                        undone[op_ix] = true;
+                        redo_stack.push(op_ix);
+                    }
+                }
+                // A target that isn't in `ops` is dangling (rotated out of
+                // the active log, or never written) — skip it silently.
+            }
+            ReplayRole::Redo(target) => {
+                if let Some(op_ix) = ops.iter().position(|&r| records[r].id == target) {
+                    if undone[op_ix] {
+                        undone[op_ix] = false;
+                        redo_stack.retain(|&x| x != op_ix);
+                    }
+                }
+            }
+            ReplayRole::Ignore => {}
+        }
+    }
+
+    let undoable = ops
+        .iter()
+        .zip(&undone)
+        .rev()
+        .find(|(_, &u)| !u)
+        .map(|(&r, _)| records[r].clone());
+    // `sequence_break` only matters while the redo stack still holds
+    // something; if a (CLI-forced) redo emptied it, drop the stale flag.
+    let sequence_break = sequence_break && !redo_stack.is_empty();
+    let redoable = if sequence_break {
+        None
+    } else {
+        redo_stack.last().map(|&op_ix| records[ops[op_ix]].clone())
+    };
+
+    UndoRedoState {
+        undoable,
+        redoable,
+        sequence_break,
+    }
 }
 
 /// Outcome of a [`rotate_if_needed`] call. `Skipped` covers four cases that
@@ -557,6 +758,225 @@ mod tests {
         assert_eq!(json, r#""change_kind""#);
         let json = serde_json::to_string(&Kind::Move).unwrap();
         assert_eq!(json, r#""move""#);
+        let json = serde_json::to_string(&Kind::Restore).unwrap();
+        assert_eq!(json, r#""restore""#);
+    }
+
+    fn sample_restore_record(direction: RestoreDirection) -> Record {
+        Record::new_restore(
+            LeafKind::PermissionRule,
+            Actor::Gui,
+            Some(PathBuf::from("/work/proj")),
+            vec![
+                PathSeg::Key("permissions".into()),
+                PathSeg::Key("allow".into()),
+                PathSeg::Index(0),
+            ],
+            RestoreMeta {
+                target_id: Ulid::new(),
+                direction,
+                files: vec![
+                    make_side(Scope::Project, "/work/proj/.claude/settings.json"),
+                    make_side(Scope::User, "/home/me/.claude/settings.json"),
+                ],
+            },
+        )
+    }
+
+    #[test]
+    fn restore_record_round_trips_through_json() {
+        for dir in [
+            RestoreDirection::Undo,
+            RestoreDirection::Redo,
+            RestoreDirection::ToPoint,
+        ] {
+            let rec = sample_restore_record(dir);
+            let s = serde_json::to_string(&rec).unwrap();
+            let parsed: Record = serde_json::from_str(&s).unwrap();
+            assert_eq!(parsed, rec);
+        }
+    }
+
+    #[test]
+    fn restore_direction_serializes_to_snake_case() {
+        // The wire format is a contract — pin the casing so a future
+        // `rename_all` typo can't silently rewrite every restore entry.
+        assert_eq!(
+            serde_json::to_string(&RestoreDirection::Undo).unwrap(),
+            r#""undo""#
+        );
+        assert_eq!(
+            serde_json::to_string(&RestoreDirection::Redo).unwrap(),
+            r#""redo""#
+        );
+        assert_eq!(
+            serde_json::to_string(&RestoreDirection::ToPoint).unwrap(),
+            r#""to_point""#
+        );
+    }
+
+    #[test]
+    fn non_restore_record_omits_restore_field_on_the_wire() {
+        // `restore` is skip-on-`None`, so a Phase 1-2 reader (which doesn't
+        // know the field) sees the exact same bytes it always did.
+        let json = serde_json::to_value(sample_record()).unwrap();
+        assert!(json.get("restore").is_none());
+        // A restore record carries it.
+        let json = serde_json::to_value(sample_restore_record(RestoreDirection::Undo)).unwrap();
+        assert!(json.get("restore").is_some());
+        assert!(json.get("from").is_none(), "restore records leave from/to unset");
+        assert!(json.get("to").is_none());
+    }
+
+    #[test]
+    fn restore_record_survives_append_then_read() {
+        let tmp = TempDir::new().unwrap();
+        let rec = sample_restore_record(RestoreDirection::ToPoint);
+        append(&rec, Some(tmp.path())).unwrap();
+        let (records, skipped) = read_all(Some(tmp.path())).unwrap();
+        assert_eq!(skipped, 0);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0], rec);
+    }
+
+    // -- undo/redo state machine (#124) ------------------------------------
+
+    /// A bare op record — `undo_redo_state` reads file order, not the ULID
+    /// clock, so no inter-record sleeps are needed.
+    fn op_record() -> Record {
+        Record::new(
+            Kind::Move,
+            LeafKind::PermissionRule,
+            Actor::Gui,
+            None,
+            None,
+            None,
+            vec![],
+            None,
+        )
+    }
+
+    fn restore_of(target: &Record, direction: RestoreDirection) -> Record {
+        Record::new_restore(
+            target.leaf_kind,
+            Actor::Gui,
+            None,
+            vec![],
+            RestoreMeta {
+                target_id: target.id,
+                direction,
+                files: vec![],
+            },
+        )
+    }
+
+    #[test]
+    fn undo_redo_state_empty_log_has_nothing() {
+        let state = undo_redo_state(&[]);
+        assert!(state.undoable.is_none());
+        assert!(state.redoable.is_none());
+        assert!(!state.sequence_break);
+    }
+
+    #[test]
+    fn undo_redo_state_fresh_writes_undo_targets_the_last() {
+        let (a, b, c) = (op_record(), op_record(), op_record());
+        let log = [a, b, c.clone()];
+        let state = undo_redo_state(&log);
+        assert_eq!(state.undoable.unwrap().id, c.id);
+        assert!(state.redoable.is_none(), "nothing undone yet");
+        assert!(!state.sequence_break);
+    }
+
+    #[test]
+    fn undo_redo_state_after_one_undo() {
+        let (a, b, c) = (op_record(), op_record(), op_record());
+        let log = [a.clone(), b.clone(), c.clone(), restore_of(&c, RestoreDirection::Undo)];
+        let state = undo_redo_state(&log);
+        // C is undone, so the next undo targets B and the next redo C.
+        assert_eq!(state.undoable.unwrap().id, b.id);
+        assert_eq!(state.redoable.unwrap().id, c.id);
+        assert!(!state.sequence_break);
+    }
+
+    #[test]
+    fn undo_redo_state_stacked_undos_walk_backward() {
+        let (a, b, c) = (op_record(), op_record(), op_record());
+        let log = [
+            a.clone(),
+            b.clone(),
+            c.clone(),
+            restore_of(&c, RestoreDirection::Undo),
+            restore_of(&b, RestoreDirection::Undo),
+        ];
+        let state = undo_redo_state(&log);
+        assert_eq!(state.undoable.unwrap().id, a.id);
+        // Redo re-applies the most recently undone op first: B.
+        assert_eq!(state.redoable.unwrap().id, b.id);
+    }
+
+    #[test]
+    fn undo_redo_state_redo_clears_the_forward_step() {
+        let (a, b, c) = (op_record(), op_record(), op_record());
+        let log = [
+            a,
+            b,
+            c.clone(),
+            restore_of(&c, RestoreDirection::Undo),
+            restore_of(&c, RestoreDirection::Redo),
+        ];
+        let state = undo_redo_state(&log);
+        // C is applied again; redo stack is empty.
+        assert_eq!(state.undoable.unwrap().id, c.id);
+        assert!(state.redoable.is_none());
+    }
+
+    #[test]
+    fn undo_redo_state_write_after_undo_is_a_sequence_break() {
+        let (a, b, c, d) = (op_record(), op_record(), op_record(), op_record());
+        let log = [
+            a,
+            b,
+            c.clone(),
+            restore_of(&c, RestoreDirection::Undo),
+            d.clone(),
+        ];
+        let state = undo_redo_state(&log);
+        // The new write D is undoable; redo is withheld and the break flag
+        // is set so the UI can explain it.
+        assert_eq!(state.undoable.unwrap().id, d.id);
+        assert!(state.redoable.is_none());
+        assert!(state.sequence_break);
+    }
+
+    #[test]
+    fn undo_redo_state_restore_to_point_counts_as_an_op() {
+        let a = op_record();
+        let to_point = restore_of(&a, RestoreDirection::ToPoint);
+        // A restore-to-point is itself undoable.
+        let state = undo_redo_state(&[a.clone(), to_point.clone()]);
+        assert_eq!(state.undoable.unwrap().id, to_point.id);
+        // And undoing it walks back to A.
+        let undo_tp = restore_of(&to_point, RestoreDirection::Undo);
+        let state = undo_redo_state(&[a.clone(), to_point.clone(), undo_tp]);
+        assert_eq!(state.undoable.unwrap().id, a.id);
+        assert_eq!(state.redoable.unwrap().id, to_point.id);
+    }
+
+    #[test]
+    fn undo_redo_state_ignores_dangling_and_malformed_restores() {
+        let a = op_record();
+        // An undo targeting an op that isn't in the log (rotated out) must
+        // not perturb the cursor.
+        let orphan = op_record();
+        let dangling = restore_of(&orphan, RestoreDirection::Undo);
+        let state = undo_redo_state(&[a.clone(), dangling]);
+        assert_eq!(state.undoable.unwrap().id, a.id);
+        // A restore record with no payload is ignored entirely.
+        let mut malformed = restore_of(&a, RestoreDirection::Undo);
+        malformed.restore = None;
+        let state = undo_redo_state(&[a.clone(), malformed]);
+        assert_eq!(state.undoable.unwrap().id, a.id, "malformed restore left A applied");
     }
 
     #[test]

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -824,7 +824,10 @@ mod tests {
         // A restore record carries it.
         let json = serde_json::to_value(sample_restore_record(RestoreDirection::Undo)).unwrap();
         assert!(json.get("restore").is_some());
-        assert!(json.get("from").is_none(), "restore records leave from/to unset");
+        assert!(
+            json.get("from").is_none(),
+            "restore records leave from/to unset"
+        );
         assert!(json.get("to").is_none());
     }
 
@@ -891,7 +894,12 @@ mod tests {
     #[test]
     fn undo_redo_state_after_one_undo() {
         let (a, b, c) = (op_record(), op_record(), op_record());
-        let log = [a.clone(), b.clone(), c.clone(), restore_of(&c, RestoreDirection::Undo)];
+        let log = [
+            a.clone(),
+            b.clone(),
+            c.clone(),
+            restore_of(&c, RestoreDirection::Undo),
+        ];
         let state = undo_redo_state(&log);
         // C is undone, so the next undo targets B and the next redo C.
         assert_eq!(state.undoable.unwrap().id, b.id);
@@ -976,7 +984,11 @@ mod tests {
         let mut malformed = restore_of(&a, RestoreDirection::Undo);
         malformed.restore = None;
         let state = undo_redo_state(&[a.clone(), malformed]);
-        assert_eq!(state.undoable.unwrap().id, a.id, "malformed restore left A applied");
+        assert_eq!(
+            state.undoable.unwrap().id,
+            a.id,
+            "malformed restore left A applied"
+        );
     }
 
     #[test]

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -818,6 +818,17 @@ fn format_verb(rec: &AuditRecord) -> String {
             None => "change-kind".to_string(),
         };
     }
+    if matches!(rec.kind, audit::Kind::Restore) {
+        // A restore meta-entry: name the direction. The payload is in
+        // `rec.restore`; a record missing it is malformed but shouldn't
+        // panic the history printer.
+        return match rec.restore.as_ref().map(|r| r.direction) {
+            Some(audit::RestoreDirection::Undo) => "undo".to_string(),
+            Some(audit::RestoreDirection::Redo) => "redo".to_string(),
+            Some(audit::RestoreDirection::ToPoint) => "restore-to-point".to_string(),
+            None => "restore".to_string(),
+        };
+    }
     let noun = match rec.leaf_kind {
         audit::LeafKind::PermissionRule => "rule",
         audit::LeafKind::PermissionList => "list",
@@ -827,7 +838,7 @@ fn format_verb(rec: &AuditRecord) -> String {
         audit::Kind::Move => "move",
         audit::Kind::Add => "add",
         audit::Kind::Delete => "delete",
-        audit::Kind::ChangeKind => unreachable!("handled above"),
+        audit::Kind::ChangeKind | audit::Kind::Restore => unreachable!("handled above"),
     };
     format!("{verb}-{noun}")
 }

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -11,12 +11,14 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand, ValueEnum};
 use serde::Serialize;
 use serde_json::{json, Value};
+use ulid::Ulid;
 
 use claude_scope_lib::app_info::AppInfo;
 use claude_scope_lib::audit::{self, Record as AuditRecord};
 use claude_scope_lib::commands::{
-    apply_move_leaf_impl, build_loaded, diff_move_leaf_impl, AuditLogPage, AuditRecordView,
-    MoveLeafPreview, MoveLeafRequest,
+    apply_move_leaf_impl, apply_restore_plan, build_loaded, build_restore_plan, diff_move_leaf_impl,
+    plan_restore_to, preview_restore_plan, restore_record, AuditLogPage, AuditRecordView,
+    MoveLeafPreview, MoveLeafRequest, RestorePlan, RestorePreview,
 };
 use claude_scope_lib::io_atomic::{self, BackupTracker};
 use claude_scope_lib::model::{PathSeg, PermissionKind};
@@ -129,6 +131,55 @@ enum Command {
         json: bool,
     },
 
+    /// Undo the most recent change in the audit log (#19 phase 5). Reverts
+    /// a move / add / delete / change-kind / restore-to-point by writing
+    /// the affected files back to their pre-op snapshots, then logs a
+    /// `restore` entry (actor `cli`) so a GUI session sees it in History.
+    Undo {
+        /// Print the planned restore as a diff and exit without writing.
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip the interactive `Apply? [y/N]` prompt.
+        #[arg(long)]
+        yes: bool,
+        /// Emit machine-readable JSON: the `RestorePreview` for `--dry-run`,
+        /// otherwise the `restore` entry as an `AuditRecordView`.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Redo the most recently undone change (#19 phase 5). Refuses with a
+    /// non-zero exit when a change was made after the last undo (the
+    /// forward stack is then ambiguous — same rule as the GUI).
+    Redo {
+        /// Print the planned restore as a diff and exit without writing.
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip the interactive `Apply? [y/N]` prompt.
+        #[arg(long)]
+        yes: bool,
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Restore every file affected by an audit entry — and the entries
+    /// after it — back to its state before that entry (#19 phase 5).
+    Restore {
+        /// Audit entry id: a full ULID or any unique prefix (ULIDs
+        /// lex-sort, so prefix matching is cheap and unambiguous).
+        id: String,
+        /// Print the planned restore as a diff and exit without writing.
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip the interactive `Apply? [y/N]` prompt.
+        #[arg(long)]
+        yes: bool,
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Move a permission rule between scopes. Writes are atomic and create a
     /// `.bak` of the original on the first write of the session.
     Move {
@@ -206,8 +257,7 @@ impl KindArg {
 /// CLI counterpart to `audit::Kind`. Mirrored locally rather than re-using
 /// the lib enum so the wire format of `--kind <value>` stays a CLI concern
 /// (kebab-case as clap renders ValueEnum), independent of the JSON
-/// snake_case the audit module already pins. The `restore` value lands in
-/// Phase 3+ alongside `audit::Kind::Restore`.
+/// snake_case the audit module already pins.
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 enum AuditKindArg {
     Move,
@@ -215,6 +265,7 @@ enum AuditKindArg {
     Delete,
     #[value(name = "change-kind")]
     ChangeKind,
+    Restore,
 }
 
 impl AuditKindArg {
@@ -225,6 +276,7 @@ impl AuditKindArg {
                 | (AuditKindArg::Add, audit::Kind::Add)
                 | (AuditKindArg::Delete, audit::Kind::Delete)
                 | (AuditKindArg::ChangeKind, audit::Kind::ChangeKind)
+                | (AuditKindArg::Restore, audit::Kind::Restore)
         )
     }
 }
@@ -272,6 +324,34 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             *json,
         );
     }
+    // `undo` / `redo` / `restore` operate purely off the audit log and the
+    // absolute file paths recorded in it — like `history`, they need no
+    // project root, so dispatch before `resolve_paths`.
+    if let Command::Undo {
+        dry_run,
+        yes,
+        json,
+    } = cli.command
+    {
+        return cmd_undo(cli.home_dir.as_deref(), dry_run, yes, json);
+    }
+    if let Command::Redo {
+        dry_run,
+        yes,
+        json,
+    } = cli.command
+    {
+        return cmd_redo(cli.home_dir.as_deref(), dry_run, yes, json);
+    }
+    if let Command::Restore {
+        id,
+        dry_run,
+        yes,
+        json,
+    } = &cli.command
+    {
+        return cmd_restore(cli.home_dir.as_deref(), id, *dry_run, *yes, *json);
+    }
 
     let paths = resolve_paths(cli.project_dir.as_deref(), cli.home_dir.as_deref())?;
     match cli.command {
@@ -285,6 +365,9 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::ListProjects { .. } => unreachable!("handled above"),
         Command::Version { .. } => unreachable!("handled above"),
         Command::History { .. } => unreachable!("handled above"),
+        Command::Undo { .. } => unreachable!("handled above"),
+        Command::Redo { .. } => unreachable!("handled above"),
+        Command::Restore { .. } => unreachable!("handled above"),
         Command::Move {
             rule,
             kind,
@@ -642,6 +725,208 @@ fn cmd_move(
         );
     }
     Ok(())
+}
+
+/// Read the audit log for a CLI restore command, surfacing the
+/// unreadable-line count the same way `history` does. `--home-dir`
+/// redirects it identically.
+fn read_audit_log(
+    home: Option<&std::path::Path>,
+) -> Result<Vec<AuditRecord>, Box<dyn std::error::Error>> {
+    let (records, skipped) = audit::read_all(home)?;
+    if skipped > 0 {
+        eprintln!(
+            "note: {skipped} unreadable {} skipped in the log",
+            if skipped == 1 { "entry" } else { "entries" }
+        );
+    }
+    Ok(records)
+}
+
+fn restore_action_label(direction: audit::RestoreDirection) -> &'static str {
+    match direction {
+        audit::RestoreDirection::Undo => "undo",
+        audit::RestoreDirection::Redo => "redo",
+        audit::RestoreDirection::ToPoint => "restore-to-point",
+    }
+}
+
+/// Print a restore preview as a human-readable block: the entry being
+/// acted on, the spanned-entry count for a restore-to-point, and one line
+/// per affected file with its write status.
+fn print_restore_preview(preview: &RestorePreview) {
+    println!(
+        "{}: {} {}",
+        restore_action_label(preview.direction),
+        format_verb(&preview.target.record),
+        extract_rule_summary(&preview.target.record).unwrap_or_default(),
+    );
+    if matches!(preview.direction, audit::RestoreDirection::ToPoint) {
+        println!(
+            "  reverting {} logged entr{}",
+            preview.ops_spanned,
+            if preview.ops_spanned == 1 { "y" } else { "ies" }
+        );
+    }
+    for side in &preview.sides {
+        let status = if !side.will_write {
+            "no change"
+        } else if side.state_mismatch {
+            "write — overwrites an external edit"
+        } else {
+            "write"
+        };
+        println!(
+            "  {:<11} {}  [{status}]",
+            side.scope.label(),
+            side.file_path
+        );
+    }
+}
+
+/// Prompt `Apply? [y/N]` on the terminal; returns true only for an explicit
+/// yes. Any other input (including EOF on a closed stdin) is a "no".
+fn confirm_prompt() -> Result<bool, Box<dyn std::error::Error>> {
+    use std::io::Write;
+    print!("Apply? [y/N] ");
+    std::io::stdout().flush()?;
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    let answer = line.trim().to_lowercase();
+    Ok(answer == "y" || answer == "yes")
+}
+
+/// Find the single audit entry whose id begins with `prefix` — a full ULID
+/// or any unique prefix. ULIDs render as uppercase Crockford base32 and
+/// lex-sort, so prefix matching is a cheap `starts_with`.
+fn resolve_entry_id(
+    records: &[AuditRecord],
+    prefix: &str,
+) -> Result<Ulid, Box<dyn std::error::Error>> {
+    let needle = prefix.trim().to_uppercase();
+    if needle.is_empty() {
+        return Err("empty audit entry id".into());
+    }
+    let matches: Vec<&AuditRecord> = records
+        .iter()
+        .filter(|r| r.id.to_string().starts_with(&needle))
+        .collect();
+    match matches.as_slice() {
+        [] => Err(format!("no audit entry matches id `{prefix}`").into()),
+        [one] => Ok(one.id),
+        many => {
+            let ids: Vec<String> = many.iter().map(|r| r.id.to_string()).collect();
+            Err(format!(
+                "id `{prefix}` is ambiguous — matches {} entries:\n  {}",
+                many.len(),
+                ids.join("\n  ")
+            )
+            .into())
+        }
+    }
+}
+
+/// Shared driver for `undo` / `redo` / `restore`: preview, optionally
+/// confirm, apply, and log the resulting `restore` entry (actor `cli`).
+fn run_cli_restore(
+    home: Option<&std::path::Path>,
+    plan: &RestorePlan,
+    target: &AuditRecord,
+    dry_run: bool,
+    yes: bool,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let preview = preview_restore_plan(plan, target)?;
+    if dry_run {
+        if json {
+            println!("{}", serde_json::to_string_pretty(&preview)?);
+        } else {
+            print_restore_preview(&preview);
+            println!("(dry run — nothing written)");
+        }
+        return Ok(());
+    }
+    if !yes {
+        if !json {
+            print_restore_preview(&preview);
+        }
+        if !confirm_prompt()? {
+            // A declined confirm is not an error — mirror the GUI's Cancel.
+            if !json {
+                println!("aborted");
+            }
+            return Ok(());
+        }
+    }
+    let files = apply_restore_plan(plan, Some(&BackupTracker::new()), &WatchState::default())?;
+    let record = restore_record(plan, audit::Actor::Cli, files);
+    // Fail-open: the restore already took effect on disk, so a log-append
+    // failure is a warning, not a command failure (matches the GUI).
+    if let Err(err) = audit::append(&record, home) {
+        eprintln!("warning: restore applied but audit-log append failed: {err}");
+    }
+    if json {
+        let view = AuditRecordView {
+            ts_ms: record.id.timestamp_ms(),
+            record,
+        };
+        println!("{}", serde_json::to_string_pretty(&view)?);
+    } else {
+        println!(
+            "{} applied — {} file(s) restored",
+            restore_action_label(preview.direction),
+            preview.sides.len()
+        );
+    }
+    Ok(())
+}
+
+fn cmd_undo(
+    home: Option<&std::path::Path>,
+    dry_run: bool,
+    yes: bool,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let records = read_audit_log(home)?;
+    let target = audit::undo_redo_state(&records)
+        .undoable
+        .ok_or("nothing to undo")?;
+    let plan = build_restore_plan(&target, audit::RestoreDirection::Undo)?;
+    run_cli_restore(home, &plan, &target, dry_run, yes, json)
+}
+
+fn cmd_redo(
+    home: Option<&std::path::Path>,
+    dry_run: bool,
+    yes: bool,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let records = read_audit_log(home)?;
+    let state = audit::undo_redo_state(&records);
+    if state.sequence_break {
+        return Err("redo is unavailable: a change was made after the last undo".into());
+    }
+    let target = state.redoable.ok_or("nothing to redo")?;
+    let plan = build_restore_plan(&target, audit::RestoreDirection::Redo)?;
+    run_cli_restore(home, &plan, &target, dry_run, yes, json)
+}
+
+fn cmd_restore(
+    home: Option<&std::path::Path>,
+    id: &str,
+    dry_run: bool,
+    yes: bool,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let records = read_audit_log(home)?;
+    let target_id = resolve_entry_id(&records, id)?;
+    let plan = plan_restore_to(&records, target_id)?;
+    let target = records
+        .iter()
+        .find(|r| r.id == target_id)
+        .expect("plan_restore_to verified the id is in the log")
+        .clone();
+    run_cli_restore(home, &plan, &target, dry_run, yes, json)
 }
 
 fn rules_at(doc: &claude_scope_lib::model::SettingsDoc, kind_key: &str) -> Vec<String> {
@@ -1078,7 +1363,9 @@ mod tests {
 
     // -- history subcommand (#126) -----------------------------------------
 
-    use claude_scope_lib::audit::{self as audit_lib, Actor, Kind, LeafKind, Record, Side};
+    use claude_scope_lib::audit::{
+        self as audit_lib, Actor, Kind, LeafKind, Record, RestoreDirection, RestoreMeta, Side,
+    };
 
     fn make_audit_record(kind: Kind, leaf_kind: LeafKind) -> Record {
         Record::new(kind, leaf_kind, Actor::Gui, None, None, None, vec![], None)
@@ -1358,5 +1645,156 @@ mod tests {
         // Cross-check that the GUI's IPC would produce the same shape —
         // both consume `audit::Record` via `AuditRecordView`, so this
         // assertion is a forward-compat anchor.
+    }
+
+    // -- undo / redo / restore subcommands (#126) --------------------------
+
+    /// Write a settings file, creating parent dirs.
+    fn write_file(path: &Path, body: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    /// A logged move of `Bash(ls)` from `project` to `user`, with
+    /// before/after snapshots — the shape `cmd_undo` reads.
+    fn logged_move(project: &Path, user: &Path) -> Record {
+        let mut rec = make_audit_record(Kind::Move, LeafKind::PermissionRule);
+        rec.path = vec![
+            PathSeg::Key("permissions".into()),
+            PathSeg::Key("allow".into()),
+            PathSeg::Index(0),
+        ];
+        rec.from = Some(Side {
+            scope: Scope::Project,
+            file_path: project.to_path_buf(),
+            top_level_key: "permissions".into(),
+            key_before: Some(json!({"allow": ["Bash(ls)"]})),
+            key_after: Some(json!({"allow": []})),
+        });
+        rec.to = Some(Side {
+            scope: Scope::User,
+            file_path: user.to_path_buf(),
+            top_level_key: "permissions".into(),
+            key_before: Some(json!({"allow": []})),
+            key_after: Some(json!({"allow": ["Bash(ls)"]})),
+        });
+        rec
+    }
+
+    #[test]
+    fn cli_undo_reverts_the_last_logged_move_and_logs_a_cli_restore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let project = tmp.path().join("proj/.claude/settings.json");
+        let user = home.join(".claude/settings.json");
+        // Files at their post-move state: the rule has moved Project → User.
+        write_file(&project, r#"{"permissions":{"allow":[]}}"#);
+        write_file(&user, r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
+        audit_lib::append(&logged_move(&project, &user), Some(home)).unwrap();
+
+        // `--yes` skips the prompt; not a dry run.
+        cmd_undo(Some(home), false, true, false).unwrap();
+
+        // Both files are back to the pre-move state.
+        assert_eq!(
+            rules_at(&io_atomic::load(&project).unwrap().unwrap(), "allow"),
+            vec!["Bash(ls)".to_string()],
+        );
+        assert!(rules_at(&io_atomic::load(&user).unwrap().unwrap(), "allow").is_empty());
+        // A `restore` entry was logged with actor `cli`, so a GUI session
+        // sees the CLI-driven undo in its History.
+        let (records, _) = audit_lib::read_all(Some(home)).unwrap();
+        assert_eq!(records.len(), 2);
+        assert!(matches!(records[1].kind, Kind::Restore));
+        assert!(matches!(records[1].actor, Actor::Cli));
+    }
+
+    #[test]
+    fn cli_undo_dry_run_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let project = tmp.path().join("proj/.claude/settings.json");
+        let user = home.join(".claude/settings.json");
+        write_file(&project, r#"{"permissions":{"allow":[]}}"#);
+        write_file(&user, r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
+        audit_lib::append(&logged_move(&project, &user), Some(home)).unwrap();
+
+        cmd_undo(Some(home), true, true, false).unwrap();
+
+        // Files untouched, no restore entry appended.
+        assert!(rules_at(&io_atomic::load(&project).unwrap().unwrap(), "allow").is_empty());
+        let (records, _) = audit_lib::read_all(Some(home)).unwrap();
+        assert_eq!(records.len(), 1, "a dry run must not append a restore entry");
+    }
+
+    #[test]
+    fn cli_undo_errors_on_an_empty_log() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = cmd_undo(Some(tmp.path()), false, true, false).unwrap_err();
+        assert!(err.to_string().contains("nothing to undo"));
+    }
+
+    #[test]
+    fn cli_redo_errors_after_a_sequence_break() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let project = tmp.path().join("proj/.claude/settings.json");
+        let user = home.join(".claude/settings.json");
+        write_file(&project, r#"{"permissions":{"allow":[]}}"#);
+        write_file(&user, r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
+        // move → undo(move) → another move = a sequence break.
+        let m1 = logged_move(&project, &user);
+        let undo = Record::new_restore(
+            LeafKind::PermissionRule,
+            Actor::Gui,
+            None,
+            vec![],
+            RestoreMeta {
+                target_id: m1.id,
+                direction: RestoreDirection::Undo,
+                files: vec![],
+            },
+        );
+        let m2 = logged_move(&project, &user);
+        for rec in [&m1, &undo, &m2] {
+            audit_lib::append(rec, Some(home)).unwrap();
+        }
+        let err = cmd_redo(Some(home), false, true, false).unwrap_err();
+        assert!(err.to_string().contains("redo is unavailable"));
+    }
+
+    #[test]
+    fn resolve_entry_id_matches_a_full_ulid_and_rejects_misses() {
+        let a = make_audit_record(Kind::Move, LeafKind::PermissionRule);
+        let records = vec![a.clone()];
+        // Full id resolves, case-insensitively.
+        assert_eq!(resolve_entry_id(&records, &a.id.to_string()).unwrap(), a.id);
+        assert_eq!(
+            resolve_entry_id(&records, &a.id.to_string().to_lowercase()).unwrap(),
+            a.id,
+        );
+        // No 2026-era ULID begins with `Z`, so this matches nothing.
+        assert!(resolve_entry_id(&records, "ZZZZZZ")
+            .unwrap_err()
+            .to_string()
+            .contains("no audit entry"));
+        // Whitespace-only is rejected up front.
+        assert!(resolve_entry_id(&records, "  ")
+            .unwrap_err()
+            .to_string()
+            .contains("empty"));
+    }
+
+    #[test]
+    fn resolve_entry_id_reports_an_ambiguous_prefix() {
+        let a = make_audit_record(Kind::Move, LeafKind::PermissionRule);
+        let b = make_audit_record(Kind::Add, LeafKind::PermissionRule);
+        let records = vec![a.clone(), b];
+        // The leading base32 char encodes the top 5 bits of the 48-bit ms
+        // timestamp — identical for any two ULIDs minted this century — so a
+        // one-char prefix matches both records.
+        let one_char = &a.id.to_string()[..1];
+        let err = resolve_entry_id(&records, one_char).unwrap_err();
+        assert!(err.to_string().contains("ambiguous"));
     }
 }

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -16,9 +16,9 @@ use ulid::Ulid;
 use claude_scope_lib::app_info::AppInfo;
 use claude_scope_lib::audit::{self, Record as AuditRecord};
 use claude_scope_lib::commands::{
-    apply_move_leaf_impl, apply_restore_plan, build_loaded, build_restore_plan, diff_move_leaf_impl,
-    plan_restore_to, preview_restore_plan, restore_record, AuditLogPage, AuditRecordView,
-    MoveLeafPreview, MoveLeafRequest, RestorePlan, RestorePreview,
+    apply_move_leaf_impl, apply_restore_plan, build_loaded, build_restore_plan,
+    diff_move_leaf_impl, plan_restore_to, preview_restore_plan, restore_record, AuditLogPage,
+    AuditRecordView, MoveLeafPreview, MoveLeafRequest, RestorePlan, RestorePreview,
 };
 use claude_scope_lib::io_atomic::{self, BackupTracker};
 use claude_scope_lib::model::{PathSeg, PermissionKind};
@@ -327,20 +327,10 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     // `undo` / `redo` / `restore` operate purely off the audit log and the
     // absolute file paths recorded in it — like `history`, they need no
     // project root, so dispatch before `resolve_paths`.
-    if let Command::Undo {
-        dry_run,
-        yes,
-        json,
-    } = cli.command
-    {
+    if let Command::Undo { dry_run, yes, json } = cli.command {
         return cmd_undo(cli.home_dir.as_deref(), dry_run, yes, json);
     }
-    if let Command::Redo {
-        dry_run,
-        yes,
-        json,
-    } = cli.command
-    {
+    if let Command::Redo { dry_run, yes, json } = cli.command {
         return cmd_redo(cli.home_dir.as_deref(), dry_run, yes, json);
     }
     if let Command::Restore {
@@ -1724,7 +1714,11 @@ mod tests {
         // Files untouched, no restore entry appended.
         assert!(rules_at(&io_atomic::load(&project).unwrap().unwrap(), "allow").is_empty());
         let (records, _) = audit_lib::read_all(Some(home)).unwrap();
-        assert_eq!(records.len(), 1, "a dry run must not append a restore entry");
+        assert_eq!(
+            records.len(),
+            1,
+            "a dry run must not append a restore entry"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3226,7 +3226,7 @@ mod tests {
             side_at(Scope::Project, &project, perms(&["A"]), perms(&[])),
             side_at(Scope::User, &user, perms(&[]), perms(&["A"])),
         );
-        let plan = plan_restore_to(&[m1.clone()], m1.id).unwrap();
+        let plan = plan_restore_to(std::slice::from_ref(&m1), m1.id).unwrap();
         assert_eq!(plan.ops_spanned, 1);
         apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
         assert_eq!(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,10 +5,11 @@ use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
+use ulid::Ulid;
 
 use crate::app_info::AppInfo;
 use crate::audit;
-use crate::io_atomic::{self, BackupTracker};
+use crate::io_atomic::{self, BackupTracker, FileStamp};
 use crate::model::{
     describe_path, key_policy, validate_movable_path, KeyPolicy, MovablePath, PathSeg,
     PermissionKind, PermissionRules, SettingsDoc,
@@ -602,14 +603,155 @@ pub struct AuditLogPage {
 #[tauri::command]
 pub fn list_audit_records(overrides: State<'_, RuntimeOverrides>) -> Result<AuditLogPage, String> {
     let (records, skipped) = audit::read_all(overrides.home()).map_err(|e| e.to_string())?;
-    let records = records
-        .into_iter()
-        .map(|r| {
-            let ts_ms = r.id.timestamp_ms();
-            AuditRecordView { record: r, ts_ms }
-        })
-        .collect();
+    let records = records.into_iter().map(record_view).collect();
     Ok(AuditLogPage { records, skipped })
+}
+
+/// Undo / redo availability for the topbar buttons (#19 Phase 3). `undo` /
+/// `redo` carry the audit entry the next click would act on so the frontend
+/// can render a descriptive tooltip with the same helpers the History view
+/// uses; `sequence_break` lets it explain a disabled redo button.
+#[derive(Debug, Serialize)]
+pub struct UndoRedoStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub undo: Option<AuditRecordView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redo: Option<AuditRecordView>,
+    pub sequence_break: bool,
+}
+
+/// Report what the next undo / redo would target (#19 Phase 3). Routes
+/// through `RuntimeOverrides::home` like the other audit commands, so a
+/// sandbox session reads its scratch log. A sandbox log is always empty
+/// (writes there are never logged), so undo / redo are simply unavailable
+/// in scratch mode — `.bak` remains the recovery path there.
+#[tauri::command]
+pub fn audit_undo_status(
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<UndoRedoStatus, String> {
+    let (records, _) = audit::read_all(overrides.home()).map_err(|e| e.to_string())?;
+    let state = audit::undo_redo_state(&records);
+    Ok(UndoRedoStatus {
+        undo: state.undoable.map(record_view),
+        redo: state.redoable.map(record_view),
+        sequence_break: state.sequence_break,
+    })
+}
+
+/// Resolve the audit entry the next undo or redo would act on, or a
+/// descriptive error. Shared by the preview and apply commands so they
+/// can't drift on which entry is the target.
+fn undo_redo_target(
+    direction: audit::RestoreDirection,
+    overrides: &RuntimeOverrides,
+) -> Result<audit::Record, Box<dyn std::error::Error>> {
+    let (records, _) = audit::read_all(overrides.home())?;
+    let state = audit::undo_redo_state(&records);
+    let target = match direction {
+        audit::RestoreDirection::Undo => state.undoable,
+        audit::RestoreDirection::Redo => {
+            if state.sequence_break {
+                return Err(
+                    "redo is unavailable: a change was made after the last undo".into(),
+                );
+            }
+            state.redoable
+        }
+        audit::RestoreDirection::ToPoint => {
+            return Err("restore-to-point is not an undo/redo target".into())
+        }
+    };
+    target.ok_or_else(|| -> Box<dyn std::error::Error> {
+        match direction {
+            audit::RestoreDirection::Undo => "nothing to undo".into(),
+            _ => "nothing to redo".into(),
+        }
+    })
+}
+
+fn undo_redo_preview(
+    direction: audit::RestoreDirection,
+    overrides: &RuntimeOverrides,
+) -> Result<RestorePreview, Box<dyn std::error::Error>> {
+    let target = undo_redo_target(direction, overrides)?;
+    let plan = build_restore_plan(&target, direction)?;
+    preview_restore_plan(&plan, &target, 1)
+}
+
+/// Diff preview for the next undo (#19 Phase 3) — same modal the move /
+/// delete / add flows confirm through.
+#[tauri::command]
+pub fn audit_undo_preview(
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<RestorePreview, String> {
+    undo_redo_preview(audit::RestoreDirection::Undo, &overrides).map_err(|e| e.to_string())
+}
+
+/// Diff preview for the next redo (#19 Phase 3).
+#[tauri::command]
+pub fn audit_redo_preview(
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<RestorePreview, String> {
+    undo_redo_preview(audit::RestoreDirection::Redo, &overrides).map_err(|e| e.to_string())
+}
+
+fn apply_undo_redo(
+    expected_id: &str,
+    direction: audit::RestoreDirection,
+    app: &AppHandle,
+    watch: &WatchState,
+    overrides: &RuntimeOverrides,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let target = undo_redo_target(direction, overrides)?;
+    // The frontend confirmed a preview built from a specific entry; if the
+    // log moved under us (a concurrent CLI write, an external rotation)
+    // refuse rather than silently acting on a different op.
+    if target.id.to_string() != expected_id {
+        return Err(
+            "the audit log changed since the preview — reload and try again".into(),
+        );
+    }
+    let plan = build_restore_plan(&target, direction)?;
+    let files = apply_restore_plan(&plan, backups_for_session(), watch)?;
+    emit_audit(app, overrides, restore_record(&plan, audit::Actor::Gui, files));
+    Ok(())
+}
+
+/// Apply the next undo (#19 Phase 3). `expected_id` is the id of the entry
+/// the confirmed preview was built from — see [`apply_undo_redo`].
+#[tauri::command]
+pub fn audit_apply_undo(
+    expected_id: String,
+    app: AppHandle,
+    watch: State<'_, WatchState>,
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<(), String> {
+    apply_undo_redo(
+        &expected_id,
+        audit::RestoreDirection::Undo,
+        &app,
+        &watch,
+        &overrides,
+    )
+    .map_err(|e| e.to_string())
+}
+
+/// Apply the next redo (#19 Phase 3).
+#[tauri::command]
+pub fn audit_apply_redo(
+    expected_id: String,
+    app: AppHandle,
+    watch: State<'_, WatchState>,
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<(), String> {
+    apply_undo_redo(
+        &expected_id,
+        audit::RestoreDirection::Redo,
+        &app,
+        &watch,
+        &overrides,
+    )
+    .map_err(|e| e.to_string())
 }
 
 /// Build- and runtime-time diagnostic block for the About dialog (#21).
@@ -1505,6 +1647,317 @@ fn require_path(paths: &ScopePaths, scope: Scope) -> Result<&Path, Box<dyn std::
     })
 }
 
+// -- audit-log restore: undo / redo / restore-to-point (#19 Phases 3-4) -----
+
+/// One file a restore will rewrite. Internal to the restore planner; the
+/// wire-facing shape is [`RestoreSidePreview`].
+#[derive(Debug, Clone)]
+struct RestoreTarget {
+    scope: Scope,
+    file_path: PathBuf,
+    /// Top-level key the restore replaces (or removes).
+    top_level_key: String,
+    /// Value the key should hold after the restore. `None` removes the key.
+    target_value: Option<serde_json::Value>,
+    /// Value the audit log expected the key to currently hold. Drives the
+    /// state-mismatch warning only — it never gates the write.
+    expected_current: Option<serde_json::Value>,
+}
+
+/// A computed, ready-to-apply restoration. Built from an audit record by
+/// [`build_restore_plan`] (undo / redo) or [`plan_restore_to`] (Phase 4),
+/// then handed to [`apply_restore_plan`] / [`preview_restore_plan`].
+#[derive(Debug, Clone)]
+pub struct RestorePlan {
+    direction: audit::RestoreDirection,
+    /// The entry being undone / redone / restored-to.
+    target_id: Ulid,
+    /// Leaf kind + path + project, copied onto the resulting restore record
+    /// so the History view can label the row.
+    leaf_kind: audit::LeafKind,
+    project_dir: Option<PathBuf>,
+    path: Vec<PathSeg>,
+    targets: Vec<RestoreTarget>,
+}
+
+/// Per-file diff in a [`RestorePreview`]. `key_current` / `key_target`
+/// follow `MoveLeafSide`'s skip-on-`None` convention: an absent field means
+/// "key unset", distinct from a literal JSON `null`.
+#[derive(Debug, Serialize)]
+pub struct RestoreSidePreview {
+    pub scope: Scope,
+    pub file_path: String,
+    pub file_path_exists: bool,
+    pub top_level_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_current: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_target: Option<serde_json::Value>,
+    pub will_write: bool,
+    /// True when the on-disk value differs from what the audit log
+    /// expected — i.e. the file was hand-edited since the logged op. The
+    /// restore still proceeds on confirm; the flag drives a warning band.
+    pub state_mismatch: bool,
+}
+
+/// Diff preview for an undo / redo / restore-to-point, rendered by the
+/// frontend's restore-confirm modal.
+#[derive(Debug, Serialize)]
+pub struct RestorePreview {
+    pub direction: audit::RestoreDirection,
+    /// The audit entry being acted on, so the modal can describe it with
+    /// the same helpers the History view uses.
+    pub target: AuditRecordView,
+    pub sides: Vec<RestoreSidePreview>,
+    /// How many ops this restore reverts: 1 for undo / redo, the count of
+    /// spanned entries for a restore-to-point (#125).
+    pub ops_spanned: usize,
+}
+
+/// The sides an audit record snapshots: `from` + `to` for an ordinary op,
+/// or `restore.files` for a `Kind::Restore` entry (which leaves `from` /
+/// `to` unset because a restore can touch more than two files).
+fn record_sides(rec: &audit::Record) -> Vec<&audit::Side> {
+    if let Some(meta) = &rec.restore {
+        return meta.files.iter().collect();
+    }
+    let mut sides = Vec::new();
+    if let Some(f) = &rec.from {
+        sides.push(f);
+    }
+    if let Some(t) = &rec.to {
+        sides.push(t);
+    }
+    sides
+}
+
+/// Wrap an [`audit::Record`] as an [`AuditRecordView`] (record + decoded
+/// timestamp) — the shape both the History view and the restore modal read.
+fn record_view(rec: audit::Record) -> AuditRecordView {
+    let ts_ms = rec.id.timestamp_ms();
+    AuditRecordView { record: rec, ts_ms }
+}
+
+/// Build the plan to undo or redo a single op record.
+///
+/// Undo writes each affected file's key back to the snapshot `key_before`
+/// and expects the file to currently hold `key_after`; redo is the mirror.
+/// Snapshot-restore — rather than synthesizing a reverse move/add/delete
+/// request — is faithful by construction (it writes back a value the log
+/// already captured) and handles rules, lists, and top-level keys
+/// uniformly.
+pub fn build_restore_plan(
+    rec: &audit::Record,
+    direction: audit::RestoreDirection,
+) -> Result<RestorePlan, Box<dyn std::error::Error>> {
+    let undo = match direction {
+        audit::RestoreDirection::Undo => true,
+        audit::RestoreDirection::Redo => false,
+        audit::RestoreDirection::ToPoint => {
+            return Err("restore-to-point plans are built by plan_restore_to".into())
+        }
+    };
+    let sides = record_sides(rec);
+    if sides.is_empty() {
+        return Err("audit entry carries no file snapshots — cannot restore".into());
+    }
+    let mut targets: Vec<RestoreTarget> = Vec::new();
+    for s in sides {
+        // A same-scope change-kind records its one file as both `from` and
+        // `to`; collapse the duplicate so the file is written once.
+        if targets.iter().any(|t| t.file_path == s.file_path) {
+            continue;
+        }
+        let (target_value, expected_current) = if undo {
+            (s.key_before.clone(), s.key_after.clone())
+        } else {
+            (s.key_after.clone(), s.key_before.clone())
+        };
+        targets.push(RestoreTarget {
+            scope: s.scope,
+            file_path: s.file_path.clone(),
+            top_level_key: s.top_level_key.clone(),
+            target_value,
+            expected_current,
+        });
+    }
+    Ok(RestorePlan {
+        direction,
+        target_id: rec.id,
+        leaf_kind: rec.leaf_kind,
+        project_dir: rec.project_dir.clone(),
+        path: rec.path.clone(),
+        targets,
+    })
+}
+
+/// Read a single top-level key's current on-disk value, plus whether the
+/// file exists. Errors (unreadable / malformed file) propagate — a restore
+/// preview that can't read its target should surface that, not paper over
+/// it.
+fn current_top_level(
+    file_path: &Path,
+    key: &str,
+) -> Result<(Option<serde_json::Value>, bool), Box<dyn std::error::Error>> {
+    let loaded = io_atomic::load(file_path)?;
+    let exists = loaded.is_some();
+    let current = loaded.and_then(|d| d.get_top_level(key).cloned());
+    Ok((current, exists))
+}
+
+/// Compute the diff preview for a restore plan without writing anything.
+/// `target` is the audit entry being acted on; `ops_spanned` is 1 for an
+/// undo / redo and the spanned-entry count for a restore-to-point.
+pub fn preview_restore_plan(
+    plan: &RestorePlan,
+    target: &audit::Record,
+    ops_spanned: usize,
+) -> Result<RestorePreview, Box<dyn std::error::Error>> {
+    let mut sides = Vec::with_capacity(plan.targets.len());
+    for t in &plan.targets {
+        let (current, exists) = current_top_level(&t.file_path, &t.top_level_key)?;
+        sides.push(RestoreSidePreview {
+            scope: t.scope,
+            file_path: t.file_path.display().to_string(),
+            file_path_exists: exists,
+            top_level_key: t.top_level_key.clone(),
+            will_write: current != t.target_value,
+            state_mismatch: current != t.expected_current,
+            key_current: current,
+            key_target: t.target_value.clone(),
+        });
+    }
+    Ok(RestorePreview {
+        direction: plan.direction,
+        target: record_view(target.clone()),
+        sides,
+        ops_spanned,
+    })
+}
+
+/// Apply a restore plan: rewrite every target file's affected top-level key
+/// atomically, rolling the whole batch back if any single write fails.
+///
+/// Returns one [`audit::Side`] per target — `key_before` is the value the
+/// file actually held at write time, `key_after` the value written — so the
+/// caller can record a `Kind::Restore` entry that a later undo can itself
+/// invert.
+pub fn apply_restore_plan(
+    plan: &RestorePlan,
+    backups: Option<&BackupTracker>,
+    watch: &WatchState,
+) -> Result<Vec<audit::Side>, Box<dyn std::error::Error>> {
+    /// Everything needed to write one file and, if a later file fails, to
+    /// roll this one back. `pending[i]` lines up with `plan.targets[i]`.
+    struct Pending {
+        path: PathBuf,
+        existed: bool,
+        original: SettingsDoc,
+        stamp: FileStamp,
+        new_doc: SettingsDoc,
+        before_key: Option<serde_json::Value>,
+    }
+
+    // Phase 1 — load + compute. No disk writes here, so a failure to read
+    // any target aborts the whole batch with nothing on disk touched.
+    let mut pending: Vec<Pending> = Vec::with_capacity(plan.targets.len());
+    for t in &plan.targets {
+        let (loaded, stamp) = io_atomic::load_with_stamp(&t.file_path)?;
+        let existed = loaded.is_some();
+        let original = loaded.unwrap_or_else(SettingsDoc::empty);
+        let before_key = original.get_top_level(&t.top_level_key).cloned();
+        let mut new_doc = original.clone();
+        match &t.target_value {
+            Some(v) => new_doc.set_top_level(&t.top_level_key, v.clone()),
+            None => {
+                new_doc.remove_at_path(&[PathSeg::Key(t.top_level_key.clone())]);
+            }
+        }
+        pending.push(Pending {
+            path: t.file_path.clone(),
+            existed,
+            original,
+            stamp,
+            new_doc,
+            before_key,
+        });
+    }
+
+    // Phase 2 — write. Track which files landed so a mid-batch failure
+    // rolls them back: same posture as `apply_move_leaf_impl`'s two-file
+    // dance, generalized to N files.
+    let mut written: Vec<usize> = Vec::new();
+    for (i, p) in pending.iter().enumerate() {
+        // Skip a file already at the target value — no point churning the
+        // watcher or dropping a `.bak` for a zero-delta write.
+        if p.before_key == plan.targets[i].target_value {
+            continue;
+        }
+        if let Err(write_err) = io_atomic::save(&p.path, &p.new_doc, backups, Some(&p.stamp)) {
+            for &w in written.iter().rev() {
+                let pw = &pending[w];
+                let rollback: Result<(), Box<dyn std::error::Error>> = if pw.existed {
+                    io_atomic::save(&pw.path, &pw.original, backups, None).map_err(Into::into)
+                } else {
+                    std::fs::remove_file(&pw.path).map_err(Into::into)
+                };
+                if let Err(rollback_err) = rollback {
+                    return Err(format!(
+                        "restore write of {} failed: {write_err}; \
+                         rolling back {} also failed: {rollback_err}",
+                        p.path.display(),
+                        pw.path.display()
+                    )
+                    .into());
+                }
+                watch.note_self_write(&pw.path);
+            }
+            return Err(format!(
+                "restore write of {} failed — all earlier files rolled back: {write_err}",
+                p.path.display()
+            )
+            .into());
+        }
+        watch.note_self_write(&p.path);
+        written.push(i);
+    }
+
+    // The audit Sides describe what each file held before vs after. Built
+    // for every target, including no-op ones, so undoing this restore has
+    // a complete picture.
+    Ok(plan
+        .targets
+        .iter()
+        .zip(&pending)
+        .map(|(t, p)| audit::Side {
+            scope: t.scope,
+            file_path: t.file_path.clone(),
+            top_level_key: t.top_level_key.clone(),
+            key_before: p.before_key.clone(),
+            key_after: t.target_value.clone(),
+        })
+        .collect())
+}
+
+/// Build the `Kind::Restore` audit record describing a completed restore.
+pub fn restore_record(
+    plan: &RestorePlan,
+    actor: audit::Actor,
+    files: Vec<audit::Side>,
+) -> audit::Record {
+    audit::Record::new_restore(
+        plan.leaf_kind,
+        actor,
+        plan.project_dir.clone(),
+        plan.path.clone(),
+        audit::RestoreMeta {
+            target_id: plan.target_id,
+            direction: plan.direction,
+            files,
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2383,6 +2836,204 @@ mod tests {
         assert_eq!(
             preview.from.key_after.unwrap(),
             serde_json::json!({"allow": [], "deny": ["Bash(rm)"]})
+        );
+    }
+
+    // -- audit restore: undo / redo (#124) ---------------------------------
+
+    fn perms(allow: &[&str]) -> serde_json::Value {
+        serde_json::json!({ "allow": allow })
+    }
+
+    fn side_at(
+        scope: Scope,
+        path: &Path,
+        before: serde_json::Value,
+        after: serde_json::Value,
+    ) -> audit::Side {
+        audit::Side {
+            scope,
+            file_path: path.to_path_buf(),
+            top_level_key: "permissions".to_string(),
+            key_before: Some(before),
+            key_after: Some(after),
+        }
+    }
+
+    fn move_record(from: audit::Side, to: audit::Side) -> audit::Record {
+        audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            Some(from),
+            Some(to),
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        )
+    }
+
+    #[test]
+    fn undo_of_a_move_restores_both_files_to_pre_move_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        let project = paths.project.clone().unwrap();
+        let user = paths.user.clone().unwrap();
+        // Disk reflects the post-move state: rule A moved Project → User.
+        write(&project, r#"{"permissions":{"allow":["B"]}}"#);
+        write(&user, r#"{"permissions":{"allow":["C","A"]}}"#);
+        let rec = move_record(
+            side_at(Scope::Project, &project, perms(&["A", "B"]), perms(&["B"])),
+            side_at(Scope::User, &user, perms(&["C"]), perms(&["C", "A"])),
+        );
+        let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
+        let sides = apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
+        assert_eq!(
+            io_atomic::load(&project).unwrap().unwrap().permissions().allow,
+            vec!["A".to_string(), "B".to_string()],
+        );
+        assert_eq!(
+            io_atomic::load(&user).unwrap().unwrap().permissions().allow,
+            vec!["C".to_string()],
+        );
+        // The returned sides snapshot what the undo wrote, so the resulting
+        // restore record is itself invertible.
+        assert_eq!(sides.len(), 2);
+        assert_eq!(sides[0].key_before, Some(perms(&["B"])));
+        assert_eq!(sides[0].key_after, Some(perms(&["A", "B"])));
+    }
+
+    #[test]
+    fn redo_of_a_move_re_applies_the_post_move_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        let project = paths.project.clone().unwrap();
+        let user = paths.user.clone().unwrap();
+        // Disk reflects the pre-move state (an undo has already happened).
+        write(&project, r#"{"permissions":{"allow":["A","B"]}}"#);
+        write(&user, r#"{"permissions":{"allow":["C"]}}"#);
+        let rec = move_record(
+            side_at(Scope::Project, &project, perms(&["A", "B"]), perms(&["B"])),
+            side_at(Scope::User, &user, perms(&["C"]), perms(&["C", "A"])),
+        );
+        let plan = build_restore_plan(&rec, audit::RestoreDirection::Redo).unwrap();
+        apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
+        assert_eq!(
+            io_atomic::load(&project).unwrap().unwrap().permissions().allow,
+            vec!["B".to_string()],
+        );
+        assert_eq!(
+            io_atomic::load(&user).unwrap().unwrap().permissions().allow,
+            vec!["C".to_string(), "A".to_string()],
+        );
+    }
+
+    #[test]
+    fn undo_then_redo_round_trips_to_the_original_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        let project = paths.project.clone().unwrap();
+        let user = paths.user.clone().unwrap();
+        write(&project, r#"{"permissions":{"allow":["B"]}}"#);
+        write(&user, r#"{"permissions":{"allow":["C","A"]}}"#);
+        let rec = move_record(
+            side_at(Scope::Project, &project, perms(&["A", "B"]), perms(&["B"])),
+            side_at(Scope::User, &user, perms(&["C"]), perms(&["C", "A"])),
+        );
+        let undo = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
+        apply_restore_plan(&undo, None, &WatchState::default()).unwrap();
+        let redo = build_restore_plan(&rec, audit::RestoreDirection::Redo).unwrap();
+        apply_restore_plan(&redo, None, &WatchState::default()).unwrap();
+        // Back to the post-move state we started from.
+        assert_eq!(
+            io_atomic::load(&user).unwrap().unwrap().permissions().allow,
+            vec!["C".to_string(), "A".to_string()],
+        );
+    }
+
+    #[test]
+    fn build_restore_plan_collapses_change_kind_to_one_target() {
+        // A same-scope change-kind records its single file as both `from`
+        // and `to`; the plan must write that file once, not twice.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("settings.json");
+        let side = side_at(
+            Scope::Project,
+            &project,
+            serde_json::json!({"allow": ["A"], "deny": []}),
+            serde_json::json!({"allow": [], "deny": ["A"]}),
+        );
+        let rec = audit::Record::new(
+            audit::Kind::ChangeKind,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            Some(side.clone()),
+            Some(side),
+            vec![key("permissions"), key("allow"), idx(0)],
+            Some(PermissionKind::Deny),
+        );
+        let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
+        assert_eq!(plan.targets.len(), 1);
+    }
+
+    #[test]
+    fn restore_preview_flags_a_hand_edited_file_as_state_mismatch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        let project = paths.project.clone().unwrap();
+        let user = paths.user.clone().unwrap();
+        // The record's `key_after` for Project is {"allow":["B"]}, but the
+        // file on disk says something else — an external hand-edit.
+        write(&project, r#"{"permissions":{"allow":["B","HAND_EDITED"]}}"#);
+        write(&user, r#"{"permissions":{"allow":["C","A"]}}"#);
+        let rec = move_record(
+            side_at(Scope::Project, &project, perms(&["A", "B"]), perms(&["B"])),
+            side_at(Scope::User, &user, perms(&["C"]), perms(&["C", "A"])),
+        );
+        let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
+        let preview = preview_restore_plan(&plan, &rec, 1).unwrap();
+        let project_side = preview
+            .sides
+            .iter()
+            .find(|s| s.scope == Scope::Project)
+            .unwrap();
+        assert!(
+            project_side.state_mismatch,
+            "the hand-edited project file should flag a mismatch"
+        );
+        let user_side = preview
+            .sides
+            .iter()
+            .find(|s| s.scope == Scope::User)
+            .unwrap();
+        assert!(
+            !user_side.state_mismatch,
+            "the untouched user file is not a mismatch"
+        );
+    }
+
+    #[test]
+    fn undo_of_an_add_removes_the_added_rule() {
+        // An add record carries only a `to` side; its undo removes the rule.
+        let tmp = tempfile::tempdir().unwrap();
+        let user = paths_in(tmp.path()).user.clone().unwrap();
+        write(&user, r#"{"permissions":{"allow":["C","A"]}}"#);
+        let rec = audit::Record::new(
+            audit::Kind::Add,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            None,
+            Some(side_at(Scope::User, &user, perms(&["C"]), perms(&["C", "A"]))),
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+        let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
+        apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
+        assert_eq!(
+            io_atomic::load(&user).unwrap().unwrap().permissions().allow,
+            vec!["C".to_string()],
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -675,7 +675,7 @@ fn undo_redo_preview(
 ) -> Result<RestorePreview, Box<dyn std::error::Error>> {
     let target = undo_redo_target(direction, overrides)?;
     let plan = build_restore_plan(&target, direction)?;
-    preview_restore_plan(&plan, &target, 1)
+    preview_restore_plan(&plan, &target)
 }
 
 /// Diff preview for the next undo (#19 Phase 3) — same modal the move /
@@ -752,6 +752,73 @@ pub fn audit_apply_redo(
         &overrides,
     )
     .map_err(|e| e.to_string())
+}
+
+/// Parse a ULID string from the frontend, mapping a decode failure to a
+/// readable error rather than the `ulid` crate's terse one.
+fn parse_audit_id(s: &str) -> Result<Ulid, Box<dyn std::error::Error>> {
+    Ulid::from_string(s).map_err(|e| format!("invalid audit entry id `{s}`: {e}").into())
+}
+
+fn restore_to_point_preview(
+    target_id: &str,
+    overrides: &RuntimeOverrides,
+) -> Result<RestorePreview, Box<dyn std::error::Error>> {
+    let id = parse_audit_id(target_id)?;
+    let (records, _) = audit::read_all(overrides.home())?;
+    let plan = plan_restore_to(&records, id)?;
+    let target = records
+        .iter()
+        .find(|r| r.id == id)
+        .expect("plan_restore_to already verified the id is in the log");
+    preview_restore_plan(&plan, target)
+}
+
+/// Diff preview for a restore-to-point (#19 Phase 4) — rolls the affected
+/// files back to their state before `target_id` was written.
+#[tauri::command]
+pub fn audit_restore_to_point_preview(
+    target_id: String,
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<RestorePreview, String> {
+    restore_to_point_preview(&target_id, &overrides).map_err(|e| e.to_string())
+}
+
+fn apply_restore_to_point(
+    target_id: &str,
+    expected_ops_spanned: usize,
+    app: &AppHandle,
+    watch: &WatchState,
+    overrides: &RuntimeOverrides,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let id = parse_audit_id(target_id)?;
+    let (records, _) = audit::read_all(overrides.home())?;
+    let plan = plan_restore_to(&records, id)?;
+    // The window the user confirmed had `expected_ops_spanned` entries; if
+    // a write landed since (a concurrent CLI op) the window has grown —
+    // refuse rather than reverting more than the preview showed.
+    if plan.ops_spanned != expected_ops_spanned {
+        return Err(
+            "the audit log changed since the preview — reload and try again".into(),
+        );
+    }
+    let files = apply_restore_plan(&plan, backups_for_session(), watch)?;
+    emit_audit(app, overrides, restore_record(&plan, audit::Actor::Gui, files));
+    Ok(())
+}
+
+/// Apply a restore-to-point (#19 Phase 4). `expected_ops_spanned` is the
+/// span the confirmed preview reported — see [`apply_restore_to_point`].
+#[tauri::command]
+pub fn audit_apply_restore_to_point(
+    target_id: String,
+    expected_ops_spanned: usize,
+    app: AppHandle,
+    watch: State<'_, WatchState>,
+    overrides: State<'_, RuntimeOverrides>,
+) -> Result<(), String> {
+    apply_restore_to_point(&target_id, expected_ops_spanned, &app, &watch, &overrides)
+        .map_err(|e| e.to_string())
 }
 
 /// Build- and runtime-time diagnostic block for the About dialog (#21).
@@ -1677,6 +1744,9 @@ pub struct RestorePlan {
     leaf_kind: audit::LeafKind,
     project_dir: Option<PathBuf>,
     path: Vec<PathSeg>,
+    /// How many logged entries this plan reverts: 1 for an undo / redo, the
+    /// count of spanned entries for a restore-to-point.
+    ops_spanned: usize,
     targets: Vec<RestoreTarget>,
 }
 
@@ -1787,6 +1857,79 @@ pub fn build_restore_plan(
         leaf_kind: rec.leaf_kind,
         project_dir: rec.project_dir.clone(),
         path: rec.path.clone(),
+        ops_spanned: 1,
+        targets,
+    })
+}
+
+/// Build the plan for a restore-to-point (#125): roll the affected files
+/// back to the state they were in immediately before `target_id` was
+/// written, reverting that entry and every entry logged after it.
+///
+/// The forward walk from the target to HEAD aggregates a per-file delta:
+/// the value to write back is the *first* `key_before` seen for that file
+/// in the window (its state when the window began — i.e. before the target),
+/// and the expected-current value is the *last* `key_after` seen (what the
+/// log believes the file holds now). `restore` entries inside the window
+/// count too — their `restore.files` snapshots are walked like any other.
+pub fn plan_restore_to(
+    records: &[audit::Record],
+    target_id: Ulid,
+) -> Result<RestorePlan, Box<dyn std::error::Error>> {
+    let target_idx = records
+        .iter()
+        .position(|r| r.id == target_id)
+        .ok_or("target audit entry not found in the log")?;
+    let target = &records[target_idx];
+    if target.kind == audit::Kind::Restore {
+        return Err(
+            "that entry is itself a restore — pick an original move / add / delete to restore before"
+                .into(),
+        );
+    }
+    let window = &records[target_idx..];
+    // Preserve first-seen file order so the plan (and the modal) list files
+    // in a stable, log-driven order rather than hash order.
+    let mut order: Vec<PathBuf> = Vec::new();
+    let mut by_path: std::collections::HashMap<PathBuf, RestoreTarget> =
+        std::collections::HashMap::new();
+    for entry in window {
+        for s in record_sides(entry) {
+            match by_path.get_mut(&s.file_path) {
+                // Already seen: keep the first `key_before` (window-start
+                // state) and advance `expected_current` to this later
+                // `key_after`.
+                Some(existing) => existing.expected_current = s.key_after.clone(),
+                None => {
+                    order.push(s.file_path.clone());
+                    by_path.insert(
+                        s.file_path.clone(),
+                        RestoreTarget {
+                            scope: s.scope,
+                            file_path: s.file_path.clone(),
+                            top_level_key: s.top_level_key.clone(),
+                            target_value: s.key_before.clone(),
+                            expected_current: s.key_after.clone(),
+                        },
+                    );
+                }
+            }
+        }
+    }
+    let targets: Vec<RestoreTarget> = order
+        .into_iter()
+        .map(|p| by_path.remove(&p).expect("path inserted above"))
+        .collect();
+    if targets.is_empty() {
+        return Err("nothing to restore — the spanned entries touched no files".into());
+    }
+    Ok(RestorePlan {
+        direction: audit::RestoreDirection::ToPoint,
+        target_id,
+        leaf_kind: target.leaf_kind,
+        project_dir: target.project_dir.clone(),
+        path: target.path.clone(),
+        ops_spanned: window.len(),
         targets,
     })
 }
@@ -1806,12 +1949,10 @@ fn current_top_level(
 }
 
 /// Compute the diff preview for a restore plan without writing anything.
-/// `target` is the audit entry being acted on; `ops_spanned` is 1 for an
-/// undo / redo and the spanned-entry count for a restore-to-point.
+/// `target` is the audit entry being acted on.
 pub fn preview_restore_plan(
     plan: &RestorePlan,
     target: &audit::Record,
-    ops_spanned: usize,
 ) -> Result<RestorePreview, Box<dyn std::error::Error>> {
     let mut sides = Vec::with_capacity(plan.targets.len());
     for t in &plan.targets {
@@ -1831,7 +1972,7 @@ pub fn preview_restore_plan(
         direction: plan.direction,
         target: record_view(target.clone()),
         sides,
-        ops_spanned,
+        ops_spanned: plan.ops_spanned,
     })
 }
 
@@ -2992,7 +3133,7 @@ mod tests {
             side_at(Scope::User, &user, perms(&["C"]), perms(&["C", "A"])),
         );
         let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
-        let preview = preview_restore_plan(&plan, &rec, 1).unwrap();
+        let preview = preview_restore_plan(&plan, &rec).unwrap();
         let project_side = preview
             .sides
             .iter()
@@ -3034,6 +3175,166 @@ mod tests {
         assert_eq!(
             io_atomic::load(&user).unwrap().unwrap().permissions().allow,
             vec!["C".to_string()],
+        );
+    }
+
+    // -- restore-to-point (#125) -------------------------------------------
+
+    #[test]
+    fn restore_to_point_reverts_the_target_and_everything_after() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        let project = paths.project.clone().unwrap();
+        let user = paths.user.clone().unwrap();
+        // Disk reflects the state after two moves: A then B, Project → User.
+        write(&project, r#"{"permissions":{"allow":["C"]}}"#);
+        write(&user, r#"{"permissions":{"allow":["A","B"]}}"#);
+        let m1 = move_record(
+            side_at(Scope::Project, &project, perms(&["A", "B", "C"]), perms(&["B", "C"])),
+            side_at(Scope::User, &user, perms(&[]), perms(&["A"])),
+        );
+        let m2 = move_record(
+            side_at(Scope::Project, &project, perms(&["B", "C"]), perms(&["C"])),
+            side_at(Scope::User, &user, perms(&["A"]), perms(&["A", "B"])),
+        );
+        let records = vec![m1.clone(), m2];
+        let plan = plan_restore_to(&records, m1.id).unwrap();
+        assert_eq!(plan.ops_spanned, 2, "two entries spanned");
+        apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
+        // Both files are back to the pre-m1 state.
+        assert_eq!(
+            io_atomic::load(&project).unwrap().unwrap().permissions().allow,
+            vec!["A".to_string(), "B".to_string(), "C".to_string()],
+        );
+        assert!(io_atomic::load(&user)
+            .unwrap()
+            .unwrap()
+            .permissions()
+            .allow
+            .is_empty());
+    }
+
+    #[test]
+    fn restore_to_point_on_the_last_entry_reverts_just_that_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        let project = paths.project.clone().unwrap();
+        let user = paths.user.clone().unwrap();
+        write(&project, r#"{"permissions":{"allow":[]}}"#);
+        write(&user, r#"{"permissions":{"allow":["A"]}}"#);
+        let m1 = move_record(
+            side_at(Scope::Project, &project, perms(&["A"]), perms(&[])),
+            side_at(Scope::User, &user, perms(&[]), perms(&["A"])),
+        );
+        let plan = plan_restore_to(&[m1.clone()], m1.id).unwrap();
+        assert_eq!(plan.ops_spanned, 1);
+        apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
+        assert_eq!(
+            io_atomic::load(&project).unwrap().unwrap().permissions().allow,
+            vec!["A".to_string()],
+        );
+        assert!(io_atomic::load(&user)
+            .unwrap()
+            .unwrap()
+            .permissions()
+            .allow
+            .is_empty());
+    }
+
+    #[test]
+    fn restore_to_point_rejects_a_restore_entry_as_target() {
+        // Restoring to before an undo is confusing — the user should target
+        // an original write instead.
+        let restore = audit::Record::new_restore(
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            vec![],
+            audit::RestoreMeta {
+                target_id: Ulid::new(),
+                direction: audit::RestoreDirection::Undo,
+                files: vec![],
+            },
+        );
+        let err = plan_restore_to(std::slice::from_ref(&restore), restore.id).unwrap_err();
+        assert!(err.to_string().contains("itself a restore"));
+    }
+
+    #[test]
+    fn restore_to_point_rejects_an_unknown_target() {
+        let err = plan_restore_to(&[], Ulid::new()).unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn a_restore_to_point_entry_is_itself_undoable() {
+        // A restore-to-point lands a `Kind::Restore` record; undoing it
+        // walks `restore.files` and puts the file back.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = paths_in(tmp.path()).project.clone().unwrap();
+        write(&project, r#"{"permissions":{"allow":["NEW"]}}"#);
+        let rec = audit::Record::new_restore(
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            vec![key("permissions"), key("allow"), idx(0)],
+            audit::RestoreMeta {
+                target_id: Ulid::new(),
+                direction: audit::RestoreDirection::ToPoint,
+                files: vec![side_at(
+                    Scope::Project,
+                    &project,
+                    perms(&["OLD"]),
+                    perms(&["NEW"]),
+                )],
+            },
+        );
+        let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
+        apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
+        assert_eq!(
+            io_atomic::load(&project).unwrap().unwrap().permissions().allow,
+            vec!["OLD".to_string()],
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_restore_plan_rolls_back_an_earlier_file_when_a_later_one_fails() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let good_dir = tmp.path().join("good");
+        let bad_dir = tmp.path().join("bad");
+        std::fs::create_dir_all(&good_dir).unwrap();
+        std::fs::create_dir_all(&bad_dir).unwrap();
+        let good = good_dir.join("settings.json");
+        let bad = bad_dir.join("settings.json");
+        write(&good, r#"{"permissions":{"allow":["POST"]}}"#);
+        write(&bad, r#"{"permissions":{"allow":["POST"]}}"#);
+        // An undo plan targets `good` then `bad` (record_sides order).
+        let rec = move_record(
+            side_at(Scope::Project, &good, perms(&["PRE"]), perms(&["POST"])),
+            side_at(Scope::User, &bad, perms(&["PRE"]), perms(&["POST"])),
+        );
+        // Lock the bad file's directory so its atomic write can't create a
+        // tempfile — phase 2 fails on the second target.
+        let mut ro = std::fs::metadata(&bad_dir).unwrap().permissions();
+        ro.set_mode(0o555);
+        std::fs::set_permissions(&bad_dir, ro).unwrap();
+
+        let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
+        let result = apply_restore_plan(&plan, None, &WatchState::default());
+
+        // Re-grant write so TempDir cleanup and the load below can proceed.
+        let mut rw = std::fs::metadata(&bad_dir).unwrap().permissions();
+        rw.set_mode(0o755);
+        std::fs::set_permissions(&bad_dir, rw).unwrap();
+
+        assert!(result.is_err(), "the locked file should fail the batch");
+        // `good` was written, then rolled back to its pre-restore content.
+        assert_eq!(
+            io_atomic::load(&good).unwrap().unwrap().permissions().allow,
+            vec!["POST".to_string()],
+            "the earlier file must be rolled back, not left half-restored",
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -626,9 +626,7 @@ pub struct UndoRedoStatus {
 /// (writes there are never logged), so undo / redo are simply unavailable
 /// in scratch mode — `.bak` remains the recovery path there.
 #[tauri::command]
-pub fn audit_undo_status(
-    overrides: State<'_, RuntimeOverrides>,
-) -> Result<UndoRedoStatus, String> {
+pub fn audit_undo_status(overrides: State<'_, RuntimeOverrides>) -> Result<UndoRedoStatus, String> {
     let (records, _) = audit::read_all(overrides.home()).map_err(|e| e.to_string())?;
     let state = audit::undo_redo_state(&records);
     Ok(UndoRedoStatus {
@@ -651,9 +649,7 @@ fn undo_redo_target(
         audit::RestoreDirection::Undo => state.undoable,
         audit::RestoreDirection::Redo => {
             if state.sequence_break {
-                return Err(
-                    "redo is unavailable: a change was made after the last undo".into(),
-                );
+                return Err("redo is unavailable: a change was made after the last undo".into());
             }
             state.redoable
         }
@@ -707,13 +703,15 @@ fn apply_undo_redo(
     // log moved under us (a concurrent CLI write, an external rotation)
     // refuse rather than silently acting on a different op.
     if target.id.to_string() != expected_id {
-        return Err(
-            "the audit log changed since the preview — reload and try again".into(),
-        );
+        return Err("the audit log changed since the preview — reload and try again".into());
     }
     let plan = build_restore_plan(&target, direction)?;
     let files = apply_restore_plan(&plan, backups_for_session(), watch)?;
-    emit_audit(app, overrides, restore_record(&plan, audit::Actor::Gui, files));
+    emit_audit(
+        app,
+        overrides,
+        restore_record(&plan, audit::Actor::Gui, files),
+    );
     Ok(())
 }
 
@@ -798,12 +796,14 @@ fn apply_restore_to_point(
     // a write landed since (a concurrent CLI op) the window has grown —
     // refuse rather than reverting more than the preview showed.
     if plan.ops_spanned != expected_ops_spanned {
-        return Err(
-            "the audit log changed since the preview — reload and try again".into(),
-        );
+        return Err("the audit log changed since the preview — reload and try again".into());
     }
     let files = apply_restore_plan(&plan, backups_for_session(), watch)?;
-    emit_audit(app, overrides, restore_record(&plan, audit::Actor::Gui, files));
+    emit_audit(
+        app,
+        overrides,
+        restore_record(&plan, audit::Actor::Gui, files),
+    );
     Ok(())
 }
 
@@ -3030,7 +3030,11 @@ mod tests {
         let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
         let sides = apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
         assert_eq!(
-            io_atomic::load(&project).unwrap().unwrap().permissions().allow,
+            io_atomic::load(&project)
+                .unwrap()
+                .unwrap()
+                .permissions()
+                .allow,
             vec!["A".to_string(), "B".to_string()],
         );
         assert_eq!(
@@ -3060,7 +3064,11 @@ mod tests {
         let plan = build_restore_plan(&rec, audit::RestoreDirection::Redo).unwrap();
         apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
         assert_eq!(
-            io_atomic::load(&project).unwrap().unwrap().permissions().allow,
+            io_atomic::load(&project)
+                .unwrap()
+                .unwrap()
+                .permissions()
+                .allow,
             vec!["B".to_string()],
         );
         assert_eq!(
@@ -3166,7 +3174,12 @@ mod tests {
             audit::Actor::Gui,
             None,
             None,
-            Some(side_at(Scope::User, &user, perms(&["C"]), perms(&["C", "A"]))),
+            Some(side_at(
+                Scope::User,
+                &user,
+                perms(&["C"]),
+                perms(&["C", "A"]),
+            )),
             vec![key("permissions"), key("allow"), idx(0)],
             None,
         );
@@ -3190,7 +3203,12 @@ mod tests {
         write(&project, r#"{"permissions":{"allow":["C"]}}"#);
         write(&user, r#"{"permissions":{"allow":["A","B"]}}"#);
         let m1 = move_record(
-            side_at(Scope::Project, &project, perms(&["A", "B", "C"]), perms(&["B", "C"])),
+            side_at(
+                Scope::Project,
+                &project,
+                perms(&["A", "B", "C"]),
+                perms(&["B", "C"]),
+            ),
             side_at(Scope::User, &user, perms(&[]), perms(&["A"])),
         );
         let m2 = move_record(
@@ -3203,7 +3221,11 @@ mod tests {
         apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
         // Both files are back to the pre-m1 state.
         assert_eq!(
-            io_atomic::load(&project).unwrap().unwrap().permissions().allow,
+            io_atomic::load(&project)
+                .unwrap()
+                .unwrap()
+                .permissions()
+                .allow,
             vec!["A".to_string(), "B".to_string(), "C".to_string()],
         );
         assert!(io_atomic::load(&user)
@@ -3230,7 +3252,11 @@ mod tests {
         assert_eq!(plan.ops_spanned, 1);
         apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
         assert_eq!(
-            io_atomic::load(&project).unwrap().unwrap().permissions().allow,
+            io_atomic::load(&project)
+                .unwrap()
+                .unwrap()
+                .permissions()
+                .allow,
             vec!["A".to_string()],
         );
         assert!(io_atomic::load(&user)
@@ -3292,7 +3318,11 @@ mod tests {
         let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
         apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
         assert_eq!(
-            io_atomic::load(&project).unwrap().unwrap().permissions().allow,
+            io_atomic::load(&project)
+                .unwrap()
+                .unwrap()
+                .permissions()
+                .allow,
             vec!["OLD".to_string()],
         );
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,8 @@ pub fn run(context: tauri::Context) {
             commands::audit_redo_preview,
             commands::audit_apply_undo,
             commands::audit_apply_redo,
+            commands::audit_restore_to_point_preview,
+            commands::audit_apply_restore_to_point,
             commands::get_app_info,
         ])
         .run(context)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,11 @@ pub fn run(context: tauri::Context) {
             commands::load_runtime_info,
             commands::list_known_projects,
             commands::list_audit_records,
+            commands::audit_undo_status,
+            commands::audit_undo_preview,
+            commands::audit_redo_preview,
+            commands::audit_apply_undo,
+            commands::audit_apply_redo,
             commands::get_app_info,
         ])
         .run(context)

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -272,6 +272,15 @@ impl SettingsDoc {
         }
     }
 
+    /// Unconditionally set a top-level key to `value`, bypassing the per-key
+    /// merge policy that [`merge_top_level`](Self::merge_top_level) applies.
+    /// The restore path (#124) writes verbatim snapshots back to disk rather
+    /// than merging — an exact assignment a policy-aware merge (which
+    /// deep-merges `env`, array-unions list keys, …) can't express.
+    pub fn set_top_level(&mut self, key: &str, value: Value) {
+        ensure_object(&mut self.root).insert(key.to_string(), value);
+    }
+
     /// Read the JSON value at `path` if every segment resolves. Object keys
     /// are matched verbatim; array indices must be in-bounds. Returns `None`
     /// when any segment misses, which the move flow distinguishes from

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,15 +18,18 @@ import type {
   PathSeg,
   PermissionKind,
   Preferences,
+  RestorePreview,
   RuntimeInfo,
   Scope,
   Theme,
+  UndoRedoStatus,
 } from "./types.ts";
 import { SCOPES, SEARCH_INPUT_ID } from "./types.ts";
 import {
   confirmAddLeaf,
   confirmDeleteLeaf,
   confirmMoveLeaf,
+  confirmRestore,
   openAbout,
   openHistory,
   openSettings,
@@ -56,6 +59,7 @@ const state: {
   runtime: RuntimeInfo;
   knownProjects: KnownProject[];
   appInfo: AppInfo | null;
+  undoStatus: UndoRedoStatus | null;
 } = {
   scopes: null,
   projectDir: null,
@@ -74,6 +78,10 @@ const state: {
   // discovery failure; `openAbout` renders a Loading… stub in that case
   // rather than treating it as an error.
   appInfo: null,
+  // Undo/redo availability (#124), refreshed by `refreshUndoStatus` after
+  // every load. Null until the first fetch resolves — the topbar buttons
+  // render disabled in the meantime.
+  undoStatus: null,
 };
 
 // Set by the scopes-changed listener when it fires while another load or
@@ -100,6 +108,10 @@ async function load(projectDir: string | null): Promise<void> {
     // Fire-and-forget — a stale list is purely cosmetic and self-heals on
     // the next successful load.
     refreshPreferences();
+    // Refresh undo/redo availability (#124): every move / add / delete /
+    // undo runs through load(), so this one call keeps the topbar
+    // buttons current after any write.
+    refreshUndoStatus();
   } catch (err) {
     alert(`Failed to load settings: ${err}`);
   } finally {
@@ -131,6 +143,19 @@ function refreshPreferences(): void {
     })
     .catch((err) => {
       console.warn("failed to refresh preferences:", err);
+    });
+}
+
+function refreshUndoStatus(): void {
+  invoke<UndoRedoStatus>("audit_undo_status")
+    .then((status) => {
+      state.undoStatus = status;
+      render();
+    })
+    .catch((err) => {
+      // Non-fatal: a failed status fetch just leaves the undo/redo
+      // buttons disabled until the next load retries.
+      console.warn("failed to read undo/redo status:", err);
     });
 }
 
@@ -331,6 +356,62 @@ async function addLeaf(req: AddLeafRequest, trigger?: HTMLElement): Promise<void
   }
 }
 
+/**
+ * Drive an undo or redo (#124): fetch the preview, route it through the
+ * restore-confirm modal, and on confirm apply it and reload. Shares the
+ * `moveInFlight` guard and deferred-reload drain with the move/add/delete
+ * flows so a write can't start mid-restore.
+ */
+async function runRestore(direction: "undo" | "redo", trigger?: HTMLElement): Promise<void> {
+  if (moveInFlight) return;
+  moveInFlight = true;
+  const label = direction === "undo" ? "Undo" : "Redo";
+  try {
+    let preview: RestorePreview;
+    try {
+      preview = await invoke<RestorePreview>(
+        direction === "undo" ? "audit_undo_preview" : "audit_redo_preview",
+      );
+    } catch (err) {
+      alert(`${label} failed: ${err}`);
+      return;
+    }
+
+    const apply = await confirmRestore(preview, trigger);
+    if (!apply) return;
+
+    state.busy = true;
+    render();
+    try {
+      // `expected_id` lets the backend refuse if the audit log moved since
+      // the preview (a concurrent CLI write) rather than acting on a
+      // different entry than the one the user just confirmed.
+      await invoke(direction === "undo" ? "audit_apply_undo" : "audit_apply_redo", {
+        expected_id: preview.target.id,
+      });
+      await load(state.projectDir);
+    } catch (err) {
+      alert(`${label} failed: ${err}`);
+      state.busy = false;
+      render();
+    }
+  } finally {
+    moveInFlight = false;
+    if (externalReloadPending && !state.busy) {
+      externalReloadPending = false;
+      void load(state.projectDir);
+    }
+  }
+}
+
+function handleUndo(trigger?: HTMLElement): void {
+  void runRestore("undo", trigger);
+}
+
+function handleRedo(trigger?: HTMLElement): void {
+  void runRestore("redo", trigger);
+}
+
 function setQuery(next: string): void {
   if (state.query === next) return;
   state.query = next;
@@ -474,9 +555,12 @@ function render(): void {
     preferences: state.preferences,
     runtime: state.runtime,
     knownProjects: state.knownProjects,
+    undoStatus: state.undoStatus,
     onPickProject: pickProject,
     onPickRecentProject: pickRecentProject,
     onReload: reload,
+    onUndo: handleUndo,
+    onRedo: handleRedo,
     onMoveLeaf: moveLeaf,
     onChangeKind: changeKind,
     onDeleteLeaf: deleteLeaf,
@@ -533,6 +617,36 @@ document.addEventListener("keydown", (e) => {
   e.preventDefault();
   search.focus();
   search.select();
+});
+
+// Ctrl+Z / Cmd+Z undo, Ctrl+Shift+Z / Cmd+Shift+Z redo (#124). Global, but
+// — like the "/" shortcut above — skipped while a text field is focused or
+// a modal is open, so we never steal a keystroke the user meant elsewhere.
+document.addEventListener("keydown", (e) => {
+  if (e.key !== "z" && e.key !== "Z") return;
+  // Require exactly the platform modifier; Alt+Ctrl+Z is left alone.
+  if (!(e.ctrlKey || e.metaKey) || e.altKey) return;
+  if (e.defaultPrevented) return;
+  const target = e.target as HTMLElement | null;
+  if (
+    target &&
+    (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+  ) {
+    return;
+  }
+  if (document.querySelector(".modal-backdrop")) return;
+  // A load or move/restore in flight: drop the keystroke rather than queue
+  // a second overlapping flow.
+  if (moveInFlight || state.busy) return;
+  if (e.shiftKey) {
+    if (!state.undoStatus?.redo) return;
+    e.preventDefault();
+    handleRedo();
+  } else {
+    if (!state.undoStatus?.undo) return;
+    e.preventDefault();
+    handleUndo();
+  }
 });
 
 // The Rust watcher (`src-tauri/src/watcher.rs`) emits `scopes-changed` when

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import type {
   AddLeafRequest,
   AppInfo,
   AuditLogPage,
+  AuditRecordView,
   DeleteLeafPreview,
   DeleteLeafRequest,
   KnownProject,
@@ -357,21 +358,27 @@ async function addLeaf(req: AddLeafRequest, trigger?: HTMLElement): Promise<void
 }
 
 /**
- * Drive an undo or redo (#124): fetch the preview, route it through the
- * restore-confirm modal, and on confirm apply it and reload. Shares the
- * `moveInFlight` guard and deferred-reload drain with the move/add/delete
- * flows so a write can't start mid-restore.
+ * Drive an undo / redo / restore-to-point (#124 / #125): fetch the preview,
+ * route it through the restore-confirm modal, and on confirm apply it and
+ * reload. Shares the `moveInFlight` guard and deferred-reload drain with the
+ * move/add/delete flows so a write can't start mid-restore.
+ *
+ * `fetchPreview` / `applyRestore` are passed in because the three flows hit
+ * different IPC commands; everything else — the guard, modal, busy state,
+ * reload — is identical.
  */
-async function runRestore(direction: "undo" | "redo", trigger?: HTMLElement): Promise<void> {
+async function runRestoreFlow(
+  label: string,
+  fetchPreview: () => Promise<RestorePreview>,
+  applyRestore: (preview: RestorePreview) => Promise<void>,
+  trigger?: HTMLElement,
+): Promise<void> {
   if (moveInFlight) return;
   moveInFlight = true;
-  const label = direction === "undo" ? "Undo" : "Redo";
   try {
     let preview: RestorePreview;
     try {
-      preview = await invoke<RestorePreview>(
-        direction === "undo" ? "audit_undo_preview" : "audit_redo_preview",
-      );
+      preview = await fetchPreview();
     } catch (err) {
       alert(`${label} failed: ${err}`);
       return;
@@ -383,12 +390,7 @@ async function runRestore(direction: "undo" | "redo", trigger?: HTMLElement): Pr
     state.busy = true;
     render();
     try {
-      // `expected_id` lets the backend refuse if the audit log moved since
-      // the preview (a concurrent CLI write) rather than acting on a
-      // different entry than the one the user just confirmed.
-      await invoke(direction === "undo" ? "audit_apply_undo" : "audit_apply_redo", {
-        expected_id: preview.target.id,
-      });
+      await applyRestore(preview);
       await load(state.projectDir);
     } catch (err) {
       alert(`${label} failed: ${err}`);
@@ -405,11 +407,43 @@ async function runRestore(direction: "undo" | "redo", trigger?: HTMLElement): Pr
 }
 
 function handleUndo(trigger?: HTMLElement): void {
-  void runRestore("undo", trigger);
+  // `expected_id` lets the backend refuse if the audit log moved since the
+  // preview (a concurrent CLI write) rather than acting on a different
+  // entry than the one the user just confirmed.
+  void runRestoreFlow(
+    "Undo",
+    () => invoke<RestorePreview>("audit_undo_preview"),
+    (preview) => invoke("audit_apply_undo", { expected_id: preview.target.id }),
+    trigger,
+  );
 }
 
 function handleRedo(trigger?: HTMLElement): void {
-  void runRestore("redo", trigger);
+  void runRestoreFlow(
+    "Redo",
+    () => invoke<RestorePreview>("audit_redo_preview"),
+    (preview) => invoke("audit_apply_redo", { expected_id: preview.target.id }),
+    trigger,
+  );
+}
+
+/**
+ * Restore every file affected by `rec` (and the entries after it) back to
+ * its pre-`rec` state (#125). Invoked from a History-row "Restore" button;
+ * the History dialog closes itself first so the confirm modal opens clean.
+ */
+function handleRestoreToPoint(rec: AuditRecordView): void {
+  // `expected_ops_spanned` guards against the log growing between preview
+  // and apply — the backend reverts only the span the user confirmed.
+  void runRestoreFlow(
+    "Restore",
+    () => invoke<RestorePreview>("audit_restore_to_point_preview", { target_id: rec.id }),
+    (preview) =>
+      invoke("audit_apply_restore_to_point", {
+        target_id: rec.id,
+        expected_ops_spanned: preview.ops_spanned,
+      }),
+  );
 }
 
 function setQuery(next: string): void {
@@ -591,7 +625,7 @@ async function handleOpenHistory(trigger?: HTMLElement): Promise<void> {
   } catch (err) {
     console.warn("failed to read audit log:", err);
   }
-  openHistory(page, trigger ?? null);
+  openHistory(page, { trigger: trigger ?? null, onRestoreToPoint: handleRestoreToPoint });
 }
 
 // Pressing "/" anywhere focuses the rule-search input, GitHub / Gmail style —

--- a/src/styles.css
+++ b/src/styles.css
@@ -1473,6 +1473,51 @@ button:disabled {
   grid-template-columns: 1fr;
 }
 
+/* Restore-confirm modal: undo / redo / restore-to-point (#124 / #125). */
+.modal-restore-span {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.modal-warning-band {
+  margin-bottom: 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--ask);
+  border-radius: 6px;
+  background: var(--panel-2);
+  color: var(--ask);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+/* One file per row — a restore can touch up to four. */
+.modal-diff-restore {
+  grid-template-columns: 1fr;
+}
+
+.modal-side-restore {
+  border-left: 3px solid var(--accent);
+}
+
+.modal-side-note-warn {
+  color: var(--ask);
+  font-weight: 600;
+}
+
+.modal-restore-block {
+  margin-top: 8px;
+}
+
+.modal-restore-block-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin-bottom: 3px;
+}
+
 /* History dialog (#19 phase 2). Wider than About so long paths and rule
    strings have room without wrapping into hard-to-scan multi-line blocks. */
 .modal-history {
@@ -1538,6 +1583,19 @@ button:disabled {
 
 .history-verb-change_kind {
   color: var(--warn, #b88216);
+}
+
+.history-verb-restore {
+  color: var(--accent);
+}
+
+/* The "· Move permission rule" reference a restore row shows for the entry
+   it acted on. `margin-right: auto` keeps it grouped with the verb on the
+   left while the timestamp stays pinned right. */
+.history-restore-ref {
+  margin-right: auto;
+  color: var(--muted);
+  font-size: 12px;
 }
 
 .history-ts {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1560,7 +1560,6 @@ button:disabled {
 .history-row-head {
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
   gap: 12px;
 }
 
@@ -1590,15 +1589,30 @@ button:disabled {
 }
 
 /* The "· Move permission rule" reference a restore row shows for the entry
-   it acted on. `margin-right: auto` keeps it grouped with the verb on the
-   left while the timestamp stays pinned right. */
+   it acted on. Sits next to the verb; the timestamp's `margin-left: auto`
+   pushes everything after it to the right edge. */
 .history-restore-ref {
-  margin-right: auto;
   color: var(--muted);
   font-size: 12px;
 }
 
+.history-restore-btn {
+  padding: 1px 8px;
+  font-size: 11px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--panel-2);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.history-restore-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .history-ts {
+  margin-left: auto;
   color: var(--muted);
   font-size: 12px;
   font-variant-numeric: tabular-nums;

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,10 +252,29 @@ export interface AppInfo {
 /**
  * Audit log entry kinds (#19). Mirrors Rust's `audit::Kind` — snake_case
  * wire strings pinned by `record_kind_serializes_to_snake_case_strings`
- * in commands.rs. `change_kind` is the same-scope reclassification flow;
- * the full set will grow as #16 / #17 / #18 land in future phases.
+ * in audit.rs. `change_kind` is the same-scope reclassification flow;
+ * `restore` is the meta-entry an undo / redo / restore-to-point writes
+ * (#124), with its payload in [[AuditRecordView]]`.restore`.
  */
-export type AuditKind = "move" | "change_kind" | "add" | "delete";
+export type AuditKind = "move" | "change_kind" | "add" | "delete" | "restore";
+
+/**
+ * Direction of a `restore` audit entry. Mirrors Rust's
+ * `audit::RestoreDirection`: `undo` / `redo` are cursor moves, `to_point`
+ * is a restore-to-point (#125).
+ */
+export type AuditRestoreDirection = "undo" | "redo" | "to_point";
+
+/**
+ * Payload of a `restore` audit entry (#124). Mirrors Rust's
+ * `audit::RestoreMeta`: the id of the entry acted on, the direction, and a
+ * per-file before/after snapshot of everything the restore rewrote.
+ */
+export interface AuditRestoreMeta {
+  target_id: string;
+  direction: AuditRestoreDirection;
+  files: AuditSide[];
+}
 
 /**
  * What shape of leaf the audit record's `path` targets. Mirrors Rust's
@@ -266,12 +285,11 @@ export type AuditKind = "move" | "change_kind" | "add" | "delete";
 export type AuditLeafKind = "top_level_key" | "permission_list" | "permission_rule";
 
 /**
- * Who triggered an audit record. Phase 1 only emits `gui`; the other
- * variants reserve wire-format slots for the CLI (#13) and undo / restore
- * (#19 phases 3-4) so the schema can extend without breaking older
- * History readers.
+ * Who triggered an audit record. Mirrors Rust's `audit::Actor`. Orthogonal
+ * to [[AuditKind]]: an undo run from the CLI is `actor: "cli"`,
+ * `kind: "restore"` — there is deliberately no `restore` actor.
  */
-export type AuditActor = "gui" | "cli" | "skill" | "restore";
+export type AuditActor = "gui" | "cli" | "skill";
 
 /**
  * One side of an audit record's write. Mirrors Rust's `audit::Side` —
@@ -304,8 +322,57 @@ export interface AuditRecordView {
   to?: AuditSide;
   path: PathSeg[];
   to_kind?: PermissionKind;
+  /** Present only on `kind: "restore"` entries — the undo / redo /
+   *  restore-to-point payload. */
+  restore?: AuditRestoreMeta;
   claude_scope_version: string;
   ts_ms: number;
+}
+
+/**
+ * One file's diff in a [[RestorePreview]]. Mirrors Rust's
+ * `RestoreSidePreview`. `key_current` / `key_target` follow the
+ * skip-on-absent convention: `undefined` means the key is unset, distinct
+ * from a literal JSON `null`.
+ */
+export interface RestoreSidePreview {
+  scope: Scope;
+  file_path: string;
+  file_path_exists: boolean;
+  top_level_key: string;
+  key_current?: JsonValue;
+  key_target?: JsonValue;
+  will_write: boolean;
+  /** True when the on-disk value differs from what the audit log expected
+   *  — the file was hand-edited since the logged op. The restore still
+   *  proceeds on confirm; this drives a warning band in the modal. */
+  state_mismatch: boolean;
+}
+
+/**
+ * Diff preview for an undo / redo / restore-to-point (#124 / #125).
+ * Returned by `audit_undo_preview` / `audit_redo_preview`. Mirrors Rust's
+ * `RestorePreview`.
+ */
+export interface RestorePreview {
+  direction: AuditRestoreDirection;
+  /** The audit entry being undone / redone / restored-to. */
+  target: AuditRecordView;
+  sides: RestoreSidePreview[];
+  /** How many ops the restore reverts: 1 for undo / redo. */
+  ops_spanned: number;
+}
+
+/**
+ * Undo / redo availability for the topbar buttons (#124). Returned by
+ * `audit_undo_status`. `undo` / `redo` carry the audit entry the next
+ * click would act on; `sequence_break` is true when redo is unavailable
+ * specifically because a change landed after the last undo.
+ */
+export interface UndoRedoStatus {
+  undo?: AuditRecordView;
+  redo?: AuditRecordView;
+  sequence_break: boolean;
 }
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2851,6 +2851,10 @@ function openModal(opts: {
    *  when the caller needs to resolve a pending promise that the actions
    *  might not have resolved (e.g. the user dismisses without picking). */
   onClose?: () => void;
+  /** Called once with the modal's `close` function right after it's wired,
+   *  so a caller that builds interactive body content (e.g. the History
+   *  dialog's per-row Restore buttons) can dismiss the modal itself. */
+  onReady?: (close: () => void) => void;
 }): void {
   const backdrop = document.createElement("div");
   backdrop.className = "modal-backdrop";
@@ -2953,6 +2957,7 @@ function openModal(opts: {
   });
 
   document.body.appendChild(backdrop);
+  opts.onReady?.(close);
   const initial = actionButtons.find((_, i) => opts.actions[i].focus) ?? actionButtons[0];
   initial?.focus();
 }
@@ -4380,12 +4385,21 @@ export function renderDiagnosticsMarkdown(info: AppInfo): string {
   ].join("\n");
 }
 
+/** Options for [[openHistory]]. */
+export interface HistoryOptions {
+  trigger?: HTMLElement | null;
+  /** Restore-to-point handler (#125). When supplied, each original-write
+   *  row grows a "Restore to before this" button; the History dialog
+   *  closes itself before invoking it so the restore-confirm modal opens
+   *  cleanly on its own. */
+  onRestoreToPoint?: (rec: AuditRecordView) => void;
+}
+
 /**
- * Open the audit-log History dialog (#19 phase 2). Read-only: lists every
- * write ClaudeScope has made since the audit log was first written, in
- * reverse-chronological order. The "Restore to before this" action the
- * issue spec mentions lands with #19 phase 3+; this dialog deliberately
- * omits it so the read path can ship first.
+ * Open the audit-log History dialog (#19 phase 2). Lists every write
+ * ClaudeScope has made since the audit log was first written, in
+ * reverse-chronological order. With `onRestoreToPoint` supplied (#125),
+ * each original-write row offers a "Restore to before this" action.
  *
  * `page` arrives null when the bootstrap fetch failed (e.g. the audit
  * file was unreadable) — the dialog still opens, with an explanatory
@@ -4393,9 +4407,20 @@ export function renderDiagnosticsMarkdown(info: AppInfo): string {
  * are common (fresh install, no writes yet) and render as a friendly
  * empty state.
  */
-export function openHistory(page: AuditLogPage | null, trigger?: HTMLElement | null): void {
+export function openHistory(page: AuditLogPage | null, opts: HistoryOptions = {}): void {
   const body = document.createElement("div");
   body.className = "history-body";
+
+  // The list is built before `openModal` runs, but the per-row Restore
+  // buttons need the modal's `close`; capture it here and let the buttons
+  // read it once `onReady` fires.
+  let closeModal: (() => void) | null = null;
+  const restoreHandler = opts.onRestoreToPoint
+    ? (rec: AuditRecordView) => {
+        closeModal?.();
+        opts.onRestoreToPoint?.(rec);
+      }
+    : undefined;
 
   if (page === null) {
     const err = document.createElement("p");
@@ -4409,7 +4434,7 @@ export function openHistory(page: AuditLogPage | null, trigger?: HTMLElement | n
       "No audit entries yet. Every move / add / delete you make from here will appear in this list.";
     body.appendChild(empty);
   } else {
-    body.appendChild(historyList(page.records));
+    body.appendChild(historyList(page.records, restoreHandler));
     if (page.skipped > 0) {
       const warn = document.createElement("p");
       warn.className = "history-skipped";
@@ -4432,7 +4457,10 @@ export function openHistory(page: AuditLogPage | null, trigger?: HTMLElement | n
       },
     ],
     panelClassName: "modal-history",
-    trigger,
+    trigger: opts.trigger,
+    onReady: (close) => {
+      closeModal = close;
+    },
   });
 }
 
@@ -4443,7 +4471,10 @@ export function openHistory(page: AuditLogPage | null, trigger?: HTMLElement | n
  * useful ordering for a "what just happened?" view — without paying for
  * a backend sort.
  */
-function historyList(records: AuditRecordView[]): HTMLElement {
+function historyList(
+  records: AuditRecordView[],
+  onRestore?: (rec: AuditRecordView) => void,
+): HTMLElement {
   const ul = document.createElement("ul");
   ul.className = "history-list";
   // Index by id so a restore row can name the entry it acted on.
@@ -4451,12 +4482,16 @@ function historyList(records: AuditRecordView[]): HTMLElement {
   // Slice before reverse so we don't mutate the caller's array — the
   // History dialog is intentionally side-effect-free.
   for (const rec of records.slice().reverse()) {
-    ul.appendChild(historyRow(rec, byId));
+    ul.appendChild(historyRow(rec, byId, onRestore));
   }
   return ul;
 }
 
-function historyRow(rec: AuditRecordView, byId: Map<string, AuditRecordView>): HTMLElement {
+function historyRow(
+  rec: AuditRecordView,
+  byId: Map<string, AuditRecordView>,
+  onRestore?: (rec: AuditRecordView) => void,
+): HTMLElement {
   const li = document.createElement("li");
   li.className = "history-row";
 
@@ -4491,6 +4526,20 @@ function historyRow(rec: AuditRecordView, byId: Map<string, AuditRecordView>): H
   ts.dateTime = date.toISOString();
   ts.textContent = date.toLocaleString();
   head.appendChild(ts);
+
+  // Restore-to-point affordance (#125). Offered on original-write rows
+  // only — the backend rejects targeting a `restore` entry, so a button
+  // there would just error.
+  if (onRestore && rec.kind !== "restore") {
+    const restoreBtn = document.createElement("button");
+    restoreBtn.type = "button";
+    restoreBtn.className = "history-restore-btn";
+    restoreBtn.textContent = "Restore";
+    restoreBtn.title = "Restore all affected files to their state before this entry";
+    restoreBtn.setAttribute("aria-label", `Restore to before ${historyVerbLabel(rec)}`);
+    restoreBtn.onclick = () => onRestore(rec);
+    head.appendChild(restoreBtn);
+  }
 
   li.appendChild(head);
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -20,10 +20,13 @@ import type {
   PathSeg,
   PermissionKind,
   Preferences,
+  RestorePreview,
+  RestoreSidePreview,
   RuntimeInfo,
   Scope,
   ScopeView,
   Theme,
+  UndoRedoStatus,
 } from "./types.ts";
 import { AUDIT_LOG_MAX_SIZE_MB, SCOPES, SEARCH_INPUT_ID } from "./types.ts";
 
@@ -46,6 +49,14 @@ interface AppProps {
    *  the picked path equals the currently-loaded project. */
   onPickRecentProject: (projectDir: string) => void;
   onReload: () => void;
+  /** Undo/redo availability for the topbar buttons (#124). `null` until the
+   *  first `audit_undo_status` IPC resolves; the buttons render disabled
+   *  until then. */
+  undoStatus: UndoRedoStatus | null;
+  /** Apply the next undo / redo (#124). main.ts fetches the preview,
+   *  routes it through the restore-confirm modal, then applies. */
+  onUndo: (trigger?: HTMLElement) => void;
+  onRedo: (trigger?: HTMLElement) => void;
   onMoveLeaf: (req: MoveLeafRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
   /** Reclassify a permission rule between allow / deny / ask within the
    *  same scope (#8). Routes through the move-leaf primitive on the
@@ -742,6 +753,56 @@ function buildRecentProjectMenuItems(props: AppProps): MenuItem[] {
   return items;
 }
 
+/** Coarse "3 min ago" relative time for the undo/redo button tooltips. */
+function relativeTime(tsMs: number): string {
+  const deltaSec = Math.round((Date.now() - tsMs) / 1000);
+  if (deltaSec < 45) return "just now";
+  const min = Math.round(deltaSec / 60);
+  if (min < 60) return `${min} min ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr} hr ago`;
+  const days = Math.round(hr / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+/** One-line description of an audit entry for a button tooltip, e.g.
+ *  "Move permission rule Bash(ls) (3 min ago)". */
+function recordTooltip(rec: AuditRecordView): string {
+  const rule = historyRuleText(rec);
+  const when = relativeTime(rec.ts_ms);
+  return rule ? `${historyVerbLabel(rec)} ${rule} (${when})` : `${historyVerbLabel(rec)} (${when})`;
+}
+
+function undoButton(props: AppProps): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.textContent = "Undo";
+  const target = props.undoStatus?.undo;
+  btn.disabled = props.busy || !props.scopes || !target;
+  btn.title = target ? `Undo: ${recordTooltip(target)}` : "Nothing to undo";
+  btn.setAttribute("aria-label", btn.title);
+  btn.onclick = (e) => props.onUndo(e.currentTarget as HTMLElement);
+  return btn;
+}
+
+function redoButton(props: AppProps): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.textContent = "Redo";
+  const status = props.undoStatus;
+  const target = status?.redo;
+  btn.disabled = props.busy || !props.scopes || !target;
+  if (target) {
+    btn.title = `Redo: ${recordTooltip(target)}`;
+  } else if (status?.sequence_break) {
+    // The forward stack is stranded — explain rather than just greying out.
+    btn.title = "Redo unavailable — a change was made after the last undo";
+  } else {
+    btn.title = "Nothing to redo";
+  }
+  btn.setAttribute("aria-label", btn.title);
+  btn.onclick = (e) => props.onRedo(e.currentTarget as HTMLElement);
+  return btn;
+}
+
 function header(props: AppProps): HTMLElement {
   const bar = document.createElement("header");
   bar.className = "topbar";
@@ -774,6 +835,9 @@ function header(props: AppProps): HTMLElement {
   reload.onclick = props.onReload;
   reload.disabled = props.busy || !props.scopes;
   actions.appendChild(reload);
+
+  actions.appendChild(undoButton(props));
+  actions.appendChild(redoButton(props));
 
   const history = document.createElement("button");
   history.textContent = "History";
@@ -2698,6 +2762,9 @@ function openConfirmModal(opts: {
   subtitle: Node;
   body: HTMLElement;
   trigger?: HTMLElement | null;
+  /** Label for the confirm button. Defaults to "Apply"; the restore modal
+   *  passes "Undo" / "Redo" / "Restore" so the button names the action. */
+  confirmLabel?: string;
 }): Promise<boolean> {
   return new Promise((resolve) => {
     let resolved = false;
@@ -2721,7 +2788,7 @@ function openConfirmModal(opts: {
           },
         },
         {
-          label: "Apply",
+          label: opts.confirmLabel ?? "Apply",
           className: "btn-apply",
           focus: true,
           activate: (close) => {
@@ -3463,6 +3530,158 @@ export function confirmAddLeaf(
     subtitle,
     body: diff,
     trigger,
+  });
+}
+
+// -- restore-confirm modal: undo / redo / restore-to-point (#124 / #125) -----
+
+function restoreModalTitle(direction: RestorePreview["direction"]): string {
+  switch (direction) {
+    case "undo":
+      return "Undo change";
+    case "redo":
+      return "Redo change";
+    case "to_point":
+      return "Restore to before this entry";
+  }
+}
+
+function restoreConfirmLabel(direction: RestorePreview["direction"]): string {
+  switch (direction) {
+    case "undo":
+      return "Undo";
+    case "redo":
+      return "Redo";
+    case "to_point":
+      return "Restore";
+  }
+}
+
+/** One labelled JSON block (Currently / After …) inside a restore side. */
+function restoreValueBlock(label: string, value: JsonValue | undefined): HTMLElement {
+  const wrap = document.createElement("div");
+  wrap.className = "modal-restore-block";
+  const head = document.createElement("div");
+  head.className = "modal-restore-block-label";
+  head.textContent = label;
+  wrap.appendChild(head);
+  const pre = document.createElement("pre");
+  pre.className = "modal-side-json";
+  pre.textContent = formatValue(value);
+  wrap.appendChild(pre);
+  return wrap;
+}
+
+/**
+ * One affected file in the restore modal. Snapshot-restore rewrites whole
+ * top-level keys, so this shows the key's current value vs. the value the
+ * restore will write — a JSON before/after rather than the chip-list diff
+ * the move/add/delete modals use, since a single restore can touch any key
+ * (and even multiple permission kinds at once).
+ */
+function restoreDiffSide(side: RestoreSidePreview): HTMLElement {
+  const col = document.createElement("div");
+  col.className = "modal-side modal-side-restore";
+
+  const head = document.createElement("div");
+  head.className = "modal-side-head";
+  const label = document.createElement("h3");
+  label.textContent = scopeLabel(side.scope);
+  head.appendChild(label);
+
+  const filePath = document.createElement("div");
+  filePath.className = "modal-side-path";
+  filePath.textContent = side.file_path;
+  head.appendChild(filePath);
+
+  const verdict = document.createElement("div");
+  verdict.className = "modal-side-verdict";
+  if (side.will_write) {
+    verdict.textContent = `${side.top_level_key} restored`;
+    verdict.classList.add("removed");
+  } else {
+    verdict.textContent = "(no change)";
+    verdict.classList.add("muted");
+  }
+  head.appendChild(verdict);
+  col.appendChild(head);
+
+  if (side.state_mismatch) {
+    const note = document.createElement("div");
+    note.className = "modal-side-note modal-side-note-warn";
+    note.textContent =
+      "This file was changed outside ClaudeScope since the logged entry — confirming overwrites that edit.";
+    col.appendChild(note);
+  }
+
+  if (side.will_write) {
+    col.appendChild(restoreValueBlock("Currently", side.key_current));
+    col.appendChild(restoreValueBlock("After", side.key_target));
+  } else {
+    col.appendChild(restoreValueBlock("Unchanged", side.key_current));
+  }
+  return col;
+}
+
+/**
+ * Confirm modal for an undo / redo / restore-to-point (#124 / #125).
+ * Resolves to whether the user applied the restore. Reuses the shared
+ * confirm-modal shell; the confirm button is labelled with the action
+ * ("Undo" / "Redo" / "Restore").
+ */
+export function confirmRestore(
+  preview: RestorePreview,
+  trigger?: HTMLElement | null,
+): Promise<boolean> {
+  // Subtitle: describe the targeted entry with the History view's helpers
+  // so the wording matches what the user sees in the History dialog.
+  const subtitle = document.createDocumentFragment();
+  subtitle.appendChild(document.createTextNode(historyVerbLabel(preview.target)));
+  const ruleText = historyRuleText(preview.target);
+  if (ruleText) {
+    subtitle.appendChild(document.createTextNode(" "));
+    const chip = document.createElement("code");
+    chip.className = "chip";
+    chip.textContent = ruleText;
+    subtitle.appendChild(chip);
+  }
+
+  const body = document.createElement("div");
+  body.className = "modal-restore";
+
+  if (preview.direction === "to_point") {
+    const span = document.createElement("p");
+    span.className = "modal-restore-span";
+    span.textContent =
+      preview.ops_spanned === 1
+        ? "Restoring to 1 op back."
+        : `Restoring to ${preview.ops_spanned} ops back.`;
+    body.appendChild(span);
+  }
+
+  // One warning band for the whole modal when any file drifted from what
+  // the log expected.
+  if (preview.sides.some((s) => s.state_mismatch)) {
+    const warn = document.createElement("div");
+    warn.className = "modal-warning-band";
+    warn.textContent =
+      "One or more files were changed outside ClaudeScope since this entry was logged. Confirming will overwrite those external edits.";
+    body.appendChild(warn);
+  }
+
+  const diff = document.createElement("div");
+  diff.className = "modal-diff modal-diff-restore";
+  for (const side of preview.sides) {
+    diff.appendChild(restoreDiffSide(side));
+  }
+  body.appendChild(diff);
+
+  return openConfirmModal({
+    titleText: restoreModalTitle(preview.direction),
+    subtitle,
+    body,
+    trigger,
+    confirmLabel: restoreConfirmLabel(preview.direction),
   });
 }
 
@@ -4227,15 +4446,17 @@ export function openHistory(page: AuditLogPage | null, trigger?: HTMLElement | n
 function historyList(records: AuditRecordView[]): HTMLElement {
   const ul = document.createElement("ul");
   ul.className = "history-list";
+  // Index by id so a restore row can name the entry it acted on.
+  const byId = new Map(records.map((r) => [r.id, r]));
   // Slice before reverse so we don't mutate the caller's array — the
   // History dialog is intentionally side-effect-free.
   for (const rec of records.slice().reverse()) {
-    ul.appendChild(historyRow(rec));
+    ul.appendChild(historyRow(rec, byId));
   }
   return ul;
 }
 
-function historyRow(rec: AuditRecordView): HTMLElement {
+function historyRow(rec: AuditRecordView, byId: Map<string, AuditRecordView>): HTMLElement {
   const li = document.createElement("li");
   li.className = "history-row";
 
@@ -4246,6 +4467,19 @@ function historyRow(rec: AuditRecordView): HTMLElement {
   verb.className = `history-verb history-verb-${rec.kind}`;
   verb.textContent = historyVerbLabel(rec);
   head.appendChild(verb);
+
+  // A restore row names the entry it inverted / re-applied, when that
+  // entry is still in the visible log.
+  if (rec.kind === "restore" && rec.restore) {
+    const target = byId.get(rec.restore.target_id);
+    if (target) {
+      const ref = document.createElement("span");
+      ref.className = "history-restore-ref";
+      const targetRule = historyRuleText(target);
+      ref.textContent = `· ${historyVerbLabel(target)}${targetRule ? ` ${targetRule}` : ""}`;
+      head.appendChild(ref);
+    }
+  }
 
   const ts = document.createElement("time");
   ts.className = "history-ts";
@@ -4285,6 +4519,21 @@ function historyRow(rec: AuditRecordView): HTMLElement {
  * fields visually.
  */
 function historyVerbLabel(rec: AuditRecordView): string {
+  if (rec.kind === "restore") {
+    // A restore meta-entry (#124): name the direction. The payload lives
+    // in `rec.restore`; a record missing it is malformed but shouldn't
+    // crash the row renderer.
+    switch (rec.restore?.direction) {
+      case "undo":
+        return "Undo";
+      case "redo":
+        return "Redo";
+      case "to_point":
+        return "Restore to point";
+      default:
+        return "Restore";
+    }
+  }
   if (rec.kind === "change_kind") {
     // Same-scope reclassification: name the destination kind explicitly
     // so the user sees the "what changed" at a glance.
@@ -4312,10 +4561,19 @@ function historyLeafNoun(leafKind: AuditRecordView["leaf_kind"]): string {
   }
 }
 
-/** "Project → User" arrow for moves, single-scope label for adds/deletes. */
+/** "Project → User" arrow for moves, single-scope label for adds/deletes,
+ *  the affected-scope list for a restore (which has no from/to sides). */
 function historyScopeArrow(rec: AuditRecordView): HTMLElement {
   const span = document.createElement("span");
   span.className = "history-scopes";
+  if (rec.kind === "restore") {
+    // A restore touches the files in `restore.files`; show their distinct
+    // scopes rather than the empty from/to arrow.
+    const scopes = rec.restore?.files.map((f) => f.scope) ?? [];
+    const distinct = scopes.filter((s, i) => scopes.indexOf(s) === i);
+    span.textContent = distinct.length > 0 ? distinct.map(scopeLabel).join(", ") : "—";
+    return span;
+  }
   const from = rec.from?.scope;
   const to = rec.to?.scope;
   if (from && to && from !== to) {
@@ -4355,20 +4613,27 @@ function scopeLabel(scope: Scope): string {
  * lie about what changed.
  */
 function historyRuleSummary(rec: AuditRecordView): HTMLElement | null {
+  const text = historyRuleText(rec);
+  return text ? makeRuleSpan(text) : null;
+}
+
+/**
+ * The rule string / key name an op touched, as plain text — the string
+ * form of [[historyRuleSummary]], also used for the undo/redo button
+ * tooltips. Returns `null` when no single identifier can be recovered.
+ */
+function historyRuleText(rec: AuditRecordView): string | null {
   if (rec.leaf_kind === "top_level_key") {
-    const key = typeof rec.path[0] === "string" ? rec.path[0] : null;
-    if (!key) return null;
-    return makeRuleSpan(key);
+    return typeof rec.path[0] === "string" ? rec.path[0] : null;
   }
-  // Permission rule or list. For a list op, the path[1] is the kind
+  // Permission rule or list. For a list op, path[1] is the kind
   // (allow/deny/ask) and that's the most informative summary.
   if (rec.leaf_kind === "permission_list") {
     const kind = typeof rec.path[1] === "string" ? rec.path[1] : null;
-    return kind ? makeRuleSpan(`permissions.${kind}`) : null;
+    return kind ? `permissions.${kind}` : null;
   }
   // PermissionRule: diff the snapshots to recover the rule string.
-  const rule = extractRuleFromDiff(rec);
-  return rule ? makeRuleSpan(rule) : null;
+  return extractRuleFromDiff(rec);
 }
 
 function makeRuleSpan(text: string): HTMLElement {

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -9,6 +9,7 @@ import type {
   Preferences,
   Scope,
   Theme,
+  UndoRedoStatus,
 } from "../../src/types.ts";
 import { SEARCH_INPUT_ID } from "../../src/types.ts";
 import {
@@ -54,6 +55,7 @@ interface PropsOverrides {
   preferences?: ReturnType<typeof buildPreferences>;
   runtime?: ReturnType<typeof buildRuntimeInfo>;
   knownProjects?: KnownProject[];
+  undoStatus?: UndoRedoStatus | null;
   onMoveLeaf?: (req: MoveLeafRequest, trigger?: HTMLElement, opts?: MoveOptions) => void;
   onPickProject?: () => void;
   onPickRecentProject?: (projectDir: string) => void;
@@ -76,10 +78,13 @@ function makeProps(overrides: PropsOverrides = {}) {
     preferences: overrides.preferences ?? buildPreferences(),
     runtime: overrides.runtime ?? buildRuntimeInfo(),
     knownProjects: overrides.knownProjects ?? [],
+    undoStatus: overrides.undoStatus ?? null,
     onPickProject: overrides.onPickProject ?? vi.fn(),
     onPickRecentProject: overrides.onPickRecentProject ?? vi.fn(),
     onOpenHistory: vi.fn(),
     onReload: vi.fn(),
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
     onMoveLeaf: overrides.onMoveLeaf ?? vi.fn(),
     onChangeKind: vi.fn(),
     onDeleteLeaf: vi.fn(),


### PR DESCRIPTION
Implements the **v0.6 — Audit log undo/redo/restore** milestone (#19 Phases 3-5) on one branch. All three feature issues are done.

Closes #124. Closes #125. Closes #126.

## Design note — snapshot-restore

#124 specified inverting an op into a reverse move/add/delete request and reusing `apply_*`. That isn't faithful when a move's destination already shared the rule (the reverse move would wrongly strip the destination's own copy). This branch uses **snapshot-restore**: a restore writes each affected file's top-level key back to a `key_before` snapshot the log already captured — faithful by construction, uniform across rules/lists/keys, and Phase 4 falls out as the same primitive over an aggregated delta. Full rationale in [a comment on #124](https://github.com/bminier/claude-scope/issues/124#issuecomment-4514289923).

## Phase 3 — undo / redo (#124)

- `Kind::Restore` + `RestoreMeta` (target id, direction, per-file snapshots) on the audit record; `undo_redo_state()` replays the append-only log into undoable / redoable + sequence-break detection.
- `RestorePlan` with atomic N-file write + full rollback; state-mismatch detection against the log's expected value.
- Commands: `audit_undo_status` / `audit_undo_preview` / `audit_redo_preview` / `audit_apply_undo` / `audit_apply_redo` (apply verifies the target id so a concurrent write can't redirect a confirmed restore).
- Undo / Redo topbar buttons + tooltips, `Ctrl/Cmd+Z` / `Ctrl/Cmd+Shift+Z`, restore-confirm modal with the external-edit warning band, History rendering for `restore` entries.

## Phase 4 — restore-to-point (#125)

- `plan_restore_to()` walks the log forward from the target to HEAD, aggregating a per-file delta; rejects an unknown target or a restore-entry target.
- Commands `audit_restore_to_point_preview` / `audit_apply_restore_to_point` (apply verifies `expected_ops_spanned`).
- A "Restore" button on each original-write History row; the History dialog closes itself (new `openModal` `onReady` hook) before the confirm modal opens.

## Phase 5 — CLI (#126)

- `claude-scope-cli undo / redo / restore <id>` wrapping the same helpers. `--dry-run` / `--yes` / `--json`; ULID-prefix resolution for `restore`; `redo` exits non-zero after a sequence break. CLI restores log `actor: cli` so a GUI session sees them.

## Docs

README, mdbook (`undo-redo` / `cli` / `audit-log`), and `SMOKE_TEST.md` synced.

## Tests

279 Rust tests (238 lib + 26 cli + 15 bin) + 120 frontend tests pass; clippy clean, `tsc` clean, biome clean. Verified end-to-end via the CLI against a crafted audit log (undo dry-run/apply, restore-entry logging). Undo/redo aren't exercisable in sandbox mode (the audit log is deliberately not written under `--home`), so a GUI run-through against a real `~/.claude` is left for manual verification before merge — see the new non-sandbox section in `SMOKE_TEST.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)