### PR TITLE
fix: v0.6 release-gate blockers — audit log atomicity + CLI parity (#163-#171)

### DIFF
--- a/docs/src/architecture/audit-log.md
+++ b/docs/src/architecture/audit-log.md
@@ -120,22 +120,51 @@ succeeds, so a failure here means the file is updated but not
 logged — which is the safe direction for ambiguity.
 
 Tauri emits an `audit-error` event when an append fails, surfaced as
-a non-fatal warning in the GUI.
+a non-fatal warning in the GUI; the CLI prints the same information
+to stderr.
 
-## Rotation
+## Rotation and concurrency (#166)
 
-Once `audit.jsonl` exceeds the configurable size cap (default
-10 MB), `rotate_if_needed` runs before the next append. The active
-file is renamed to `audit-YYYY-MM.jsonl` (using the file's mtime, so
-the stamp reflects the data inside) and the next entry lands in a
-fresh `audit.jsonl`. Same-month collisions become `-2`, `-3`, ...
-suffixes.
+Two ClaudeScope sessions can target the same audit log — a GUI plus a
+CLI invocation, two CLI invocations in different shells, or a Claude
+Code skill driving the CLI alongside an open GUI. The rotation +
+append sequence has to behave correctly under that interleaving.
 
-The reader **only scans the active file**. Archives are archival —
-the History dialog and `claude-scope-cli history` don't surface
-them. Undo / redo and restore-to-point are bounded to the active log
-for the same reason; restoring across an archive boundary would be a
-separate feature.
+**Cross-process lock.** Every rotate-then-append pair runs inside
+`audit::persist`, which holds an advisory exclusive lock on
+`<audit_dir>/audit.lock` for the duration. `fs2` provides the
+cross-platform primitive (`flock` on POSIX, `LockFileEx` on
+Windows). Two processes both arriving with the active log near the
+cap serialize on the lock: the first rotates and appends to a fresh
+active file; the second waits, sees the active file is fresh
+(under cap, no rotation needed), and appends to the same fresh
+file.
+
+**Archive-aware reads.** Even with the lock, `audit.jsonl` may have
+been rotated into `audit-YYYY-MM.jsonl` between two appends — that's
+the normal-case behavior under rotation, not a bug. `audit::read_all`
+therefore enumerates every `audit-*.jsonl` archive in the directory,
+reads them in filename order (which is chronological — the naming
+encodes `YYYY-MM` plus collision suffix), then reads the active log,
+and returns the concatenated record stream. Undo / redo / history
+all see every persisted record regardless of which file it lives in.
+
+**File naming.** The active log is `audit.jsonl`. The first
+rotation lands at `audit-YYYY-MM.jsonl` using the file's mtime so
+the stamp reflects the data inside. Same-month collisions become
+`audit-YYYY-MM-2.jsonl`, `audit-YYYY-MM-3.jsonl`, … — the lex order
+of those filenames also matches chronological order, so the
+archive enumeration above stays sorted without timestamp parsing.
+
+**Cap.** Default 10 MB, configurable under Settings → Audit log
+rotation. The cap is on the **active** file's size; archives can
+grow unbounded across history.
+
+**Restore across archives.** Phase 4 (`plan_restore_to`) builds its
+window from `audit::read_all`, which now spans archives. Restoring
+to a point that lives in an archive works the same way as restoring
+to a point in the active log — same `record_sides` walk, same per-
+file snapshot revert.
 
 ## Sandbox
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -435,6 +435,7 @@ version = "0.3.1"
 dependencies = [
  "clap",
  "dirs",
+ "fs2",
  "notify-debouncer-mini",
  "serde",
  "serde_json",
@@ -1029,6 +1030,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,9 @@ tempfile = "3"
 notify-debouncer-mini = "0.7"
 clap = { version = "4", features = ["derive"] }
 ulid = { version = "1", features = ["serde"] }
+# Cross-process file lock around audit-log rotate+append (#166). Both
+# Windows (LockFileEx) and POSIX (flock) advisory locks via one API.
+fs2 = "0.4"
 
 [features]
 # By default Tauri runs in production mode.

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -475,6 +475,19 @@ impl Drop for AuditLock {
 /// alongside the records so a caller can surface "N entries unreadable"
 /// rather than silently swallowing data.
 pub fn read_all(home: Option<&Path>) -> io::Result<(Vec<Record>, usize)> {
+    // Hold the same advisory lock writers take in `persist`, so a
+    // rotation can't slip between our archive enumeration and the
+    // active-log read (codex second-pass [P2]). A rotation that lands
+    // in that window would rename the active file into an archive that
+    // wasn't in our enumerated list — the record would be invisible to
+    // this call until the next read. Holding the lock keeps the
+    // archives+active pair consistent.
+    //
+    // The lock is best-effort: if it can't be acquired (no home dir,
+    // permission error), we fall through to an unlocked read. That's
+    // the same fail-open posture writers take.
+    let _lock = AuditLock::acquire(home).ok().flatten();
+
     let mut records = Vec::new();
     let mut skipped = 0usize;
     for archive in audit_archives(home)? {
@@ -521,8 +534,51 @@ fn audit_archives(home: Option<&Path>) -> io::Result<Vec<PathBuf>> {
             archives.push(path);
         }
     }
-    archives.sort();
+    // Sort by (year-month, collision-suffix-as-integer) instead of pure
+    // lexicographic. Plain lex order puts `audit-2026-05-10.jsonl`
+    // *before* `audit-2026-05-2.jsonl`, which would replay records out
+    // of causal order once ten same-month rotations land. Parsing the
+    // suffix numerically keeps history monotonic.
+    archives.sort_by_cached_key(|p| {
+        let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        archive_sort_key(name)
+    });
     Ok(archives)
+}
+
+/// Sort key for an `audit-YYYY-MM[-N].jsonl` archive filename:
+/// `(YYYY-MM string, N as integer)`. The base archive (no suffix)
+/// sorts as `N=1` so it comes before any collision suffix
+/// (`audit-YYYY-MM-2.jsonl` and beyond). Names that don't match the
+/// pattern fall to the end with `N=u32::MAX`, which keeps them
+/// deterministic without claiming they were chronologically first.
+fn archive_sort_key(name: &str) -> (String, u32) {
+    // Strip the `audit-` prefix and `.jsonl` suffix; what's left is
+    // either `YYYY-MM` or `YYYY-MM-N`.
+    let stem = name
+        .strip_prefix("audit-")
+        .and_then(|s| s.strip_suffix(".jsonl"))
+        .unwrap_or("");
+    // Try `YYYY-MM-N` first: split on the LAST `-` and parse the tail.
+    if let Some((head, tail)) = stem.rsplit_once('-') {
+        if let Ok(n) = tail.parse::<u32>() {
+            // Tail parsed as a number — but only treat it as a
+            // collision suffix when the head still looks like
+            // `YYYY-MM` (7 chars, digits + one dash). Otherwise the
+            // whole stem is a bare year-month with a hyphen inside
+            // (e.g. `2026-05`).
+            if head.len() == 7 && head.as_bytes().get(4) == Some(&b'-') {
+                return (head.to_string(), n);
+            }
+        }
+    }
+    // Bare `YYYY-MM` form — treat as collision index 1 so it sorts
+    // before the `-2`, `-3`, … siblings.
+    if stem.len() == 7 && stem.as_bytes().get(4) == Some(&b'-') {
+        return (stem.to_string(), 1);
+    }
+    // Unrecognized shape; park at the end deterministically.
+    (stem.to_string(), u32::MAX)
 }
 
 /// Read records + skipped count from a single audit-log file. Factored
@@ -1424,6 +1480,43 @@ mod tests {
                 "spawned record {id:?} not retrievable from read_all"
             );
         }
+    }
+
+    #[test]
+    fn archive_sort_key_orders_collision_suffixes_numerically() {
+        // Regression for codex 2nd-pass [P2]: lex sort puts
+        // `audit-2026-05-10.jsonl` before `audit-2026-05-2.jsonl`,
+        // which would replay records out of causal order with ten or
+        // more same-month rotations. The numeric-suffix key fixes it.
+        let mut names = vec![
+            "audit-2026-05-10.jsonl",
+            "audit-2026-05.jsonl",
+            "audit-2026-05-2.jsonl",
+            "audit-2026-04.jsonl",
+            "audit-2026-05-9.jsonl",
+            "audit-2026-05-11.jsonl",
+        ];
+        names.sort_by_cached_key(|n| archive_sort_key(n));
+        assert_eq!(
+            names,
+            vec![
+                "audit-2026-04.jsonl",   // older month first
+                "audit-2026-05.jsonl",   // base file (suffix 1)
+                "audit-2026-05-2.jsonl", // then numeric suffixes …
+                "audit-2026-05-9.jsonl",
+                "audit-2026-05-10.jsonl", // -10 sorts AFTER -9, not before -2
+                "audit-2026-05-11.jsonl",
+            ]
+        );
+    }
+
+    #[test]
+    fn archive_sort_key_parks_unknown_shapes_deterministically() {
+        // Unrecognized shapes still need a stable position. Park them
+        // at the end via u32::MAX rather than mixing with parseable
+        // archives.
+        let key = archive_sort_key("audit-garbage.jsonl");
+        assert_eq!(key.1, u32::MAX);
     }
 
     #[test]

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -335,6 +335,12 @@ pub enum AppendError {
 /// taken at write time, so two ClaudeScope processes racing to log don't
 /// interleave bytes — they get sequential lines in *some* order, which is
 /// the same property we need for the in-process single-process case.
+///
+/// Note: `append` itself does NOT take the rotate/append lock. Production
+/// callers route through [`persist`] which holds the lock around the
+/// rotate-then-append pair (#166). Direct `append` callers are the
+/// truncated-tail-tolerance tests and the malformed-line injection in
+/// the CLI integration tests, where the bypass is intentional.
 pub fn append(record: &Record, home: Option<&Path>) -> Result<(), AppendError> {
     let path = audit_path(home).ok_or(AppendError::NoLocation)?;
     if let Some(parent) = path.parent() {
@@ -347,21 +353,183 @@ pub fn append(record: &Record, home: Option<&Path>) -> Result<(), AppendError> {
     Ok(())
 }
 
-/// Read every well-formed record from the audit log, in file order. A
-/// truncated tail line (no terminating newline AND a parse error) is
+/// Options for [`persist`]. `rotate_cap_bytes` is `Some(_)` to attempt a
+/// rotation before the append when the active log exceeds the cap; `None`
+/// to skip rotation entirely.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PersistOptions {
+    pub rotate_cap_bytes: Option<u64>,
+}
+
+/// Outcome of [`persist`]: rotation and append errors are reported
+/// separately so callers can surface them in their idiomatic way.
+#[derive(Debug, Default)]
+pub struct PersistResult {
+    pub rotate_error: Option<String>,
+    pub append_error: Option<AppendError>,
+}
+
+/// Persist `record` to the audit log under `home`, optionally rotating
+/// first when the active log is over `rotate_cap_bytes`.
+///
+/// The whole operation runs under an advisory file lock at
+/// `<audit_dir>/audit.lock`. The lock closes the rotate-then-append race
+/// (#166): without it, two processes can race such that one rotates the
+/// active log into an archive while the other is mid-append, leaving the
+/// fresh record stranded in the archive where [`read_all`] would have
+/// missed it pre-fix. With the lock and the now-archive-aware
+/// [`read_all`], records are durable and reachable from the undo/redo
+/// state machine regardless of how rotations interleave with writes.
+///
+/// Rotation failure is non-fatal — the append still proceeds against the
+/// over-cap log, which is better than dropping the record. Append failure
+/// is returned in the result; callers (GUI / CLI) surface it as a
+/// warning, not a hard error, because the on-disk operation that
+/// triggered the audit (the move / add / delete itself) has already
+/// succeeded.
+pub fn persist(record: &Record, home: Option<&Path>, options: PersistOptions) -> PersistResult {
+    let _lock = AuditLock::acquire(home).ok().flatten();
+    let mut result = PersistResult::default();
+    if let Some(cap_bytes) = options.rotate_cap_bytes {
+        if let Err(err) = rotate_if_needed(home, cap_bytes) {
+            result.rotate_error = Some(format!("rotation: {err}"));
+        }
+    }
+    if let Err(err) = append(record, home) {
+        result.append_error = Some(err);
+    }
+    result
+}
+
+/// Path to the cross-process advisory lock file. Lives alongside
+/// `audit.jsonl` so the lock semantically protects the log directory.
+fn audit_lock_path(home: Option<&Path>) -> Option<PathBuf> {
+    audit_path(home).and_then(|p| p.parent().map(|parent| parent.join("audit.lock")))
+}
+
+/// RAII guard for the audit-log advisory lock. Acquired around
+/// rotate-then-append in [`persist`] so two processes can't interleave a
+/// rotation with another process's append. The lock is `fs2`'s advisory
+/// flock (`LockFileEx` on Windows, `flock` on POSIX) — released when the
+/// guard drops, or when the process exits even after a crash (the kernel
+/// reclaims advisory locks on file-handle close).
+struct AuditLock(std::fs::File);
+
+impl AuditLock {
+    /// Open (creating if needed) the lock file and take an exclusive
+    /// lock. Returns `None` when the audit location is unavailable
+    /// (no home dir) — the caller falls open just like the legacy
+    /// `append` did, so audit failures never block the primary write.
+    fn acquire(home: Option<&Path>) -> io::Result<Option<Self>> {
+        let Some(path) = audit_lock_path(home) else {
+            return Ok(None);
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        // Lock file is content-irrelevant — flock semantics don't care
+        // about bytes. `.truncate(false)` keeps any stray bytes alone
+        // (which is fine, we never read it) and silences clippy's
+        // "no truncate spec on write open" warning.
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)?;
+        // Blocking exclusive lock — both POSIX and Windows. For the
+        // millisecond-scale rotate+append, blocking is fine; if a
+        // crashed process held the lock the kernel would have released
+        // it.
+        fs2::FileExt::lock_exclusive(&file)?;
+        Ok(Some(AuditLock(file)))
+    }
+}
+
+impl Drop for AuditLock {
+    fn drop(&mut self) {
+        // Best-effort. If unlock fails, dropping the file handle still
+        // releases the kernel lock on exit. Don't panic in Drop.
+        let _ = fs2::FileExt::unlock(&self.0);
+    }
+}
+
+/// Read every well-formed record from the audit log, merging the active
+/// log with any rotated archives (`audit-YYYY-MM.jsonl`, plus collision
+/// suffixes) in the same directory. Archives come first, in filename
+/// order (which encodes `YYYY-MM` plus collision suffix — older archives
+/// sort first), then the active log. Within each file, records are
+/// returned in append order — the file's own ordering, not re-sorted by
+/// ULID, because file order IS the causal record of what happened.
+///
+/// Archive-aware reads close half of the rotate/append race (#166):
+/// even if a record lands in what becomes an archive (a slow append
+/// racing a rotation), [`read_all`] still finds it. The other half is
+/// the lock held by [`persist`] which makes the race extremely narrow
+/// in the first place.
+///
+/// A truncated tail line (no terminating newline AND a parse error) is
 /// silently skipped — that's the partial-write tolerance property. A
 /// well-formed line that fails parse (e.g. a future schema field this
-/// build doesn't understand strictly) is also skipped, with the count of
-/// skipped lines returned alongside the records so a caller can surface
-/// "N entries unreadable" rather than silently swallowing data.
-///
-/// Phase 1 callers only need the count for telemetry; the Phase 2 History
-/// view will use the records themselves.
+/// build doesn't understand strictly) is also skipped, with the count
+/// of skipped lines (summed across archives + active) returned
+/// alongside the records so a caller can surface "N entries unreadable"
+/// rather than silently swallowing data.
 pub fn read_all(home: Option<&Path>) -> io::Result<(Vec<Record>, usize)> {
-    let Some(path) = audit_path(home) else {
-        return Ok((Vec::new(), 0));
+    let mut records = Vec::new();
+    let mut skipped = 0usize;
+    for archive in audit_archives(home)? {
+        let (recs, skip) = read_log_file(&archive)?;
+        records.extend(recs);
+        skipped += skip;
+    }
+    if let Some(active) = audit_path(home) {
+        let (recs, skip) = read_log_file(&active)?;
+        records.extend(recs);
+        skipped += skip;
+    }
+    Ok((records, skipped))
+}
+
+/// Enumerate `audit-*.jsonl` files in the audit directory (the rotation
+/// archives — see [`rotate_if_needed`]), sorted lexicographically by
+/// filename so older archives come first. The archive naming scheme
+/// (`audit-YYYY-MM[-N].jsonl`) makes lex order match chronological
+/// order for both the main per-month files and the within-month
+/// collision suffixes. Returns an empty vec if the directory doesn't
+/// exist; the caller treats that as "no archives."
+fn audit_archives(home: Option<&Path>) -> io::Result<Vec<PathBuf>> {
+    let Some(active) = audit_path(home) else {
+        return Ok(Vec::new());
     };
-    let file = match std::fs::File::open(&path) {
+    let Some(parent) = active.parent() else {
+        return Ok(Vec::new());
+    };
+    if !parent.exists() {
+        return Ok(Vec::new());
+    }
+    let mut archives = Vec::new();
+    for entry in std::fs::read_dir(parent)? {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        // Match `audit-*.jsonl` exactly — and skip the active log itself
+        // (which is `audit.jsonl`, no dash) since the caller reads it
+        // separately.
+        if name.starts_with("audit-") && name.ends_with(".jsonl") {
+            archives.push(path);
+        }
+    }
+    archives.sort();
+    Ok(archives)
+}
+
+/// Read records + skipped count from a single audit-log file. Factored
+/// out so [`read_all`] can apply the same parse-tolerance behavior to
+/// both the active log and each archive.
+fn read_log_file(path: &Path) -> io::Result<(Vec<Record>, usize)> {
+    let file = match std::fs::File::open(path) {
         Ok(f) => f,
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok((Vec::new(), 0)),
         Err(e) => return Err(e),
@@ -1140,15 +1308,23 @@ mod tests {
     }
 
     #[test]
-    fn read_all_ignores_rotated_archives() {
-        // After rotation the active file is fresh; an immediate read_all
-        // returns nothing. The reader deliberately doesn't scan archives —
-        // that's the "active file is authoritative" property the
-        // History UI binds to.
+    fn read_all_merges_active_log_with_rotated_archives() {
+        // After rotation the active file is fresh, but read_all is
+        // archive-aware as of #166 — records that landed in archives
+        // remain reachable so undo/redo/history don't lose entries to
+        // a rotation that interleaved with a write.
         let tmp = TempDir::new().unwrap();
+        // Seed three records into the active log…
+        let mut expected_ids = Vec::new();
         for _ in 0..3 {
-            append(&sample_record(), Some(tmp.path())).unwrap();
+            let rec = sample_record();
+            expected_ids.push(rec.id);
+            append(&rec, Some(tmp.path())).unwrap();
+            // Sleep a hair so each ULID's timestamp portion differs —
+            // makes the sort assertion meaningful.
+            std::thread::sleep(std::time::Duration::from_millis(2));
         }
+        // …then rotate them into an archive.
         let cap = fs::metadata(audit_path(Some(tmp.path())).unwrap())
             .unwrap()
             .len()
@@ -1157,16 +1333,97 @@ mod tests {
 
         let (records, skipped) = read_all(Some(tmp.path())).unwrap();
         assert_eq!(skipped, 0);
-        assert!(
-            records.is_empty(),
-            "active file is freshly empty after rotation"
+        assert_eq!(
+            records.len(),
+            3,
+            "archived records must remain reachable from read_all (#166)"
+        );
+        let got_ids: Vec<_> = records.iter().map(|r| r.id).collect();
+        assert_eq!(
+            got_ids, expected_ids,
+            "archived records must come back in append order"
         );
 
-        // A subsequent append lands in the new active file, not in the
-        // archive.
-        append(&sample_record(), Some(tmp.path())).unwrap();
+        // A subsequent append lands in the new active file. read_all
+        // returns the archive's 3 first, then the new 1 — archives
+        // before active, file-order within each.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let post_rotation = sample_record();
+        let post_id = post_rotation.id;
+        append(&post_rotation, Some(tmp.path())).unwrap();
+
         let (records, _) = read_all(Some(tmp.path())).unwrap();
-        assert_eq!(records.len(), 1);
+        assert_eq!(records.len(), 4);
+        assert_eq!(
+            records.last().map(|r| r.id),
+            Some(post_id),
+            "the post-rotation record must come after the archived ones"
+        );
+    }
+
+    #[test]
+    fn persist_concurrent_threads_lose_no_records_across_rotation() {
+        // Regression for #166. Multiple threads call `persist` with the
+        // active log near the rotation cap. Without the lock, one thread
+        // can rotate the log while another's append is in flight,
+        // potentially stranding the racer's record in the archive (and
+        // pre-fix `read_all` would never see it). With the lock + the
+        // now-archive-aware `read_all`, every record persisted must be
+        // retrievable.
+        use std::sync::Arc;
+        use std::thread;
+
+        let tmp = Arc::new(TempDir::new().unwrap());
+
+        // Seed a few records so the log has size, then pick a cap just
+        // below the current size so the first persist triggers a
+        // rotation.
+        for _ in 0..5 {
+            append(&sample_record(), Some(tmp.path())).unwrap();
+        }
+        let seeded_len = fs::metadata(audit_path(Some(tmp.path())).unwrap())
+            .unwrap()
+            .len();
+        let cap = seeded_len - 1;
+
+        let n_threads = 8;
+        let mut handles = Vec::new();
+        for _ in 0..n_threads {
+            let tmp = Arc::clone(&tmp);
+            handles.push(thread::spawn(move || {
+                let rec = sample_record();
+                let id = rec.id;
+                let options = PersistOptions {
+                    rotate_cap_bytes: Some(cap),
+                };
+                let result = persist(&rec, Some(tmp.path()), options);
+                assert!(
+                    result.append_error.is_none(),
+                    "concurrent append must not fail: {:?}",
+                    result.append_error
+                );
+                id
+            }));
+        }
+        let mut spawned_ids: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        spawned_ids.sort();
+
+        let (records, skipped) = read_all(Some(tmp.path())).unwrap();
+        assert_eq!(skipped, 0);
+        // Every record we persisted must be reachable — the 5 seeded
+        // plus the 8 concurrent appends, regardless of which file each
+        // landed in.
+        assert_eq!(
+            records.len(),
+            5 + n_threads,
+            "lost records under concurrent rotate+append (#166)"
+        );
+        for id in &spawned_ids {
+            assert!(
+                records.iter().any(|r| r.id == *id),
+                "spawned record {id:?} not retrievable from read_all"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -19,8 +19,8 @@ use claude_scope_lib::audit::{self, Record as AuditRecord};
 use claude_scope_lib::commands::{
     apply_move_leaf_impl, apply_restore_plan, audit_leaf_kind, audit_side, build_loaded,
     build_restore_plan, diff_move_leaf_impl, persist_audit_record, plan_restore_to,
-    preview_restore_plan, restore_record, snapshot_top_level_key, AuditLogPage, AuditRecordView,
-    MoveLeafPreview, MoveLeafRequest, RestorePlan, RestorePreview,
+    preview_restore_plan, restore_record, AuditLogPage, AuditRecordView, MoveLeafPreview,
+    MoveLeafRequest, RestorePlan, RestorePreview,
 };
 use claude_scope_lib::io_atomic::{self, BackupTracker};
 use claude_scope_lib::model::{PathSeg, PermissionKind};
@@ -732,40 +732,19 @@ fn cmd_move(
         return Ok(());
     }
 
-    // Pre-snapshot the affected top-level key on both sides so the audit
-    // record can carry a faithful before/after. Mirrors the GUI's
-    // `apply_move_leaf` flow at commands.rs — see #164.
+    // The impl returns before/after values captured from its own
+    // load_with_stamp — closing the race window a separate pre-snapshot
+    // at this boundary would leave open against a third-party writer
+    // (#169). Mirrors the GUI's `apply_move_leaf`.
     let top_key = "permissions";
     let from_file = paths.path_for(from).map(Path::to_path_buf);
     let to_file = paths.path_for(to).map(Path::to_path_buf);
-    let from_before = from_file
-        .as_deref()
-        .and_then(|p| snapshot_top_level_key(p, top_key));
-    let to_before = if from == to {
-        from_before.clone()
-    } else {
-        to_file
-            .as_deref()
-            .and_then(|p| snapshot_top_level_key(p, top_key))
-    };
-
-    apply_move_leaf_impl(
+    let outcome = apply_move_leaf_impl(
         paths,
         &req,
         cli_backups_for_session(),
         &WatchState::default(),
     )?;
-
-    let from_after = from_file
-        .as_deref()
-        .and_then(|p| snapshot_top_level_key(p, top_key));
-    let to_after = if from == to {
-        from_after.clone()
-    } else {
-        to_file
-            .as_deref()
-            .and_then(|p| snapshot_top_level_key(p, top_key))
-    };
 
     // Build and persist the audit record. CLI move is always
     // `Kind::Move` today — no change-kind path is exposed at the
@@ -779,15 +758,21 @@ fn cmd_move(
             req.from,
             from_file.as_deref(),
             top_key,
-            from_before,
-            from_after,
+            outcome.from_before,
+            outcome.from_after,
         ),
-        audit_side(req.to, to_file.as_deref(), top_key, to_before, to_after),
+        audit_side(
+            req.to,
+            to_file.as_deref(),
+            top_key,
+            outcome.to_before,
+            outcome.to_after,
+        ),
         req.path.clone(),
         req.to_kind,
     );
-    let outcome = persist_audit_record(&record, home);
-    report_audit_persist(outcome, "move");
+    let persist_result = persist_audit_record(&record, home);
+    report_audit_persist(persist_result, "move");
 
     if json {
         let out = json!({

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -816,11 +816,28 @@ fn read_audit_log(
     home: Option<&std::path::Path>,
 ) -> Result<Vec<AuditRecord>, Box<dyn std::error::Error>> {
     let (records, skipped) = audit::read_all(home)?;
+    // Undo/redo/restore refuse against a partial log: a corrupt restore
+    // line could leave the state machine pointing at an op that's
+    // already undone, and confirming would emit a duplicate restore
+    // entry. The GUI's `audit_undo_status` returns the same signal as
+    // `skipped` and disables the topbar buttons. See #170.
     if skipped > 0 {
-        eprintln!(
-            "note: {skipped} unreadable {} skipped in the log",
-            if skipped == 1 { "entry" } else { "entries" }
-        );
+        return Err(format!(
+            "{skipped} audit-log {} unreadable — refusing to compute \
+             undo/redo against a partial log. Repair {} (or copy aside \
+             and reset) before running undo/redo/restore.",
+            if skipped == 1 {
+                "entry is"
+            } else {
+                "entries are"
+            },
+            if skipped == 1 {
+                "the entry"
+            } else {
+                "those entries"
+            }
+        )
+        .into());
     }
     Ok(records)
 }

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -5,8 +5,9 @@
 //! binary call the same impl functions, so the two surfaces can't drift on
 //! semantics.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::sync::OnceLock;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use serde::Serialize;
@@ -16,15 +17,45 @@ use ulid::Ulid;
 use claude_scope_lib::app_info::AppInfo;
 use claude_scope_lib::audit::{self, Record as AuditRecord};
 use claude_scope_lib::commands::{
-    apply_move_leaf_impl, apply_restore_plan, build_loaded, build_restore_plan,
-    diff_move_leaf_impl, plan_restore_to, preview_restore_plan, restore_record, AuditLogPage,
-    AuditRecordView, MoveLeafPreview, MoveLeafRequest, RestorePlan, RestorePreview,
+    apply_move_leaf_impl, apply_restore_plan, audit_leaf_kind, audit_side, build_loaded,
+    build_restore_plan, diff_move_leaf_impl, persist_audit_record, plan_restore_to,
+    preview_restore_plan, restore_record, snapshot_top_level_key, AuditLogPage, AuditRecordView,
+    MoveLeafPreview, MoveLeafRequest, RestorePlan, RestorePreview,
 };
 use claude_scope_lib::io_atomic::{self, BackupTracker};
 use claude_scope_lib::model::{PathSeg, PermissionKind};
+use claude_scope_lib::preferences;
 use claude_scope_lib::projects::{self, KnownProject};
 use claude_scope_lib::scope::{self, Scope, ScopePaths};
 use claude_scope_lib::watcher::WatchState;
+
+/// Process-local backup tracker for the CLI. Same role as the GUI's
+/// `BACKUPS`: one `.bak` per file per process. The CLI process is
+/// short-lived (one subcommand per invocation), so the tracker exists
+/// mostly to share state if a single command writes multiple files (e.g.
+/// a restore plan spanning project + user). Gated on
+/// `Preferences::backup_on_write` so a `false` setting from the GUI
+/// Settings dialog is honored from the terminal too — see #168.
+fn cli_backups_for_session() -> Option<&'static BackupTracker> {
+    static BACKUPS: OnceLock<BackupTracker> = OnceLock::new();
+    if preferences::load().backup_on_write {
+        Some(BACKUPS.get_or_init(BackupTracker::new))
+    } else {
+        None
+    }
+}
+
+/// Surface the outcome of an audit-log persist to stderr the same way
+/// the GUI emits Tauri events. Append failures are warnings, not hard
+/// errors — the on-disk operation already succeeded.
+fn report_audit_persist(outcome: claude_scope_lib::commands::AuditPersistResult, op: &str) {
+    if let Some(err) = outcome.rotate_error {
+        eprintln!("warning: {op} applied but {err}");
+    }
+    if let Some(err) = outcome.append_error {
+        eprintln!("warning: {op} applied but audit-log append failed: {err}");
+    }
+}
 
 #[derive(Debug, Parser)]
 #[command(
@@ -365,7 +396,16 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             to,
             dry_run,
             json,
-        } => cmd_move(&paths, &rule, kind, from.into(), to.into(), dry_run, json),
+        } => cmd_move(
+            &paths,
+            cli.home_dir.as_deref(),
+            &rule,
+            kind,
+            from.into(),
+            to.into(),
+            dry_run,
+            json,
+        ),
     }
 }
 
@@ -641,8 +681,10 @@ fn cmd_version(json: bool) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_move(
     paths: &ScopePaths,
+    home: Option<&Path>,
     rule: &str,
     kind: KindArg,
     from: Scope,
@@ -690,12 +732,62 @@ fn cmd_move(
         return Ok(());
     }
 
+    // Pre-snapshot the affected top-level key on both sides so the audit
+    // record can carry a faithful before/after. Mirrors the GUI's
+    // `apply_move_leaf` flow at commands.rs — see #164.
+    let top_key = "permissions";
+    let from_file = paths.path_for(from).map(Path::to_path_buf);
+    let to_file = paths.path_for(to).map(Path::to_path_buf);
+    let from_before = from_file
+        .as_deref()
+        .and_then(|p| snapshot_top_level_key(p, top_key));
+    let to_before = if from == to {
+        from_before.clone()
+    } else {
+        to_file
+            .as_deref()
+            .and_then(|p| snapshot_top_level_key(p, top_key))
+    };
+
     apply_move_leaf_impl(
         paths,
         &req,
-        Some(&BackupTracker::new()),
+        cli_backups_for_session(),
         &WatchState::default(),
     )?;
+
+    let from_after = from_file
+        .as_deref()
+        .and_then(|p| snapshot_top_level_key(p, top_key));
+    let to_after = if from == to {
+        from_after.clone()
+    } else {
+        to_file
+            .as_deref()
+            .and_then(|p| snapshot_top_level_key(p, top_key))
+    };
+
+    // Build and persist the audit record. CLI move is always
+    // `Kind::Move` today — no change-kind path is exposed at the
+    // command line (#8 is GUI-only).
+    let record = audit::Record::new(
+        audit::Kind::Move,
+        audit_leaf_kind(&req.path),
+        audit::Actor::Cli,
+        None,
+        audit_side(
+            req.from,
+            from_file.as_deref(),
+            top_key,
+            from_before,
+            from_after,
+        ),
+        audit_side(req.to, to_file.as_deref(), top_key, to_before, to_after),
+        req.path.clone(),
+        req.to_kind,
+    );
+    let outcome = persist_audit_record(&record, home);
+    report_audit_persist(outcome, "move");
 
     if json {
         let out = json!({
@@ -818,10 +910,17 @@ fn resolve_entry_id(
 
 /// Shared driver for `undo` / `redo` / `restore`: preview, optionally
 /// confirm, apply, and log the resulting `restore` entry (actor `cli`).
+///
+/// `expected_tail_id` is the ULID of the last audit-log record the caller
+/// saw when building the plan. After the confirm prompt — the only window
+/// where another process can append an entry — the log is re-read and the
+/// new tail compared against `expected_tail_id`. A mismatch means the
+/// plan is stale; abort instead of applying it (#165).
 fn run_cli_restore(
     home: Option<&std::path::Path>,
     plan: &RestorePlan,
     target: &AuditRecord,
+    expected_tail_id: Option<Ulid>,
     dry_run: bool,
     yes: bool,
     json: bool,
@@ -847,14 +946,25 @@ fn run_cli_restore(
             }
             return Ok(());
         }
+        // Re-read the log right after the prompt to catch a concurrent
+        // append from another GUI/CLI session that landed during the
+        // user's confirm window. The plan was computed against the
+        // pre-prompt log; applying it against a changed log can clobber
+        // the intervening op. Skipped only when `--yes` is set, since
+        // there's no prompt window then. See #165.
+        let (current_records, _) = audit::read_all(home)?;
+        let current_tail = current_records.last().map(|r| r.id);
+        if current_tail != expected_tail_id {
+            return Err("the audit log changed while waiting for \
+                        confirmation (another session appended an entry). \
+                        Re-run the command."
+                .into());
+        }
     }
-    let files = apply_restore_plan(plan, Some(&BackupTracker::new()), &WatchState::default())?;
+    let files = apply_restore_plan(plan, cli_backups_for_session(), &WatchState::default())?;
     let record = restore_record(plan, audit::Actor::Cli, files);
-    // Fail-open: the restore already took effect on disk, so a log-append
-    // failure is a warning, not a command failure (matches the GUI).
-    if let Err(err) = audit::append(&record, home) {
-        eprintln!("warning: restore applied but audit-log append failed: {err}");
-    }
+    let outcome = persist_audit_record(&record, home);
+    report_audit_persist(outcome, restore_action_label(preview.direction));
     if json {
         let view = AuditRecordView {
             ts_ms: record.id.timestamp_ms(),
@@ -878,11 +988,12 @@ fn cmd_undo(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let records = read_audit_log(home)?;
+    let expected_tail_id = records.last().map(|r| r.id);
     let target = audit::undo_redo_state(&records)
         .undoable
         .ok_or("nothing to undo")?;
     let plan = build_restore_plan(&target, audit::RestoreDirection::Undo)?;
-    run_cli_restore(home, &plan, &target, dry_run, yes, json)
+    run_cli_restore(home, &plan, &target, expected_tail_id, dry_run, yes, json)
 }
 
 fn cmd_redo(
@@ -892,13 +1003,14 @@ fn cmd_redo(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let records = read_audit_log(home)?;
+    let expected_tail_id = records.last().map(|r| r.id);
     let state = audit::undo_redo_state(&records);
     if state.sequence_break {
         return Err("redo is unavailable: a change was made after the last undo".into());
     }
     let target = state.redoable.ok_or("nothing to redo")?;
     let plan = build_restore_plan(&target, audit::RestoreDirection::Redo)?;
-    run_cli_restore(home, &plan, &target, dry_run, yes, json)
+    run_cli_restore(home, &plan, &target, expected_tail_id, dry_run, yes, json)
 }
 
 fn cmd_restore(
@@ -909,6 +1021,7 @@ fn cmd_restore(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let records = read_audit_log(home)?;
+    let expected_tail_id = records.last().map(|r| r.id);
     let target_id = resolve_entry_id(&records, id)?;
     let plan = plan_restore_to(&records, target_id)?;
     let target = records
@@ -916,7 +1029,7 @@ fn cmd_restore(
         .find(|r| r.id == target_id)
         .expect("plan_restore_to verified the id is in the log")
         .clone();
-    run_cli_restore(home, &plan, &target, dry_run, yes, json)
+    run_cli_restore(home, &plan, &target, expected_tail_id, dry_run, yes, json)
 }
 
 fn rules_at(doc: &claude_scope_lib::model::SettingsDoc, kind_key: &str) -> Vec<String> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -266,7 +266,7 @@ pub fn diff_move_leaf(
 /// state before computing any delta, so distinguishing the two at log time
 /// would just bloat the schema). Errors are also collapsed to `None`: an
 /// I/O hiccup pre-apply shouldn't poison the post-apply audit entry.
-fn snapshot_top_level_key(path: &Path, key: &str) -> Option<serde_json::Value> {
+pub fn snapshot_top_level_key(path: &Path, key: &str) -> Option<serde_json::Value> {
     let (doc, _stamp) = io_atomic::load_with_stamp(path).ok()?;
     doc.and_then(|d| d.get_top_level(key).cloned())
 }
@@ -277,7 +277,7 @@ fn snapshot_top_level_key(path: &Path, key: &str) -> Option<serde_json::Value> {
 /// runs the apply impl has already validated. Keeping this classifier
 /// path-driven also means the audit module doesn't pull in `MovablePath`,
 /// which is a frontend-facing wire enum.
-fn audit_leaf_kind(path: &[PathSeg]) -> audit::LeafKind {
+pub fn audit_leaf_kind(path: &[PathSeg]) -> audit::LeafKind {
     if path.len() == 1 {
         audit::LeafKind::TopLevelKey
     } else if path.len() == 2
@@ -293,7 +293,7 @@ fn audit_leaf_kind(path: &[PathSeg]) -> audit::LeafKind {
 /// when the scope has no file path on this machine (e.g. user scope
 /// disabled on a sandboxed home), so the audit record skips the field
 /// rather than emitting `"file_path":""` placeholder garbage.
-fn audit_side(
+pub fn audit_side(
     scope: Scope,
     file_path: Option<&Path>,
     key: &str,
@@ -310,31 +310,76 @@ fn audit_side(
     })
 }
 
-/// Append one entry to the audit log on a successful write. Fail-open: any
-/// error from the audit append surfaces as a Tauri event but never as a
-/// hard failure to the caller — the primary write already succeeded, and
-/// the user's stated intent (move / add / delete this rule) took effect.
-/// Sandbox sessions (`--home` override active) skip the write entirely so
-/// scratch-mode runs don't pollute the real `~/.claude/claude-scope/`.
-fn emit_audit(app: &AppHandle, overrides: &RuntimeOverrides, record: audit::Record) {
-    if overrides.home().is_some() {
-        return;
+/// Outcome of [`persist_audit_record`]. Rotation and append errors are
+/// reported separately so the GUI can surface them as distinct Tauri
+/// events and the CLI can print distinct warnings.
+#[derive(Debug, Default)]
+pub struct AuditPersistResult {
+    /// Set when log rotation failed. Non-fatal — the append still
+    /// proceeds against the over-cap log; the user just keeps writing
+    /// to a log that's larger than the configured cap until rotation
+    /// can land.
+    pub rotate_error: Option<String>,
+    /// Set when the append failed. Fatal-ish: the record is *not* in
+    /// the log; history/undo/redo won't see this op. Callers surface
+    /// it as a warning rather than a hard error because the primary
+    /// write already succeeded.
+    pub append_error: Option<String>,
+}
+
+impl AuditPersistResult {
+    pub fn is_clean(&self) -> bool {
+        self.rotate_error.is_none() && self.append_error.is_none()
     }
+}
+
+/// Rotate (if configured) and append `record` to the audit log at the
+/// location implied by `home` (None = production, Some = sandbox / test).
+///
+/// Both steps are best-effort: rotation failure is logged and execution
+/// proceeds to append; append failure is reported in the returned struct
+/// so the caller can surface it in their idiomatic way (the GUI emits a
+/// Tauri event; the CLI prints to stderr). Shared by GUI and CLI write
+/// paths so the two surfaces can't drift on rotation behavior — see
+/// #164 and #168.
+pub fn persist_audit_record(record: &audit::Record, home: Option<&Path>) -> AuditPersistResult {
+    let mut out = AuditPersistResult::default();
     let prefs = preferences::load();
     // Rotate before the append so the fresh entry lands in the new
     // active file (#127). Rotation errors are fail-open: we surface
-    // them as a non-fatal event and proceed to append against the
+    // them as a non-fatal warning and proceed to append against the
     // existing file rather than dropping the entry. The append itself
     // would then write to an over-cap log, which is still better than
     // losing the record.
     if prefs.audit_log_rotate {
         let cap_bytes = u64::from(prefs.audit_log_max_size_mb) * 1_000_000;
-        if let Err(err) = audit::rotate_if_needed(None, cap_bytes) {
-            let _ = app.emit("audit-error", format!("rotation: {err}"));
+        if let Err(err) = audit::rotate_if_needed(home, cap_bytes) {
+            out.rotate_error = Some(format!("rotation: {err}"));
         }
     }
-    if let Err(err) = audit::append(&record, None) {
-        let _ = app.emit("audit-error", err.to_string());
+    if let Err(err) = audit::append(record, home) {
+        out.append_error = Some(err.to_string());
+    }
+    out
+}
+
+/// Append one entry to the audit log on a successful GUI write. Fail-open:
+/// any error from rotation or append surfaces as a Tauri event but never
+/// as a hard failure to the caller — the primary write already succeeded,
+/// and the user's stated intent (move / add / delete this rule) took
+/// effect. Sandbox sessions (`--home` override active) skip the write
+/// entirely so scratch-mode runs don't pollute the real
+/// `~/.claude/claude-scope/`.
+fn emit_audit(app: &AppHandle, overrides: &RuntimeOverrides, record: audit::Record) {
+    if overrides.home().is_some() {
+        return;
+    }
+    let outcome = persist_audit_record(&record, None);
+    if let Some(err) = outcome.rotate_error {
+        let _ = app.emit("audit-error", err);
+    }
+    if let Some(err) = outcome.append_error {
+        let _ = app.emit("audit-error", err);
     }
 }
 
@@ -978,7 +1023,7 @@ fn accumulate(
 /// infallible after `validate_movable_path` succeeds. Pulled out so the
 /// diff/apply flows can stay readable and the invariant is documented in
 /// exactly one place.
-fn path_top_level_key(path: &[PathSeg]) -> &str {
+pub fn path_top_level_key(path: &[PathSeg]) -> &str {
     path.first()
         .and_then(PathSeg::as_key)
         .expect("validate_movable_path guarantees path[0] is a key")

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -719,7 +719,7 @@ fn undo_redo_target(
     direction: audit::RestoreDirection,
     overrides: &RuntimeOverrides,
 ) -> Result<audit::Record, Box<dyn std::error::Error>> {
-    let (records, _) = audit::read_all(overrides.home())?;
+    let records = require_clean_audit_log(overrides)?;
     let state = audit::undo_redo_state(&records);
     let target = match direction {
         audit::RestoreDirection::Undo => state.undoable,
@@ -739,6 +739,37 @@ fn undo_redo_target(
             _ => "nothing to redo".into(),
         }
     })
+}
+
+/// Read the audit log, refusing if any records were skipped. Shared
+/// gate for every undo/redo/restore-to-point GUI command path: an IPC
+/// caller that bypassed the topbar's pre-check shouldn't be able to
+/// drive the state machine against a partial log either (#170 extended
+/// per codex's second-pass finding). The CLI has its own equivalent in
+/// `read_audit_log`.
+fn require_clean_audit_log(
+    overrides: &RuntimeOverrides,
+) -> Result<Vec<audit::Record>, Box<dyn std::error::Error>> {
+    let (records, skipped) = audit::read_all(overrides.home())?;
+    if skipped > 0 {
+        return Err(format!(
+            "{skipped} audit-log {} unreadable — refusing to compute \
+             undo/redo against a partial log. Repair {} (or copy aside \
+             and reset) before retrying.",
+            if skipped == 1 {
+                "entry is"
+            } else {
+                "entries are"
+            },
+            if skipped == 1 {
+                "the entry"
+            } else {
+                "those entries"
+            }
+        )
+        .into());
+    }
+    Ok(records)
 }
 
 fn undo_redo_preview(
@@ -839,7 +870,7 @@ fn restore_to_point_preview(
     overrides: &RuntimeOverrides,
 ) -> Result<RestorePreview, Box<dyn std::error::Error>> {
     let id = parse_audit_id(target_id)?;
-    let (records, _) = audit::read_all(overrides.home())?;
+    let records = require_clean_audit_log(overrides)?;
     let plan = plan_restore_to(&records, id)?;
     let target = records
         .iter()
@@ -871,7 +902,7 @@ fn apply_restore_to_point(
     overrides: &RuntimeOverrides,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let id = parse_audit_id(target_id)?;
-    let (records, _) = audit::read_all(overrides.home())?;
+    let records = require_clean_audit_log(overrides)?;
     // Identity check first: a concurrent rotate+append can leave the log
     // with a same-length-but-different-records window (codex #166 +
     // #171). Compare the trailing ULID against the preview's snapshot.
@@ -3591,6 +3622,36 @@ mod tests {
             key_before: Some(before),
             key_after: Some(after),
         }
+    }
+
+    #[test]
+    fn require_clean_audit_log_refuses_when_skipped_nonzero() {
+        // Regression for codex 2nd-pass [P1]: every undo/redo/restore
+        // GUI command must refuse a partial log, not just the topbar
+        // pre-check via `audit_undo_status`. Write a malformed line
+        // into the audit log and assert the gate rejects it.
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let overrides = RuntimeOverrides {
+            home: Some(home.to_path_buf()),
+            project: None,
+        };
+
+        // Write the audit dir and drop a malformed line.
+        let audit_dir = home.join(".claude").join("claude-scope");
+        std::fs::create_dir_all(&audit_dir).unwrap();
+        std::fs::write(
+            audit_dir.join("audit.jsonl"),
+            b"{ this is not a valid audit record }\n",
+        )
+        .unwrap();
+
+        let err = require_clean_audit_log(&overrides).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unreadable") && msg.contains("partial log"),
+            "expected staleness/partial-log message, got: {msg}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1833,9 +1833,16 @@ pub fn build_restore_plan(
     }
     let mut targets: Vec<RestoreTarget> = Vec::new();
     for s in sides {
-        // A same-scope change-kind records its one file as both `from` and
-        // `to`; collapse the duplicate so the file is written once.
-        if targets.iter().any(|t| t.file_path == s.file_path) {
+        // Dedupe on (file_path, top_level_key) — a same-scope change-kind
+        // records its one file under one top-level key as both `from` and
+        // `to`, which should collapse; but two sides on the same file
+        // touching *different* top-level keys are independent targets and
+        // must each survive. Keying on file_path alone (the pre-fix shape)
+        // silently dropped the second key — see #167.
+        if targets
+            .iter()
+            .any(|t| t.file_path == s.file_path && t.top_level_key == s.top_level_key)
+        {
             continue;
         }
         let (target_value, expected_current) = if undo {
@@ -1888,22 +1895,30 @@ pub fn plan_restore_to(
         );
     }
     let window = &records[target_idx..];
-    // Preserve first-seen file order so the plan (and the modal) list files
+    // Preserve first-seen order so the plan (and the modal) list targets
     // in a stable, log-driven order rather than hash order.
-    let mut order: Vec<PathBuf> = Vec::new();
-    let mut by_path: std::collections::HashMap<PathBuf, RestoreTarget> =
+    //
+    // Key on (file_path, top_level_key): a window can touch two different
+    // top-level keys in the same settings.json (e.g. an `env` change
+    // followed by a `permissions` change), and each (file, key) pair is
+    // an independent restore target. Keying on file_path alone silently
+    // dropped the second key — see #163.
+    type RestoreKey = (PathBuf, String);
+    let mut order: Vec<RestoreKey> = Vec::new();
+    let mut by_key: std::collections::HashMap<RestoreKey, RestoreTarget> =
         std::collections::HashMap::new();
     for entry in window {
         for s in record_sides(entry) {
-            match by_path.get_mut(&s.file_path) {
+            let map_key: RestoreKey = (s.file_path.clone(), s.top_level_key.clone());
+            match by_key.get_mut(&map_key) {
                 // Already seen: keep the first `key_before` (window-start
-                // state) and advance `expected_current` to this later
-                // `key_after`.
+                // state for this key) and advance `expected_current` to
+                // this later `key_after`.
                 Some(existing) => existing.expected_current = s.key_after.clone(),
                 None => {
-                    order.push(s.file_path.clone());
-                    by_path.insert(
-                        s.file_path.clone(),
+                    order.push(map_key.clone());
+                    by_key.insert(
+                        map_key,
                         RestoreTarget {
                             scope: s.scope,
                             file_path: s.file_path.clone(),
@@ -1918,7 +1933,7 @@ pub fn plan_restore_to(
     }
     let targets: Vec<RestoreTarget> = order
         .into_iter()
-        .map(|p| by_path.remove(&p).expect("path inserted above"))
+        .map(|k| by_key.remove(&k).expect("key inserted above"))
         .collect();
     if targets.is_empty() {
         return Err("nothing to restore — the spanned entries touched no files".into());
@@ -3290,6 +3305,168 @@ mod tests {
     fn restore_to_point_rejects_an_unknown_target() {
         let err = plan_restore_to(&[], Ulid::new()).unwrap_err();
         assert!(err.to_string().contains("not found"));
+    }
+
+    /// Helper for the multi-key dedupe regression tests below: build a Side
+    /// with a caller-supplied `top_level_key` so we can synthesize records
+    /// that touch two keys in one file (the case #163 / #167 exposed).
+    fn side_at_key(
+        scope: Scope,
+        path: &Path,
+        top_level_key: &str,
+        before: serde_json::Value,
+        after: serde_json::Value,
+    ) -> audit::Side {
+        audit::Side {
+            scope,
+            file_path: path.to_path_buf(),
+            top_level_key: top_level_key.to_string(),
+            key_before: Some(before),
+            key_after: Some(after),
+        }
+    }
+
+    #[test]
+    fn build_restore_plan_keeps_two_keys_in_one_file_as_distinct_targets() {
+        // Regression for #167. A single record whose `from` and `to` sides
+        // reference the same settings.json under different top-level keys
+        // must produce two restore targets — the pre-fix dedupe keyed on
+        // file_path alone collapsed the second one silently.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = paths_in(tmp.path()).project.clone().unwrap();
+        let rec = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            Some(side_at_key(
+                Scope::Project,
+                &project,
+                "permissions",
+                perms(&["A"]),
+                perms(&[]),
+            )),
+            Some(side_at_key(
+                Scope::Project,
+                &project,
+                "env",
+                serde_json::json!({"FOO": "1"}),
+                serde_json::json!({"FOO": "1", "BAR": "2"}),
+            )),
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+        let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
+        assert_eq!(
+            plan.targets.len(),
+            2,
+            "both top-level keys should survive the dedupe"
+        );
+        let keys: Vec<&str> = plan
+            .targets
+            .iter()
+            .map(|t| t.top_level_key.as_str())
+            .collect();
+        assert!(keys.contains(&"permissions"));
+        assert!(keys.contains(&"env"));
+    }
+
+    #[test]
+    fn build_restore_plan_still_collapses_same_file_same_key() {
+        // The pre-fix dedupe existed for a real reason: a same-scope
+        // change-kind records its one (file, key) tuple as both `from` and
+        // `to`. Keep that case collapsed.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = paths_in(tmp.path()).project.clone().unwrap();
+        let rec = audit::Record::new(
+            audit::Kind::ChangeKind,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            Some(side_at(
+                Scope::Project,
+                &project,
+                serde_json::json!({"allow": ["A"], "deny": []}),
+                serde_json::json!({"allow": [], "deny": ["A"]}),
+            )),
+            Some(side_at(
+                Scope::Project,
+                &project,
+                serde_json::json!({"allow": ["A"], "deny": []}),
+                serde_json::json!({"allow": [], "deny": ["A"]}),
+            )),
+            vec![key("permissions"), key("allow"), idx(0)],
+            Some(PermissionKind::Deny),
+        );
+        let plan = build_restore_plan(&rec, audit::RestoreDirection::Undo).unwrap();
+        assert_eq!(plan.targets.len(), 1, "same (file, key) must collapse");
+    }
+
+    #[test]
+    fn plan_restore_to_keeps_two_keys_in_one_file_as_distinct_targets() {
+        // Regression for #163. A restore window that touches the same
+        // settings.json under two different top-level keys must produce
+        // two targets — the pre-fix HashMap<PathBuf, _> dropped the
+        // second key's `top_level_key`/`target_value` on the floor.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = paths_in(tmp.path()).project.clone().unwrap();
+        // Two consecutive ops on the same file under different keys.
+        let r_env = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::TopLevelKey,
+            audit::Actor::Gui,
+            None,
+            Some(side_at_key(
+                Scope::Project,
+                &project,
+                "env",
+                serde_json::json!({"FOO": "1"}),
+                serde_json::json!({"FOO": "1", "BAR": "2"}),
+            )),
+            None,
+            vec![key("env")],
+            None,
+        );
+        let r_perms = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            Some(side_at_key(
+                Scope::Project,
+                &project,
+                "permissions",
+                perms(&[]),
+                perms(&["A"]),
+            )),
+            None,
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+        let plan = plan_restore_to(&[r_env.clone(), r_perms], r_env.id).unwrap();
+        assert_eq!(
+            plan.targets.len(),
+            2,
+            "both top-level keys should survive the window dedupe"
+        );
+        let keys: Vec<&str> = plan
+            .targets
+            .iter()
+            .map(|t| t.top_level_key.as_str())
+            .collect();
+        assert!(keys.contains(&"permissions"));
+        assert!(keys.contains(&"env"));
+        // `target_value` per target is the per-key window-start state
+        // (the first `key_before` seen for that key).
+        let env_target = plan
+            .targets
+            .iter()
+            .find(|t| t.top_level_key == "env")
+            .unwrap();
+        assert_eq!(
+            env_target.target_value,
+            Some(serde_json::json!({"FOO": "1"}))
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -271,6 +271,27 @@ pub fn snapshot_top_level_key(path: &Path, key: &str) -> Option<serde_json::Valu
     doc.and_then(|d| d.get_top_level(key).cloned())
 }
 
+/// Audit-side values captured during an apply_*_leaf_impl invocation,
+/// from the same `load_with_stamp` reads the impl uses for its writes.
+///
+/// Returning these from the impl (rather than having the command boundary
+/// do a separate `snapshot_top_level_key`) closes the race window a
+/// third-party writer could exploit by landing between the command's
+/// pre-snapshot and the impl's own load — pre-fix the audit's `key_before`
+/// could reflect a state the impl never actually overwrote, so a later
+/// undo would silently revert past the third-party edit. See #169.
+///
+/// Move populates both `from_*` and `to_*`. Same-scope change-kind also
+/// fills both, with identical values (one file, recorded as two sides).
+/// Delete fills only `from_*`. Add fills only `to_*`.
+#[derive(Debug, Default)]
+pub struct LeafApplyOutcome {
+    pub from_before: Option<serde_json::Value>,
+    pub from_after: Option<serde_json::Value>,
+    pub to_before: Option<serde_json::Value>,
+    pub to_after: Option<serde_json::Value>,
+}
+
 /// Classify a movable leaf path for the audit log. Path shapes mirror
 /// `validate_movable_path` — re-derived from the path itself rather than
 /// running validate again, because by the time the audit-recording code
@@ -396,36 +417,16 @@ pub fn apply_move_leaf(
     let paths =
         resolve_with_overrides(project_dir.as_deref(), &overrides).map_err(|e| e.to_string())?;
 
-    // Pre-read affected top-level keys so the audit record can carry a
-    // before-snapshot. Done here at the command boundary (rather than
-    // threading through apply_*_impl) so the 30+ impl-level unit tests
-    // stay untouched and the audit instrumentation is purely additive.
     let key = path_top_level_key(&req.path).to_string();
     let from_path = paths.path_for(req.from).map(Path::to_path_buf);
     let to_path = paths.path_for(req.to).map(Path::to_path_buf);
-    let from_before = from_path
-        .as_deref()
-        .and_then(|p| snapshot_top_level_key(p, &key));
-    let to_before = if req.from == req.to {
-        from_before.clone()
-    } else {
-        to_path
-            .as_deref()
-            .and_then(|p| snapshot_top_level_key(p, &key))
-    };
 
-    apply_move_leaf_impl(&paths, &req, backups_for_session(), &watch).map_err(|e| e.to_string())?;
-
-    let from_after = from_path
-        .as_deref()
-        .and_then(|p| snapshot_top_level_key(p, &key));
-    let to_after = if req.from == req.to {
-        from_after.clone()
-    } else {
-        to_path
-            .as_deref()
-            .and_then(|p| snapshot_top_level_key(p, &key))
-    };
+    // The impl returns the before/after values it captured from its own
+    // load_with_stamp — closing the race window a separate pre-snapshot
+    // at this boundary would leave open against a third-party writer
+    // (#169).
+    let outcome = apply_move_leaf_impl(&paths, &req, backups_for_session(), &watch)
+        .map_err(|e| e.to_string())?;
 
     // Same-scope move with `to_kind` set is the "change kind" flow (#8);
     // recorded as its own audit kind so a History reader (#19 Phase 2)
@@ -445,10 +446,16 @@ pub fn apply_move_leaf(
             req.from,
             from_path.as_deref(),
             &key,
-            from_before,
-            from_after,
+            outcome.from_before,
+            outcome.from_after,
         ),
-        audit_side(req.to, to_path.as_deref(), &key, to_before, to_after),
+        audit_side(
+            req.to,
+            to_path.as_deref(),
+            &key,
+            outcome.to_before,
+            outcome.to_after,
+        ),
         req.path.clone(),
         req.to_kind,
     );
@@ -480,16 +487,9 @@ pub fn apply_delete_leaf(
 
     let key = path_top_level_key(&req.path).to_string();
     let from_path = paths.path_for(req.from).map(Path::to_path_buf);
-    let from_before = from_path
-        .as_deref()
-        .and_then(|p| snapshot_top_level_key(p, &key));
 
-    apply_delete_leaf_impl(&paths, &req, backups_for_session(), &watch)
+    let outcome = apply_delete_leaf_impl(&paths, &req, backups_for_session(), &watch)
         .map_err(|e| e.to_string())?;
-
-    let from_after = from_path
-        .as_deref()
-        .and_then(|p| snapshot_top_level_key(p, &key));
 
     let record = audit::Record::new(
         audit::Kind::Delete,
@@ -500,8 +500,8 @@ pub fn apply_delete_leaf(
             req.from,
             from_path.as_deref(),
             &key,
-            from_before,
-            from_after,
+            outcome.from_before,
+            outcome.from_after,
         ),
         None,
         req.path.clone(),
@@ -535,15 +535,17 @@ pub fn apply_add_leaf(
 
     let key = path_top_level_key(&req.path).to_string();
     let to_path = paths.path_for(req.to).map(Path::to_path_buf);
-    let to_before = to_path
-        .as_deref()
-        .and_then(|p| snapshot_top_level_key(p, &key));
 
-    apply_add_leaf_impl(&paths, &req, backups_for_session(), &watch).map_err(|e| e.to_string())?;
+    let outcome = apply_add_leaf_impl(&paths, &req, backups_for_session(), &watch)
+        .map_err(|e| e.to_string())?;
 
-    let to_after = to_path
-        .as_deref()
-        .and_then(|p| snapshot_top_level_key(p, &key));
+    // Idempotent add: the impl returns the same before/after, meaning
+    // nothing was written. Skip the audit append so the History view
+    // doesn't show a phantom Add row that an Undo would treat as the
+    // next undoable op while doing nothing on disk (#172).
+    if outcome.to_before == outcome.to_after {
+        return Ok(());
+    }
 
     let record = audit::Record::new(
         audit::Kind::Add,
@@ -551,7 +553,13 @@ pub fn apply_add_leaf(
         audit::Actor::Gui,
         project_dir.as_ref().map(PathBuf::from),
         None,
-        audit_side(req.to, to_path.as_deref(), &key, to_before, to_after),
+        audit_side(
+            req.to,
+            to_path.as_deref(),
+            &key,
+            outcome.to_before,
+            outcome.to_after,
+        ),
         req.path.clone(),
         None,
     );
@@ -1397,7 +1405,7 @@ pub fn apply_move_leaf_impl(
     req: &MoveLeafRequest,
     backups: Option<&BackupTracker>,
     watch: &WatchState,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<LeafApplyOutcome, Box<dyn std::error::Error>> {
     let movable = validate_movable_path(&req.path)?;
     validate_move_request(req, &movable)?;
 
@@ -1418,6 +1426,12 @@ pub fn apply_move_leaf_impl(
         Some(d) => d,
         None => return Err(format!("source file {} does not exist", from_path.display()).into()),
     };
+    // Capture the source's pre-mutation top-level-key value for the
+    // audit record. From this load — not a separate snapshot at the
+    // command boundary — so a third-party writer that lands between
+    // the command and this point can't leave the audit log claiming a
+    // value the impl never overwrote (#169).
+    let from_key_before = from_doc.get_top_level(affected_key).cloned();
     let src_value =
         from_doc
             .get_at_path(&req.path)
@@ -1494,7 +1508,13 @@ pub fn apply_move_leaf_impl(
         );
     }
     watch.note_self_write(&from_path);
-    Ok(())
+    let from_key_after = from_doc.get_top_level(affected_key).cloned();
+    Ok(LeafApplyOutcome {
+        from_before: from_key_before,
+        from_after: from_key_after,
+        to_before: to_key_before,
+        to_after: to_key_after,
+    })
 }
 
 /// Apply a same-scope change-kind move (#8): one file, one save. Avoids the
@@ -1506,8 +1526,9 @@ fn apply_change_kind_same_scope(
     movable: &MovablePath<'_>,
     backups: Option<&BackupTracker>,
     watch: &WatchState,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<LeafApplyOutcome, Box<dyn std::error::Error>> {
     let path = require_path(paths, req.from)?.to_path_buf();
+    let affected_key = path_top_level_key(&req.path);
     let dest_path = dest_path_for(req);
 
     let (loaded, stamp) = io_atomic::load_with_stamp(&path)?;
@@ -1515,6 +1536,11 @@ fn apply_change_kind_same_scope(
         Some(d) => d,
         None => return Err(format!("source file {} does not exist", path.display()).into()),
     };
+    // Same-scope change-kind: one file, but the audit record carries two
+    // sides (`from` + `to`) referencing it, both pre/post the in-memory
+    // mutation. Capture before/after here from the impl's own load so
+    // the audit values reflect what was actually overwritten (#169).
+    let key_before = doc.get_top_level(affected_key).cloned();
     let src_value =
         doc.get_at_path(&req.path)
             .cloned()
@@ -1541,10 +1567,16 @@ fn apply_change_kind_same_scope(
         )
         .into());
     }
+    let key_after = doc.get_top_level(affected_key).cloned();
 
     io_atomic::save(&path, &doc, backups, Some(&stamp))?;
     watch.note_self_write(&path);
-    Ok(())
+    Ok(LeafApplyOutcome {
+        from_before: key_before.clone(),
+        from_after: key_after.clone(),
+        to_before: key_before,
+        to_after: key_after,
+    })
 }
 
 fn diff_delete_leaf_impl(
@@ -1620,15 +1652,17 @@ fn apply_delete_leaf_impl(
     req: &DeleteLeafRequest,
     backups: Option<&BackupTracker>,
     watch: &WatchState,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<LeafApplyOutcome, Box<dyn std::error::Error>> {
     let movable = validate_movable_path(&req.path)?;
     let path = require_path(paths, req.from)?.to_path_buf();
+    let affected_key = path_top_level_key(&req.path);
 
     let (loaded, stamp) = io_atomic::load_with_stamp(&path)?;
     let mut doc = match loaded {
         Some(d) => d,
         None => return Err(format!("file {} does not exist", path.display()).into()),
     };
+    let key_before = doc.get_top_level(affected_key).cloned();
     let src_value =
         doc.get_at_path(&req.path)
             .cloned()
@@ -1648,9 +1682,15 @@ fn apply_delete_leaf_impl(
         )
         .into());
     }
+    let key_after = doc.get_top_level(affected_key).cloned();
     io_atomic::save(&path, &doc, backups, Some(&stamp))?;
     watch.note_self_write(&path);
-    Ok(())
+    Ok(LeafApplyOutcome {
+        from_before: key_before,
+        from_after: key_after,
+        to_before: None,
+        to_after: None,
+    })
 }
 
 fn diff_add_leaf_impl(
@@ -1698,7 +1738,7 @@ fn apply_add_leaf_impl(
     req: &AddLeafRequest,
     backups: Option<&BackupTracker>,
     watch: &WatchState,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<LeafApplyOutcome, Box<dyn std::error::Error>> {
     let _movable = validate_movable_path(&req.path)?;
     let path = require_path(paths, req.to)?.to_path_buf();
     let affected_key = path_top_level_key(&req.path);
@@ -1709,14 +1749,22 @@ fn apply_add_leaf_impl(
     let mut doc = to_doc_before;
     doc.merge_at_path(&req.path, req.value.clone())?;
     let key_after = doc.get_top_level(affected_key).cloned();
+    let outcome = LeafApplyOutcome {
+        from_before: None,
+        from_after: None,
+        to_before: key_before.clone(),
+        to_after: key_after.clone(),
+    };
     if key_before == key_after {
         // Idempotent add — no write needed. Surface success quietly so the
         // frontend's load() runs without the watcher seeing a stale event.
-        return Ok(());
+        // The outcome still carries the (equal) before/after so the
+        // command can decide whether to skip the audit append (#172).
+        return Ok(outcome);
     }
     io_atomic::save(&path, &doc, backups, Some(&stamp))?;
     watch.note_self_write(&path);
-    Ok(())
+    Ok(outcome)
 }
 
 /// Human-readable note shown on the destination side of a `MoveLeafPreview`.
@@ -3131,6 +3179,121 @@ mod tests {
             vec![key("permissions"), key("allow"), idx(0)],
             None,
         )
+    }
+
+    #[test]
+    fn apply_move_leaf_impl_returns_audit_outcome_matching_disk_state() {
+        // Regression for #169. The impl must return before/after values
+        // captured from its own load_with_stamp — not from a separate
+        // snapshot at the command boundary. The test cuts out the
+        // command boundary entirely and verifies the impl's outcome
+        // reflects the actual transition.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        let project = paths.project.clone().unwrap();
+        let user = paths.user.clone().unwrap();
+        write(&project, r#"{"permissions":{"allow":["X","Y"]}}"#);
+        write(&user, r#"{"permissions":{"allow":["Z"]}}"#);
+
+        let req = MoveLeafRequest {
+            path: vec![key("permissions"), key("allow"), idx(0)],
+            from: Scope::Project,
+            to: Scope::User,
+            to_kind: None,
+        };
+        let outcome = apply_move_leaf_impl(&paths, &req, None, &WatchState::default()).unwrap();
+
+        // from_before reflects the file BEFORE the impl's mutation.
+        assert_eq!(
+            outcome.from_before,
+            Some(serde_json::json!({"allow": ["X", "Y"]}))
+        );
+        // from_after reflects the file AFTER the impl's mutation.
+        assert_eq!(
+            outcome.from_after,
+            Some(serde_json::json!({"allow": ["Y"]}))
+        );
+        assert_eq!(outcome.to_before, Some(serde_json::json!({"allow": ["Z"]})));
+        assert_eq!(
+            outcome.to_after,
+            Some(serde_json::json!({"allow": ["Z", "X"]}))
+        );
+    }
+
+    #[test]
+    fn apply_delete_leaf_impl_returns_audit_outcome() {
+        // Regression for #169 — same shape, delete leaf.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        let project = paths.project.clone().unwrap();
+        write(&project, r#"{"permissions":{"allow":["X","Y"]}}"#);
+
+        let req = DeleteLeafRequest {
+            path: vec![key("permissions"), key("allow"), idx(0)],
+            from: Scope::Project,
+        };
+        let outcome = apply_delete_leaf_impl(&paths, &req, None, &WatchState::default()).unwrap();
+
+        assert_eq!(
+            outcome.from_before,
+            Some(serde_json::json!({"allow": ["X", "Y"]}))
+        );
+        assert_eq!(
+            outcome.from_after,
+            Some(serde_json::json!({"allow": ["Y"]}))
+        );
+        // Delete has no `to` side.
+        assert!(outcome.to_before.is_none());
+        assert!(outcome.to_after.is_none());
+    }
+
+    #[test]
+    fn apply_add_leaf_impl_returns_audit_outcome() {
+        // Regression for #169 — same shape, add leaf.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        let user = paths.user.clone().unwrap();
+        write(&user, r#"{"permissions":{"allow":["Z"]}}"#);
+
+        let req = AddLeafRequest {
+            path: vec![key("permissions"), key("allow"), idx(0)],
+            to: Scope::User,
+            value: serde_json::Value::String("NEW".to_string()),
+        };
+        let outcome = apply_add_leaf_impl(&paths, &req, None, &WatchState::default()).unwrap();
+
+        // Add has no `from` side.
+        assert!(outcome.from_before.is_none());
+        assert!(outcome.from_after.is_none());
+        assert_eq!(outcome.to_before, Some(serde_json::json!({"allow": ["Z"]})));
+        // merge_at_path appends; the new rule lands after the existing one.
+        assert_eq!(
+            outcome.to_after,
+            Some(serde_json::json!({"allow": ["Z", "NEW"]}))
+        );
+    }
+
+    #[test]
+    fn apply_add_leaf_impl_idempotent_returns_equal_before_after() {
+        // Regression for #172 (companion to #169). When the rule is
+        // already present at the destination, the impl returns an
+        // outcome with `to_before == to_after` and the command can
+        // skip the audit append rather than emit a phantom entry.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        let user = paths.user.clone().unwrap();
+        write(&user, r#"{"permissions":{"allow":["NEW"]}}"#);
+
+        let req = AddLeafRequest {
+            path: vec![key("permissions"), key("allow"), idx(0)],
+            to: Scope::User,
+            value: serde_json::Value::String("NEW".to_string()),
+        };
+        let outcome = apply_add_leaf_impl(&paths, &req, None, &WatchState::default()).unwrap();
+
+        // Same value before and after — caller (`apply_add_leaf`) skips
+        // emit_audit on this signal.
+        assert_eq!(outcome.to_before, outcome.to_after);
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -336,6 +336,13 @@ impl AuditPersistResult {
 /// Rotate (if configured) and append `record` to the audit log at the
 /// location implied by `home` (None = production, Some = sandbox / test).
 ///
+/// Wraps [`audit::persist`], which holds a cross-process advisory lock
+/// around the rotate+append pair so two ClaudeScope sessions can't
+/// interleave a rotation with another session's append (#166). Reads the
+/// rotation preference (`audit_log_rotate` / `audit_log_max_size_mb`)
+/// fresh on every call so a toggle in Settings takes effect on the next
+/// write.
+///
 /// Both steps are best-effort: rotation failure is logged and execution
 /// proceeds to append; append failure is reported in the returned struct
 /// so the caller can surface it in their idiomatic way (the GUI emits a
@@ -343,24 +350,19 @@ impl AuditPersistResult {
 /// paths so the two surfaces can't drift on rotation behavior — see
 /// #164 and #168.
 pub fn persist_audit_record(record: &audit::Record, home: Option<&Path>) -> AuditPersistResult {
-    let mut out = AuditPersistResult::default();
     let prefs = preferences::load();
-    // Rotate before the append so the fresh entry lands in the new
-    // active file (#127). Rotation errors are fail-open: we surface
-    // them as a non-fatal warning and proceed to append against the
-    // existing file rather than dropping the entry. The append itself
-    // would then write to an over-cap log, which is still better than
-    // losing the record.
-    if prefs.audit_log_rotate {
-        let cap_bytes = u64::from(prefs.audit_log_max_size_mb) * 1_000_000;
-        if let Err(err) = audit::rotate_if_needed(home, cap_bytes) {
-            out.rotate_error = Some(format!("rotation: {err}"));
-        }
+    let options = audit::PersistOptions {
+        rotate_cap_bytes: if prefs.audit_log_rotate {
+            Some(u64::from(prefs.audit_log_max_size_mb) * 1_000_000)
+        } else {
+            None
+        },
+    };
+    let result = audit::persist(record, home, options);
+    AuditPersistResult {
+        rotate_error: result.rotate_error,
+        append_error: result.append_error.map(|e| e.to_string()),
     }
-    if let Err(err) = audit::append(record, home) {
-        out.append_error = Some(err.to_string());
-    }
-    out
 }
 
 /// Append one entry to the audit log on a successful GUI write. Fail-open:
@@ -663,6 +665,12 @@ pub struct UndoRedoStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redo: Option<AuditRecordView>,
     pub sequence_break: bool,
+    /// Count of unreadable audit-log lines (`read_all` skip count). When
+    /// non-zero, the undo/redo state machine is missing some records —
+    /// a corrupt `restore` line could make us think an op is still
+    /// undoable when it isn't. The topbar surfaces this and refuses
+    /// undo/redo until the log is repaired. See #170.
+    pub skipped: usize,
 }
 
 /// Report what the next undo / redo would target (#19 Phase 3). Routes
@@ -672,12 +680,27 @@ pub struct UndoRedoStatus {
 /// in scratch mode — `.bak` remains the recovery path there.
 #[tauri::command]
 pub fn audit_undo_status(overrides: State<'_, RuntimeOverrides>) -> Result<UndoRedoStatus, String> {
-    let (records, _) = audit::read_all(overrides.home()).map_err(|e| e.to_string())?;
+    let (records, skipped) = audit::read_all(overrides.home()).map_err(|e| e.to_string())?;
     let state = audit::undo_redo_state(&records);
+    // When the log has malformed lines, withhold undo/redo: a corrupt
+    // restore record could leave the state machine pointing at an op
+    // that was already undone, and confirming would emit a duplicate
+    // restore entry. The topbar surfaces `skipped > 0` as a warning
+    // and disables the buttons. See #170.
+    let degraded = skipped > 0;
     Ok(UndoRedoStatus {
-        undo: state.undoable.map(record_view),
-        redo: state.redoable.map(record_view),
+        undo: if degraded {
+            None
+        } else {
+            state.undoable.map(record_view)
+        },
+        redo: if degraded {
+            None
+        } else {
+            state.redoable.map(record_view)
+        },
         sequence_break: state.sequence_break,
+        skipped,
     })
 }
 
@@ -814,7 +837,11 @@ fn restore_to_point_preview(
         .iter()
         .find(|r| r.id == id)
         .expect("plan_restore_to already verified the id is in the log");
-    preview_restore_plan(&plan, target)
+    let mut preview = preview_restore_plan(&plan, target)?;
+    // Capture the trailing ULID so the apply can detect a concurrent
+    // append that left `ops_spanned` coincidentally identical (#171).
+    preview.tail_id = records.last().map(|r| r.id);
+    Ok(preview)
 }
 
 /// Diff preview for a restore-to-point (#19 Phase 4) — rolls the affected
@@ -830,16 +857,26 @@ pub fn audit_restore_to_point_preview(
 fn apply_restore_to_point(
     target_id: &str,
     expected_ops_spanned: usize,
+    expected_tail_id: Option<Ulid>,
     app: &AppHandle,
     watch: &WatchState,
     overrides: &RuntimeOverrides,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let id = parse_audit_id(target_id)?;
     let (records, _) = audit::read_all(overrides.home())?;
+    // Identity check first: a concurrent rotate+append can leave the log
+    // with a same-length-but-different-records window (codex #166 +
+    // #171). Compare the trailing ULID against the preview's snapshot.
+    // None on either side means "no tail recorded" — treat the absence
+    // as a non-mismatch only when both are absent.
+    let current_tail = records.last().map(|r| r.id);
+    if current_tail != expected_tail_id {
+        return Err("the audit log changed since the preview — reload and try again".into());
+    }
     let plan = plan_restore_to(&records, id)?;
-    // The window the user confirmed had `expected_ops_spanned` entries; if
-    // a write landed since (a concurrent CLI op) the window has grown —
-    // refuse rather than reverting more than the preview showed.
+    // Spanned-count check is now redundant with the tail check above —
+    // but keep it as defense in depth in case `expected_tail_id` is
+    // None for any future reason (callers that haven't been updated).
     if plan.ops_spanned != expected_ops_spanned {
         return Err("the audit log changed since the preview — reload and try again".into());
     }
@@ -852,18 +889,27 @@ fn apply_restore_to_point(
     Ok(())
 }
 
-/// Apply a restore-to-point (#19 Phase 4). `expected_ops_spanned` is the
-/// span the confirmed preview reported — see [`apply_restore_to_point`].
+/// Apply a restore-to-point (#19 Phase 4). `expected_ops_spanned` and
+/// `expected_tail_id` are the span and trailing-record ULID that the
+/// confirmed preview reported — see [`apply_restore_to_point`].
 #[tauri::command]
 pub fn audit_apply_restore_to_point(
     target_id: String,
     expected_ops_spanned: usize,
+    expected_tail_id: Option<Ulid>,
     app: AppHandle,
     watch: State<'_, WatchState>,
     overrides: State<'_, RuntimeOverrides>,
 ) -> Result<(), String> {
-    apply_restore_to_point(&target_id, expected_ops_spanned, &app, &watch, &overrides)
-        .map_err(|e| e.to_string())
+    apply_restore_to_point(
+        &target_id,
+        expected_ops_spanned,
+        expected_tail_id,
+        &app,
+        &watch,
+        &overrides,
+    )
+    .map_err(|e| e.to_string())
 }
 
 /// Build- and runtime-time diagnostic block for the About dialog (#21).
@@ -1824,6 +1870,15 @@ pub struct RestorePreview {
     /// the same helpers the History view uses.
     pub target: AuditRecordView,
     pub sides: Vec<RestoreSidePreview>,
+    /// ULID of the last record in the audit log at preview time. The
+    /// apply path passes this back in `expected_tail_id` so it can refuse
+    /// to apply against a log that has since changed — closes the gap
+    /// `ops_spanned` alone leaves open (a same-length window can hold
+    /// different records after a concurrent rotate+append). See #171.
+    /// `None` only when the log was empty at preview time (impossible for
+    /// any restore that has a target, but kept Optional for future-proofing).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tail_id: Option<Ulid>,
     /// How many ops this restore reverts: 1 for undo / redo, the count of
     /// spanned entries for a restore-to-point (#125).
     pub ops_spanned: usize,
@@ -2033,6 +2088,10 @@ pub fn preview_restore_plan(
         target: record_view(target.clone()),
         sides,
         ops_spanned: plan.ops_spanned,
+        // Filled in by higher-level callers that have the log handy
+        // (`restore_to_point_preview`). `preview_restore_plan` itself only
+        // sees the plan + target, not the full log.
+        tail_id: None,
     })
 }
 
@@ -3511,6 +3570,80 @@ mod tests {
         assert_eq!(
             env_target.target_value,
             Some(serde_json::json!({"FOO": "1"}))
+        );
+    }
+
+    #[test]
+    fn restore_to_point_preview_captures_trailing_ulid_for_apply_recheck() {
+        // Regression for #171. The apply path compares the trailing
+        // record's ULID against this `tail_id` to detect a concurrent
+        // rotate+append that left `ops_spanned` coincidentally identical
+        // but the window's contents different. The preview must populate
+        // `tail_id` from the same read that fed `plan_restore_to`.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = paths_in(tmp.path()).project.clone().unwrap();
+        write(&project, r#"{"permissions":{"allow":["A"]}}"#);
+        let target = move_record(
+            side_at(Scope::Project, &project, perms(&["A"]), perms(&[])),
+            side_at(Scope::User, &project, perms(&[]), perms(&["A"])),
+        );
+        let records = vec![target.clone()];
+        let plan = plan_restore_to(&records, target.id).unwrap();
+        let mut preview = preview_restore_plan(&plan, &target).unwrap();
+        // `preview_restore_plan` alone doesn't see the log; the
+        // higher-level `restore_to_point_preview` populates `tail_id`.
+        assert!(
+            preview.tail_id.is_none(),
+            "preview_restore_plan should not set tail_id"
+        );
+        preview.tail_id = records.last().map(|r| r.id);
+        // After populating, the tail should equal the target (only one
+        // entry in the log).
+        assert_eq!(preview.tail_id, Some(target.id));
+    }
+
+    #[test]
+    fn tail_ulid_changes_when_audit_log_grows() {
+        // Demonstrates the detection mechanism the #171 fix relies on.
+        // If a concurrent process appends to the audit log between
+        // preview and apply, the trailing ULID changes — even if the
+        // window's `ops_spanned` stays coincidentally identical.
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let a = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            None,
+            None,
+            None,
+            vec![],
+            None,
+        );
+        audit::append(&a, Some(home)).unwrap();
+        // Capture trailing ULID — what the preview would record.
+        let (snapshot, _) = audit::read_all(Some(home)).unwrap();
+        let expected_tail = snapshot.last().map(|r| r.id);
+
+        // Concurrent writer appends.
+        let b = audit::Record::new(
+            audit::Kind::Add,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Cli,
+            None,
+            None,
+            None,
+            vec![],
+            None,
+        );
+        audit::append(&b, Some(home)).unwrap();
+
+        // Apply-side re-read: tail has shifted.
+        let (after, _) = audit::read_all(Some(home)).unwrap();
+        let current_tail = after.last().map(|r| r.id);
+        assert_ne!(
+            current_tail, expected_tail,
+            "trailing ULID must change after a concurrent append — this is the signal apply_restore_to_point uses to detect staleness (#171)"
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ pub mod audit;
 pub mod commands;
 pub mod io_atomic;
 pub mod model;
-mod preferences;
+pub mod preferences;
 pub mod projects;
 mod runtime;
 pub mod scope;

--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -291,7 +291,15 @@ where
 /// Resolve the on-disk path for the config file. `None` when the OS couldn't
 /// give us a config directory (no `$HOME` set, say) — we treat that the same
 /// as "no config yet" and fall back to defaults.
+///
+/// `CLAUDE_SCOPE_CONFIG_DIR` overrides the default OS location. Used by the
+/// CLI integration tests to point at a sandbox config; also a useful escape
+/// hatch for users who want to relocate preferences (XDG-style on platforms
+/// where `dirs` doesn't honor it natively).
 pub fn config_path() -> Option<PathBuf> {
+    if let Some(override_dir) = std::env::var_os("CLAUDE_SCOPE_CONFIG_DIR") {
+        return Some(PathBuf::from(override_dir).join("config.json"));
+    }
     dirs::config_dir().map(|d| d.join("claude-scope").join("config.json"))
 }
 

--- a/src-tauri/tests/cli.rs
+++ b/src-tauri/tests/cli.rs
@@ -22,6 +22,7 @@ struct Sandbox {
     _tmp: TempDir,
     project: PathBuf,
     home: PathBuf,
+    config_dir: PathBuf,
 }
 
 impl Sandbox {
@@ -29,13 +30,23 @@ impl Sandbox {
         let tmp = tempfile::tempdir().expect("create tempdir");
         let project = tmp.path().join("project");
         let home = tmp.path().join("home");
+        let config_dir = tmp.path().join("config");
         std::fs::create_dir_all(project.join(".claude")).unwrap();
         std::fs::create_dir_all(home.join(".claude")).unwrap();
+        std::fs::create_dir_all(&config_dir).unwrap();
         Self {
             _tmp: tmp,
             project,
             home,
+            config_dir,
         }
+    }
+
+    /// Write the CLI's `config.json` (the file `preferences::load()` reads).
+    /// The integration tests pass `CLAUDE_SCOPE_CONFIG_DIR` to redirect
+    /// `preferences::config_path()` here, so each test gets isolated prefs.
+    fn write_pref(&self, json: &str) {
+        std::fs::write(self.config_dir.join("config.json"), json).unwrap();
     }
 
     fn write_project(&self, body: &str) {
@@ -73,6 +84,7 @@ impl Sandbox {
 
     fn run(&self, args: &[&str]) -> Output {
         Command::new(BIN)
+            .env("CLAUDE_SCOPE_CONFIG_DIR", &self.config_dir)
             .args([
                 "--project-dir",
                 self.project.to_str().unwrap(),
@@ -392,4 +404,199 @@ fn version_subcommand_json_shape_is_stable() {
     }
     // CLI process: `webview_version` must be null, not a fabricated string.
     assert!(v["webview_version"].is_null());
+}
+
+// ---------------------------------------------------------------------------
+// v0.6 release-gate fixes: audit emission, backup pref, restore log recheck
+// ---------------------------------------------------------------------------
+
+/// #164 — `claude-scope-cli move` must append an audit record. Pre-fix the
+/// command wrote settings files but never called `audit::append`, so the
+/// move was invisible to History / Undo / Redo.
+#[test]
+fn cli_move_appends_audit_record() {
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Bash(git status)"]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":[]}}"#);
+
+    let mv = sb.run(&[
+        "move",
+        "Bash(git status)",
+        "--kind",
+        "allow",
+        "--from",
+        "project",
+        "--to",
+        "user",
+    ]);
+    assert!(mv.status.success(), "stderr: {}", stderr(&mv));
+
+    let hist = sb.run(&["history", "--json"]);
+    assert!(hist.status.success(), "stderr: {}", stderr(&hist));
+    let page: serde_json::Value = serde_json::from_str(&stdout(&hist)).expect("non-json history");
+    let records = page["records"]
+        .as_array()
+        .expect("history JSON must have a records array");
+    assert_eq!(
+        records.len(),
+        1,
+        "expected exactly one audit entry from the CLI move, got: {records:?}"
+    );
+    // AuditRecordView flattens Record into the parent object via
+    // #[serde(flatten)], so `kind` / `actor` live at the top level
+    // alongside `ts_ms` — not nested under `record`.
+    let rec = &records[0];
+    assert_eq!(rec["kind"], "move", "audit kind should be move");
+    assert_eq!(
+        rec["actor"], "cli",
+        "audit actor should be cli for a CLI-initiated move"
+    );
+}
+
+/// #168 — CLI write paths must honor `Preferences::backup_on_write`. With
+/// the pref set to `false`, no `.bak` should be created.
+#[test]
+fn cli_move_respects_backup_on_write_false_pref() {
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Bash(git status)"]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":[]}}"#);
+    sb.write_pref(r#"{"backup_on_write":false}"#);
+
+    let out = sb.run(&[
+        "move",
+        "Bash(git status)",
+        "--kind",
+        "allow",
+        "--from",
+        "project",
+        "--to",
+        "user",
+    ]);
+    assert!(out.status.success(), "stderr: {}", stderr(&out));
+
+    // The move itself must still succeed — pref only affects .bak creation.
+    let project_allow = read_allow(&sb.project.join(".claude").join("settings.json"));
+    assert!(project_allow.is_empty(), "rule should have moved out");
+
+    // No .bak alongside either touched file.
+    assert!(
+        !sb.project
+            .join(".claude")
+            .join("settings.json.bak")
+            .exists(),
+        "project settings.json.bak must not exist when backup_on_write=false"
+    );
+    assert!(
+        !sb.home.join(".claude").join("settings.json.bak").exists(),
+        "user settings.json.bak must not exist when backup_on_write=false"
+    );
+}
+
+/// #165 — CLI restore must re-read the audit log after the confirm prompt
+/// and refuse to apply if another session appended between preview and
+/// apply. Uses a stdin pipe with a brief sleep so the child has time to
+/// build the preview + print the prompt; then we inject a concurrent
+/// append before sending `y`.
+#[test]
+fn cli_undo_aborts_when_audit_log_changes_during_confirm_prompt() {
+    use std::io::Write as _;
+    use std::process::Stdio;
+    use std::time::Duration;
+
+    use claude_scope_lib::audit;
+
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Bash(git status)"]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":[]}}"#);
+
+    // Seed the audit log with one CLI move so there's something to undo.
+    let mv = sb.run(&[
+        "move",
+        "Bash(git status)",
+        "--kind",
+        "allow",
+        "--from",
+        "project",
+        "--to",
+        "user",
+    ]);
+    assert!(mv.status.success(), "seed move failed: {}", stderr(&mv));
+
+    // Snapshot the project file so we can confirm the aborted undo did NOT
+    // overwrite it.
+    let project_after_move = sb.project_settings();
+
+    // Spawn `undo` with stdin piped — we'll send "y\n" later but only
+    // AFTER injecting a concurrent append.
+    let mut child = Command::new(BIN)
+        .env("CLAUDE_SCOPE_CONFIG_DIR", &sb.config_dir)
+        .args([
+            "--project-dir",
+            sb.project.to_str().unwrap(),
+            "--home-dir",
+            sb.home.to_str().unwrap(),
+        ])
+        .arg("undo")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn claude-scope-cli undo");
+
+    // The child reads the audit log, prints the preview, then prompts. By
+    // the time we wake up, the log read is done (expected_tail_id captured)
+    // and the child is blocked on stdin. 400ms is generous on a CI-ish
+    // machine; bump if this turns flaky.
+    std::thread::sleep(Duration::from_millis(400));
+
+    // Inject a fresh audit record via the lib — this is the "concurrent
+    // GUI/CLI session" the issue's failure scenario describes. The child's
+    // post-prompt re-read must notice this and refuse to apply.
+    let bogus = audit::Record::new(
+        audit::Kind::Add,
+        audit::LeafKind::PermissionRule,
+        audit::Actor::Cli,
+        None,
+        None,
+        Some(audit::Side {
+            scope: claude_scope_lib::scope::Scope::Project,
+            file_path: sb.project.join(".claude").join("settings.json"),
+            top_level_key: "permissions".to_string(),
+            key_before: Some(serde_json::json!({"allow": []})),
+            key_after: Some(serde_json::json!({"allow": ["Sleep(injected)"]})),
+        }),
+        vec![],
+        None,
+    );
+    audit::append(&bogus, Some(sb.home.as_path())).expect("inject bogus audit append");
+
+    // Now confirm the prompt. The child reads "y", proceeds to its
+    // post-prompt re-read, sees the tail shifted, and aborts.
+    child
+        .stdin
+        .as_mut()
+        .expect("piped stdin")
+        .write_all(b"y\n")
+        .expect("write y to child stdin");
+
+    let out = child
+        .wait_with_output()
+        .expect("wait for claude-scope-cli undo");
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on stale-log apply, got success. stderr: {}",
+        stderr(&out)
+    );
+    let err = stderr(&out);
+    assert!(
+        err.contains("log changed"),
+        "expected staleness error on stderr, got: {err}"
+    );
+
+    // The aborted undo must not have touched the on-disk settings.
+    assert_eq!(
+        sb.project_settings(),
+        project_after_move,
+        "project settings must be unchanged after a refused undo"
+    );
 }

--- a/src-tauri/tests/cli.rs
+++ b/src-tauri/tests/cli.rs
@@ -600,3 +600,52 @@ fn cli_undo_aborts_when_audit_log_changes_during_confirm_prompt() {
         "project settings must be unchanged after a refused undo"
     );
 }
+
+/// #170 — CLI undo / redo / restore must refuse against a log with
+/// unreadable lines. A corrupt restore line could leave the state
+/// machine pointing at an op that's already undone; running undo
+/// against that would emit a duplicate restore entry. Refuse with a
+/// clear message and non-zero status instead.
+#[test]
+fn cli_undo_refuses_when_audit_log_has_unreadable_lines() {
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Bash(git status)"]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":[]}}"#);
+
+    // Seed one valid CLI move so there's something the state machine
+    // would have considered undoable.
+    let mv = sb.run(&[
+        "move",
+        "Bash(git status)",
+        "--kind",
+        "allow",
+        "--from",
+        "project",
+        "--to",
+        "user",
+    ]);
+    assert!(mv.status.success(), "seed move failed: {}", stderr(&mv));
+
+    // Append a malformed line to the audit log. `audit::read_all` will
+    // count it as `skipped`. The CLI's `read_audit_log` should refuse.
+    let audit_path = sb
+        .home
+        .join(".claude")
+        .join("claude-scope")
+        .join("audit.jsonl");
+    let mut existing = std::fs::read_to_string(&audit_path).expect("read audit log");
+    existing.push_str("{ not even close to valid json }\n");
+    std::fs::write(&audit_path, existing).expect("rewrite audit log with corrupt line");
+
+    let out = sb.run(&["undo", "--yes"]);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on degraded log, got success. stderr: {}",
+        stderr(&out)
+    );
+    let err = stderr(&out);
+    assert!(
+        err.contains("unreadable") && err.contains("partial log"),
+        "expected staleness error on stderr, got: {err}"
+    );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -433,8 +433,11 @@ function handleRedo(trigger?: HTMLElement): void {
  * the History dialog closes itself first so the confirm modal opens clean.
  */
 function handleRestoreToPoint(rec: AuditRecordView): void {
-  // `expected_ops_spanned` guards against the log growing between preview
-  // and apply — the backend reverts only the span the user confirmed.
+  // `expected_ops_spanned` + `expected_tail_id` guard against the log
+  // changing between preview and apply. Ops_spanned catches the common
+  // case (an extra op was appended → window grows); tail_id catches the
+  // rarer same-length case (a concurrent rotate+append left the window
+  // with the same count but different records — #171).
   void runRestoreFlow(
     "Restore",
     () => invoke<RestorePreview>("audit_restore_to_point_preview", { target_id: rec.id }),
@@ -442,6 +445,7 @@ function handleRestoreToPoint(rec: AuditRecordView): void {
       invoke("audit_apply_restore_to_point", {
         target_id: rec.id,
         expected_ops_spanned: preview.ops_spanned,
+        expected_tail_id: preview.tail_id ?? null,
       }),
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -361,6 +361,15 @@ export interface RestorePreview {
   sides: RestoreSidePreview[];
   /** How many ops the restore reverts: 1 for undo / redo. */
   ops_spanned: number;
+  /**
+   * ULID (Crockford base32) of the audit log's trailing record at preview
+   * time. The apply call passes this back as `expected_tail_id` so the
+   * backend can refuse if the log has changed since — closes the gap
+   * `ops_spanned` alone leaves open (a same-length window after a
+   * concurrent rotate+append). Populated for restore-to-point only;
+   * absent for undo / redo. See #171.
+   */
+  tail_id?: string;
 }
 
 /**
@@ -373,6 +382,15 @@ export interface UndoRedoStatus {
   undo?: AuditRecordView;
   redo?: AuditRecordView;
   sequence_break: boolean;
+  /**
+   * Count of unreadable audit-log lines (corrupt JSON, truncated tail,
+   * schema drift the reader couldn't parse). When non-zero, the backend
+   * withholds both `undo` and `redo` and the topbar should surface a
+   * "log degraded" warning. Acting against a partial log can emit a
+   * duplicate restore entry, so undo/redo stay disabled until the
+   * issue is resolved. See #170.
+   */
+  skipped: number;
 }
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -773,12 +773,30 @@ function recordTooltip(rec: AuditRecordView): string {
   return rule ? `${historyVerbLabel(rec)} ${rule} (${when})` : `${historyVerbLabel(rec)} (${when})`;
 }
 
+/**
+ * Build the "log degraded" tooltip text when the audit log has unreadable
+ * lines (#170). Surfaces the count and explains why undo/redo are off.
+ */
+function logDegradedTooltip(skipped: number): string {
+  const lines = skipped === 1 ? "1 audit-log entry is" : `${skipped} audit-log entries are`;
+  return `${lines} unreadable — undo/redo are disabled until the log is repaired`;
+}
+
 function undoButton(props: AppProps): HTMLButtonElement {
   const btn = document.createElement("button");
   btn.textContent = "Undo";
-  const target = props.undoStatus?.undo;
+  const status = props.undoStatus;
+  const target = status?.undo;
   btn.disabled = props.busy || !props.scopes || !target;
-  btn.title = target ? `Undo: ${recordTooltip(target)}` : "Nothing to undo";
+  if (target) {
+    btn.title = `Undo: ${recordTooltip(target)}`;
+  } else if (status && status.skipped > 0) {
+    // Backend withheld undo because the log has malformed lines. Tell
+    // the user why rather than the default "Nothing to undo".
+    btn.title = logDegradedTooltip(status.skipped);
+  } else {
+    btn.title = "Nothing to undo";
+  }
   btn.setAttribute("aria-label", btn.title);
   btn.onclick = (e) => props.onUndo(e.currentTarget as HTMLElement);
   return btn;
@@ -795,6 +813,9 @@ function redoButton(props: AppProps): HTMLButtonElement {
   } else if (status?.sequence_break) {
     // The forward stack is stranded — explain rather than just greying out.
     btn.title = "Redo unavailable — a change was made after the last undo";
+  } else if (status && status.skipped > 0) {
+    // Same log-degraded posture as undo.
+    btn.title = logDegradedTooltip(status.skipped);
   } else {
     btn.title = "Nothing to redo";
   }


### PR DESCRIPTION
## Summary

Closes all nine v0.6 release blockers surfaced by the codex + Claude `/code-review` adversarial review pass (#163–#171), plus one P2 follow-up (#172) that shared the same code surface.

Per the tracker (#177), the fixes cluster into four PR-sized units, here as four commits:

1. **`fix(audit): dedupe restore-plan sides by (file_path, top_level_key) (#163, #167)`** — the codex-flagged dedupe bug and its twin in a sibling function. Restore plans now key on `(file_path, top_level_key)`, so a window touching two keys in one file produces two targets instead of silently dropping one.

2. **`fix(cli): audit emit, log re-read after confirm, honor backup pref (#164, #165, #168)`** — CLI parity. CLI `move` now appends an audit record; CLI restore re-reads the log after the confirm prompt and aborts on staleness; CLI honors `Preferences::backup_on_write`. New `CLAUDE_SCOPE_CONFIG_DIR` env hook lets integration tests supply sandbox preferences.

3. **`fix(audit): cross-process lock, archive-aware reads, tail-id check, degraded-log gating (#166, #170, #171)`** — audit log atomicity. `audit::persist` holds a cross-process advisory lock (`fs2`) around rotate+append; `audit::read_all` is archive-aware; `apply_restore_to_point` checks the trailing ULID in addition to `ops_spanned`; `audit_undo_status` surfaces the `skipped` count and the topbar withholds undo/redo when the log is degraded.

4. **`fix(audit): impl returns before/after values; eliminates pre-snapshot race (#169, #172)`** — `apply_*_leaf_impl` now returns a `LeafApplyOutcome` carrying the before/after values it read from `load_with_stamp`. The command boundary's separate `snapshot_top_level_key` call (and its race window) is gone. As a side-effect, the idempotent-Add no-op signal (`to_before == to_after`) now lets the command skip `emit_audit`, closing #172.

## Test plan

- [x] `just check` passes end-to-end (264 lib tests + 19 CLI integration + 120 JS tests, lint clean)
- [x] New tests for each fix per the issue acceptance criteria — see commit bodies
- [x] Cross-process / concurrency tests: `persist_concurrent_threads_lose_no_records_across_rotation` (8 threads near rotation cap) and `cli_undo_aborts_when_audit_log_changes_during_confirm_prompt` (subprocess + stdin race)
- [x] Existing 246 lib + 15 cli integration tests still pass
- [ ] CI confirms on Linux runner

## Doc updates

- `docs/src/architecture/audit-log.md` — rewrote "Rotation" section to document the cross-process lock, archive-aware reads, and cross-process invariants.

## Release-gate status

After this PR lands, v0.6 release gate (#143):

- ✅ Adversarial code review (codex + /code-review) — done, blockers fixed
- ⏭️ Re-run adversarial review against the fixes (next)
- ⏭️ Security review (`/security-review` on the v0.6 diff)
- ⏭️ Document consistency and cleanup
- ⏭️ Version bump and release (your step — release-please workflow_dispatch)

Closes #163, closes #164, closes #165, closes #166, closes #167, closes #168, closes #169, closes #170, closes #171, closes #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)