### PR TITLE
fix(security): allowlist audit-log file_paths (#183, #180)

### DIFF
--- a/docs/src/architecture/audit-log.md
+++ b/docs/src/architecture/audit-log.md
@@ -36,7 +36,7 @@ record valid.
   },
   "path": ["permissions", "allow", 0],
   "to_kind": null,                   // set on change-kind ops
-  "claude_scope_version": "0.3.0"
+  "claude_scope_version": "0.6.0"
 }
 ```
 
@@ -165,6 +165,45 @@ window from `audit::read_all`, which now spans archives. Restoring
 to a point that lives in an archive works the same way as restoring
 to a point in the active log — same `record_sides` walk, same per-
 file snapshot revert.
+
+## Security invariants
+
+The audit log is read by every undo / redo / restore call, and its
+contents drive direct writes to the user's settings files. A hostile
+line appended to `audit.jsonl` (cloud-sync collision, malicious
+postinstall, compromised tool with user-scope write) must not be able
+to escalate into arbitrary file-write. Three gates enforce that.
+
+**Path allowlist (#183).** Every audit-log boundary —
+`undo_redo_target`, `restore_to_point_preview`,
+`apply_restore_to_point`, and the CLI's `cmd_undo` / `cmd_redo` /
+`cmd_restore` — calls `validate_audit_records` immediately after
+reading records and before building any `RestorePlan`. Each
+`Side.file_path` must equal one of the four resolved `ScopePaths`
+slots (`local`, `project`, `user_local`, `user`) for that record's
+own `project_dir`, against the active home override. Canonicalization
+absorbs platform-specific path forms (`/var → /private/var` on macOS,
+`\\?\C:\…` extended-length paths on Windows). The basename must be
+`settings.json` or `settings.local.json`. Any path outside the
+allowlist is refused with a clear `path injection refused` message;
+no writes happen.
+
+**Degraded-log refusal (#170).** `audit::read_all` reports a count
+of unreadable lines (corrupt JSON, schema drift the reader can't
+parse, truncated tails). Every undo / redo / restore path gates on
+that count: the GUI's `require_clean_audit_log` and the CLI's
+`read_audit_log` both refuse with a non-zero exit / blocked topbar
+button when `skipped > 0`. A partial log could leave the undo/redo
+state machine pointing at an op that was already undone, and
+confirming would emit a duplicate `restore` entry.
+
+**Tail-ID stalecheck (#165, #171).** Every restore re-reads the log
+immediately before applying and compares the trailing record's ULID
+against the value captured at preview time. A mismatch means the log
+changed under the user — refuse rather than apply a plan against a
+log the user didn't see. This catches concurrent GUI/CLI appends in
+the prompt window AND the (smaller) window between the initial read
+and `--yes` apply.
 
 ## Sandbox
 

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -137,3 +137,26 @@ For `undo` / `redo` / `restore`, `--json` emits the `RestorePreview`
 for a `--dry-run` and the resulting `restore` entry (as an
 `AuditRecordView`, the same shape `history --json` produces) once
 applied.
+
+### Refusals
+
+`undo` / `redo` / `restore` exit non-zero with a clear message and
+write nothing in these cases:
+
+- **`N audit-log entries are unreadable — refusing to compute
+  undo/redo against a partial log.`** The audit log has malformed
+  lines that the reader skipped. Acting against a partial log could
+  emit a duplicate restore entry; repair the log (copy aside, drop
+  the broken lines) and retry.
+- **`the audit log changed since the plan was built` /
+  `the audit log changed while waiting for confirmation`.** A
+  concurrent CLI or GUI session appended to the log between this
+  command's plan-build and apply (or during the confirm prompt). The
+  stale plan is rejected; re-run the command against the fresh log.
+- **`path injection refused`.** An entry's `file_path` points outside
+  the legitimate scope set for its `project_dir`. Indicates the log
+  has been hand-edited or corrupted by a third party; do not apply.
+  See the [security threat model](../security.md#threat-model).
+
+These refusals apply equally under `--yes` — there is no path that
+silently writes to the wrong file.

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -61,3 +61,44 @@ tomorrow with no code change on our end.
   documented at [Architecture → Audit log](./architecture/audit-log.md).
 - The docs site (this one) has **no analytics**. No tracking
   pixels, no third-party scripts.
+
+## Threat model
+
+ClaudeScope is a single-user desktop tool. The user running the app
+is the only legitimate operator. Within that frame, two threat
+surfaces are explicitly defended:
+
+**Hostile audit-log entries.** An attacker who can append a line to
+`~/.claude/claude-scope/audit.jsonl` (cloud-sync collision from a
+compromised peer, a previously-compromised tool with user-scope
+write, a malicious package postinstall, a shared workstation) should
+not be able to escalate that capability. The audit log drives
+`apply_restore_plan` to write to files at paths recorded in the log
+itself — without defenses, one well-formed line could direct
+ClaudeScope to write attacker-controlled JSON to any path the user
+can write to. The
+[Architecture → Audit log § Security invariants](./architecture/audit-log.md#security-invariants)
+section documents the three gates (path allowlist, degraded-log
+refusal, tail-ID stalecheck) that enforce containment. The path
+allowlist is the load-bearing control: every `Side.file_path` is
+validated against the four legitimate `ScopePaths` for its
+`project_dir` before any write happens.
+
+**Hand-edited settings files.** Users (or other tools) may edit
+`settings.json` outside ClaudeScope at any time. The atomic-write
+path captures a `FileStamp` at load time and refuses the save when
+the stamp differs at persist time — the user's external edit
+survives. See
+[Architecture → Atomic writes](./architecture/atomic-writes.md) for
+the contract.
+
+Out of scope:
+
+- Multi-user systems with adversarial co-users. The threat model
+  assumes a single trusted user; on shared workstations, OS-level
+  ACLs are the right layer.
+- Resource-exhaustion attacks. A user who can write large amounts
+  of data into `audit.jsonl` can fill the disk; that's a property
+  of any append-only log, not a ClaudeScope-specific issue.
+- Tampering with the bundled binary. Binary integrity is the
+  installer / OS package manager's responsibility.

--- a/docs/src/user-guide/undo-redo.md
+++ b/docs/src/user-guide/undo-redo.md
@@ -69,6 +69,28 @@ captured. If the file was hand-edited since (so its current contents
 differ from what the log expected), the confirm modal shows a warning
 band — you can still proceed, but you'll be overwriting that edit.
 
+**Disabled with a "log degraded" tooltip.** If
+`~/.claude/claude-scope/audit.jsonl` has unreadable lines (corrupt
+JSON, a crash mid-write, schema drift the build doesn't recognize),
+both Undo and Redo are withheld until the log is repaired. The
+tooltip names the count of unreadable entries. Acting against a
+partial log could emit a duplicate restore entry, so ClaudeScope
+refuses rather than guess. The CLI exits non-zero with the same
+message. Repair option: copy `audit.jsonl` aside, drop the broken
+lines, restart.
+
+**"Log changed since the preview."** If a concurrent CLI or GUI
+session writes to the audit log while the confirm modal is open,
+the apply is refused with that message — re-open the History view
+and retry against the fresh state. Same posture under
+`claude-scope-cli undo` and `--yes`.
+
+**"Path injection refused."** If an audit-log entry's `file_path`
+points outside the legitimate scope set for its project (e.g. an
+attacker hand-wrote a hostile line into `audit.jsonl`), the restore
+is refused before any I/O. See the
+[Security threat model](../security.md#threat-model) for context.
+
 ## Restore to before an entry
 
 Single-step undo walks back one operation at a time. To jump back

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -19,8 +19,8 @@ use claude_scope_lib::audit::{self, Record as AuditRecord};
 use claude_scope_lib::commands::{
     apply_move_leaf_impl, apply_restore_plan, audit_leaf_kind, audit_side, build_loaded,
     build_restore_plan, diff_move_leaf_impl, persist_audit_record, plan_restore_to,
-    preview_restore_plan, restore_record, AuditLogPage, AuditRecordView, MoveLeafPreview,
-    MoveLeafRequest, RestorePlan, RestorePreview,
+    preview_restore_plan, restore_record, validate_audit_records, AuditLogPage, AuditRecordView,
+    MoveLeafPreview, MoveLeafRequest, RestorePlan, RestorePreview,
 };
 use claude_scope_lib::io_atomic::{self, BackupTracker};
 use claude_scope_lib::model::{PathSeg, PermissionKind};
@@ -769,12 +769,15 @@ fn cmd_move(
 
     // Build and persist the audit record. CLI move is always
     // `Kind::Move` today — no change-kind path is exposed at the
-    // command line (#8 is GUI-only).
+    // command line (#8 is GUI-only). `project_dir` is required for
+    // the #183 path allowlist: without it, undo/redo/restore would
+    // refuse the record because they couldn't resolve the legitimate
+    // scope set. Closes #180 alongside the security fix.
     let record = audit::Record::new(
         audit::Kind::Move,
         audit_leaf_kind(&req.path),
         audit::Actor::Cli,
-        None,
+        Some(paths.project_dir.clone()),
         audit_side(
             req.from,
             from_file.as_deref(),
@@ -1029,6 +1032,11 @@ fn cmd_undo(
     let target = audit::undo_redo_state(&records)
         .undoable
         .ok_or("nothing to undo")?;
+    // Audit-log boundary check (#183). Refuse any record whose Side
+    // points outside the legitimate scope allowlist for its
+    // project_dir, so a hostile log line can't drive the apply path
+    // into writing attacker JSON to an attacker-chosen file.
+    validate_audit_records(std::slice::from_ref(&target), home)?;
     let plan = build_restore_plan(&target, audit::RestoreDirection::Undo)?;
     run_cli_restore(home, &plan, &target, expected_tail_id, dry_run, yes, json)
 }
@@ -1046,6 +1054,7 @@ fn cmd_redo(
         return Err("redo is unavailable: a change was made after the last undo".into());
     }
     let target = state.redoable.ok_or("nothing to redo")?;
+    validate_audit_records(std::slice::from_ref(&target), home)?;
     let plan = build_restore_plan(&target, audit::RestoreDirection::Redo)?;
     run_cli_restore(home, &plan, &target, expected_tail_id, dry_run, yes, json)
 }
@@ -1060,12 +1069,14 @@ fn cmd_restore(
     let records = read_audit_log(home)?;
     let expected_tail_id = records.last().map(|r| r.id);
     let target_id = resolve_entry_id(&records, id)?;
-    let plan = plan_restore_to(&records, target_id)?;
-    let target = records
+    let target_idx = records
         .iter()
-        .find(|r| r.id == target_id)
-        .expect("plan_restore_to verified the id is in the log")
-        .clone();
+        .position(|r| r.id == target_id)
+        .ok_or("target audit entry not found in the log")?;
+    // Validate the entire window (#183).
+    validate_audit_records(&records[target_idx..], home)?;
+    let plan = plan_restore_to(&records, target_id)?;
+    let target = records[target_idx].clone();
     run_cli_restore(home, &plan, &target, expected_tail_id, dry_run, yes, json)
 }
 
@@ -1820,9 +1831,14 @@ mod tests {
     }
 
     /// A logged move of `Bash(ls)` from `project` to `user`, with
-    /// before/after snapshots — the shape `cmd_undo` reads.
-    fn logged_move(project: &Path, user: &Path) -> Record {
+    /// before/after snapshots — the shape `cmd_undo` reads. The
+    /// `project_dir` argument scopes the record so the #183 path
+    /// allowlist accepts the `project` file_path; pre-validator the
+    /// helper left project_dir = None which now (correctly) fails
+    /// the security gate.
+    fn logged_move(project_dir: &Path, project: &Path, user: &Path) -> Record {
         let mut rec = make_audit_record(Kind::Move, LeafKind::PermissionRule);
+        rec.project_dir = Some(project_dir.to_path_buf());
         rec.path = vec![
             PathSeg::Key("permissions".into()),
             PathSeg::Key("allow".into()),
@@ -1854,7 +1870,11 @@ mod tests {
         // Files at their post-move state: the rule has moved Project → User.
         write_file(&project, r#"{"permissions":{"allow":[]}}"#);
         write_file(&user, r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
-        audit_lib::append(&logged_move(&project, &user), Some(home)).unwrap();
+        audit_lib::append(
+            &logged_move(&tmp.path().join("proj"), &project, &user),
+            Some(home),
+        )
+        .unwrap();
 
         // `--yes` skips the prompt; not a dry run.
         cmd_undo(Some(home), false, true, false).unwrap();
@@ -1881,7 +1901,11 @@ mod tests {
         let user = home.join(".claude/settings.json");
         write_file(&project, r#"{"permissions":{"allow":[]}}"#);
         write_file(&user, r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
-        audit_lib::append(&logged_move(&project, &user), Some(home)).unwrap();
+        audit_lib::append(
+            &logged_move(&tmp.path().join("proj"), &project, &user),
+            Some(home),
+        )
+        .unwrap();
 
         cmd_undo(Some(home), true, true, false).unwrap();
 
@@ -1911,7 +1935,7 @@ mod tests {
         write_file(&project, r#"{"permissions":{"allow":[]}}"#);
         write_file(&user, r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
         // move → undo(move) → another move = a sequence break.
-        let m1 = logged_move(&project, &user);
+        let m1 = logged_move(&tmp.path().join("proj"), &project, &user);
         let undo = Record::new_restore(
             LeafKind::PermissionRule,
             Actor::Gui,
@@ -1923,7 +1947,7 @@ mod tests {
                 files: vec![],
             },
         );
-        let m2 = logged_move(&project, &user);
+        let m2 = logged_move(&tmp.path().join("proj"), &project, &user);
         for rec in [&m1, &undo, &m2] {
             audit_lib::append(rec, Some(home)).unwrap();
         }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -720,6 +720,12 @@ fn undo_redo_target(
     overrides: &RuntimeOverrides,
 ) -> Result<audit::Record, Box<dyn std::error::Error>> {
     let records = require_clean_audit_log(overrides)?;
+    // Audit log boundary check — refuse any record whose Side points
+    // at a path outside the legitimate scope-file allowlist for its
+    // project_dir (#183). A hostile log line can otherwise drive
+    // `apply_restore_plan` to write attacker JSON to any user-writable
+    // path.
+    validate_audit_records(&records, overrides.home())?;
     let state = audit::undo_redo_state(&records);
     let target = match direction {
         audit::RestoreDirection::Undo => state.undoable,
@@ -871,6 +877,14 @@ fn restore_to_point_preview(
 ) -> Result<RestorePreview, Box<dyn std::error::Error>> {
     let id = parse_audit_id(target_id)?;
     let records = require_clean_audit_log(overrides)?;
+    // Validate the entire window before building the plan (#183). Each
+    // record in `[target..]` could reference a different project_dir;
+    // the validator checks each against its own allowlist.
+    let target_idx = records
+        .iter()
+        .position(|r| r.id == id)
+        .ok_or("target audit entry not found in the log")?;
+    validate_audit_records(&records[target_idx..], overrides.home())?;
     let plan = plan_restore_to(&records, id)?;
     let target = records
         .iter()
@@ -903,6 +917,14 @@ fn apply_restore_to_point(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let id = parse_audit_id(target_id)?;
     let records = require_clean_audit_log(overrides)?;
+    // Allowlist gate on the window — see `restore_to_point_preview`.
+    // Mirrored at apply time so a malicious record appended between
+    // preview and apply also fails the security check (#183).
+    let target_idx_for_validate = records
+        .iter()
+        .position(|r| r.id == id)
+        .ok_or("target audit entry not found in the log")?;
+    validate_audit_records(&records[target_idx_for_validate..], overrides.home())?;
     // Identity check first: a concurrent rotate+append can leave the log
     // with a same-length-but-different-records window (codex #166 +
     // #171). Compare the trailing ULID against the preview's snapshot.
@@ -1985,6 +2007,103 @@ fn record_sides(rec: &audit::Record) -> Vec<&audit::Side> {
 fn record_view(rec: audit::Record) -> AuditRecordView {
     let ts_ms = rec.id.timestamp_ms();
     AuditRecordView { record: rec, ts_ms }
+}
+
+/// Validate every record in `records` against the legitimate scope-file
+/// allowlist (#183). Returns an error on the first record whose Side
+/// points outside the resolved [`ScopePaths`] for that record's own
+/// `project_dir`. Used at every audit-log boundary — GUI commands and
+/// CLI subcommands call this immediately after loading records and
+/// before building any [`RestorePlan`], so a hostile audit-log line
+/// can never reach `apply_restore_plan` with an attacker-controlled
+/// `file_path`.
+pub fn validate_audit_records(
+    records: &[audit::Record],
+    home_dir: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for entry in records {
+        for s in record_sides(entry) {
+            validate_audit_path(
+                &s.file_path,
+                &s.top_level_key,
+                entry.project_dir.as_deref(),
+                home_dir,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Verify that an audit-log-derived `file_path` belongs to the legitimate
+/// scope-file allowlist for `record_project_dir` under `home_dir`. Returns
+/// an error if the path is outside the resolved [`ScopePaths`] (local,
+/// project, user_local, user) for that project, or if the basename isn't
+/// a settings file.
+///
+/// Closes the path-injection primitive in #183: without this check, a
+/// hostile audit-log line carrying an arbitrary `file_path` would drive
+/// [`apply_restore_plan`] to write attacker-chosen JSON to any path the
+/// user can write to (including, on Windows, the Startup folder, and on
+/// Unix files like `~/.config/Code/User/settings.json` whose contents
+/// trigger code execution on the next app launch).
+///
+/// Both sides are canonicalized before comparison so a stamp-style path
+/// (`/private/var/...` on macOS, `\\?\C:\...` on Windows) doesn't slip
+/// past byte-equal checks. A canonicalize failure (target file doesn't
+/// exist yet — legitimate for create-on-restore) falls back to lexical
+/// equality, which is safe: the audit log stores the same path string
+/// the resolver produces, so they match without canonicalization too.
+fn validate_audit_path(
+    target_path: &Path,
+    _target_top_level_key: &str,
+    record_project_dir: Option<&Path>,
+    home_dir: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let basename = target_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    if !matches!(basename, "settings.json" | "settings.local.json") {
+        return Err(format!(
+            "audit-log path injection refused: file_path `{}` does not look \
+             like a Claude Code settings file (basename `{}`).",
+            target_path.display(),
+            basename
+        )
+        .into());
+    }
+    let paths = scope::resolve_with_home(record_project_dir, home_dir)?;
+    let allowed: [Option<&Path>; 4] = [
+        paths.local.as_deref(),
+        paths.project.as_deref(),
+        paths.user_local.as_deref(),
+        paths.user.as_deref(),
+    ];
+    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    let target_canon = canon(target_path);
+    if !allowed
+        .iter()
+        .filter_map(|opt| *opt)
+        .any(|allowed_path| canon(allowed_path) == target_canon || allowed_path == target_path)
+    {
+        return Err(format!(
+            "audit-log path injection refused: file_path `{}` is not a \
+             legitimate scope file for project_dir `{}`. \
+             Refusing to restore to a path outside the resolved scope set.",
+            target_path.display(),
+            record_project_dir
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "<user-only>".to_string()),
+        )
+        .into());
+    }
+    // Top-level key allowlist is intentionally left for follow-up — the
+    // load-bearing security control is the path allowlist above. A
+    // hostile `top_level_key` on a *legitimate* settings.json file
+    // expands attacker control to the user's own Claude config keys,
+    // which is a much narrower blast radius than the original
+    // arbitrary-file-write primitive.
+    Ok(())
 }
 
 /// Build the plan to undo or redo a single op record.
@@ -3712,6 +3831,116 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&on_disk).unwrap();
         assert_eq!(v["env"], serde_json::json!({"X": "1"}));
         assert_eq!(v["permissions"], serde_json::json!({"allow": []}));
+    }
+
+    #[test]
+    fn validate_audit_records_refuses_path_outside_scope_allowlist() {
+        // Regression for #183 (security). A hostile audit-log line
+        // carrying a `file_path` outside the resolved ScopePaths for
+        // its `project_dir` must be rejected before any restore plan
+        // is built. Otherwise the apply path would write attacker-
+        // controlled JSON to an attacker-chosen file.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+
+        // Hostile record claims its project is the test's project, but
+        // its Side's file_path points at a totally different file.
+        let hostile = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            Some(paths.project_dir.clone()),
+            None,
+            Some(audit::Side {
+                scope: Scope::User,
+                file_path: tmp.path().join("malicious-target.json"),
+                top_level_key: "permissions".to_string(),
+                key_before: Some(serde_json::json!({})),
+                key_after: Some(serde_json::json!({"allow": ["pwn"]})),
+            }),
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+
+        let home = tmp.path().join("home");
+        let err = validate_audit_records(std::slice::from_ref(&hostile), Some(&home))
+            .expect_err("must refuse path outside scope allowlist");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("path injection refused"),
+            "expected path-injection refusal, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_audit_records_refuses_non_settings_basename() {
+        // Defense-in-depth: even a path the resolver might somehow
+        // produce must end in `settings.json` or `settings.local.json`.
+        // Catches hostile records that try to use the home dir
+        // structure to claim a non-settings basename.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+
+        let hostile = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            Some(paths.project_dir.clone()),
+            None,
+            Some(audit::Side {
+                scope: Scope::Project,
+                file_path: paths.project_dir.join(".claude").join("config.json"), // wrong basename
+                top_level_key: "permissions".to_string(),
+                key_before: None,
+                key_after: Some(serde_json::json!({"allow": ["x"]})),
+            }),
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+
+        let err = validate_audit_records(std::slice::from_ref(&hostile), None)
+            .expect_err("must refuse non-settings basename");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does not look like a Claude Code settings file"),
+            "expected basename refusal, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_audit_records_accepts_legitimate_record() {
+        // Sanity: a record produced for a legitimate scope file under
+        // the resolved project must pass.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+
+        let legit = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            Some(paths.project_dir.clone()),
+            Some(audit::Side {
+                scope: Scope::Project,
+                file_path: paths.project.clone().unwrap(),
+                top_level_key: "permissions".to_string(),
+                key_before: Some(serde_json::json!({"allow": ["A"]})),
+                key_after: Some(serde_json::json!({"allow": []})),
+            }),
+            Some(audit::Side {
+                scope: Scope::User,
+                file_path: paths.user.clone().unwrap(),
+                top_level_key: "permissions".to_string(),
+                key_before: Some(serde_json::json!({"allow": []})),
+                key_after: Some(serde_json::json!({"allow": ["A"]})),
+            }),
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+
+        // home_dir matches what paths_in used for user_home.
+        let home = tmp.path().join("home");
+        validate_audit_records(std::slice::from_ref(&legit), Some(&home))
+            .expect("legitimate record must pass");
     }
 
     #[test]

--- a/src-tauri/tests/cli.rs
+++ b/src-tauri/tests/cli.rs
@@ -601,6 +601,69 @@ fn cli_undo_aborts_when_audit_log_changes_during_confirm_prompt() {
     );
 }
 
+/// #183 (security): a hostile audit-log line carrying a `file_path`
+/// outside the legitimate scope set must be refused by the CLI restore
+/// pipeline. Without the allowlist gate, `claude-scope-cli undo --yes`
+/// would write attacker-controlled JSON to the attacker-chosen path.
+#[test]
+fn cli_undo_refuses_audit_record_pointing_outside_scope_allowlist() {
+    use claude_scope_lib::audit;
+    use claude_scope_lib::model::{PathSeg, PermissionKind};
+    use claude_scope_lib::scope::Scope as ScopeEnum;
+
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":[]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":[]}}"#);
+
+    let malicious_target_path = sb._tmp.path().join("attacker-chosen.json");
+
+    // Construct a hostile record via the real audit:: API so the
+    // serde shape is guaranteed correct (the threat model is "attacker
+    // gets one well-formed line into audit.jsonl"). project_dir
+    // claims the legitimate sandbox project; the Side's file_path
+    // points outside the resolved ScopePaths.
+    let hostile = audit::Record::new(
+        audit::Kind::Move,
+        audit::LeafKind::PermissionRule,
+        audit::Actor::Gui,
+        Some(sb.project.clone()),
+        None,
+        Some(audit::Side {
+            scope: ScopeEnum::User,
+            file_path: malicious_target_path.clone(),
+            top_level_key: "permissions".to_string(),
+            key_before: Some(serde_json::json!({"allow": []})),
+            key_after: Some(serde_json::json!({"allow": ["pwn"]})),
+        }),
+        vec![
+            PathSeg::Key("permissions".to_string()),
+            PathSeg::Key("allow".to_string()),
+            PathSeg::Index(0),
+        ],
+        None::<PermissionKind>,
+    );
+    audit::append(&hostile, Some(sb.home.as_path())).expect("write hostile line");
+
+    let out = sb.run(&["undo", "--yes"]);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on hostile audit record, got success. stderr: {}",
+        stderr(&out)
+    );
+    let err = stderr(&out);
+    assert!(
+        err.contains("path injection refused"),
+        "expected path-injection refusal on stderr, got: {err}"
+    );
+
+    // The attacker's target file must NOT exist — the hostile write
+    // was prevented BEFORE any I/O happened.
+    assert!(
+        !malicious_target_path.exists(),
+        "hostile target file must not have been written"
+    );
+}
+
 /// Codex 3rd-pass [P1] — even the post-confirm re-read in
 /// `run_cli_restore` must refuse a degraded log. A malformed line
 /// appended during the prompt window doesn't change the trailing


### PR DESCRIPTION
## Summary

Closes the path-injection vulnerability surfaced by `/security-review` on PR #178 (#183, confidence 0.95). Bundles the #180 follow-up (CLI moves recording `project_dir: None`) because the security gate exposed it as an immediate blocker — without #180, `cli undo` against any CLI-initiated move would refuse with the security message.

**Stacked on PR #178** — base is `fix/v0.6-release-blockers`. When PR #178 merges to `dev`, this PR's base should auto-rebase or can be retargeted to `dev`.

## The vulnerability

The undo/redo/restore-to-point pipeline trusted the `file_path: PathBuf` field of `audit::Side` records deserialized from `~/.claude/claude-scope/audit.jsonl` and wrote to that path directly. An attacker who could append one well-formed JSON line to `audit.jsonl` (cloud-sync collision, compromised tool with user-scope write, malicious npm postinstall, etc.) could cause ClaudeScope to write attacker-controlled JSON to any path the user could write to, with parent dirs auto-created. `claude-scope-cli undo --yes` made it scriptable.

## Fix

`validate_audit_records` enforces a per-record allowlist at every audit-log boundary (GUI commands + CLI subcommands). Each Side's `file_path` must equal one of the four resolved `ScopePaths` slots for the record's own `project_dir`, against the active home override. Basename allowlist (`settings.json` / `settings.local.json`) is defense in depth.

## Test plan

- [x] `validate_audit_records_refuses_path_outside_scope_allowlist` — unit test, hostile Side rejected.
- [x] `validate_audit_records_refuses_non_settings_basename` — defense-in-depth.
- [x] `validate_audit_records_accepts_legitimate_record` — sanity, real records pass.
- [x] `cli_undo_refuses_audit_record_pointing_outside_scope_allowlist` — integration test using the real `audit::` API to write a hostile record, runs `claude-scope-cli undo --yes`, asserts non-zero exit + the attacker's target file does NOT exist (write prevented before any I/O).
- [x] 257 lib + 21 CLI integration + 120 JS tests pass.
- [ ] CI confirms on Linux runner.

## v0.6 release-gate impact

This was the only [P1] / MEDIUM-or-higher finding from the security review. Once this lands, the v0.6 release-gate (#143) clears its security-review checkbox.

Closes #183, closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)