### PR TITLE
fix: land remaining v0.6 blockers (codex passes 3-6, /code-review, #183 security, #184 docs)

### DIFF
--- a/docs/src/architecture/audit-log.md
+++ b/docs/src/architecture/audit-log.md
@@ -36,7 +36,7 @@ record valid.
   },
   "path": ["permissions", "allow", 0],
   "to_kind": null,                   // set on change-kind ops
-  "claude_scope_version": "0.3.0"
+  "claude_scope_version": "0.6.0"
 }
 ```
 
@@ -165,6 +165,45 @@ window from `audit::read_all`, which now spans archives. Restoring
 to a point that lives in an archive works the same way as restoring
 to a point in the active log — same `record_sides` walk, same per-
 file snapshot revert.
+
+## Security invariants
+
+The audit log is read by every undo / redo / restore call, and its
+contents drive direct writes to the user's settings files. A hostile
+line appended to `audit.jsonl` (cloud-sync collision, malicious
+postinstall, compromised tool with user-scope write) must not be able
+to escalate into arbitrary file-write. Three gates enforce that.
+
+**Path allowlist (#183).** Every audit-log boundary —
+`undo_redo_target`, `restore_to_point_preview`,
+`apply_restore_to_point`, and the CLI's `cmd_undo` / `cmd_redo` /
+`cmd_restore` — calls `validate_audit_records` immediately after
+reading records and before building any `RestorePlan`. Each
+`Side.file_path` must equal one of the four resolved `ScopePaths`
+slots (`local`, `project`, `user_local`, `user`) for that record's
+own `project_dir`, against the active home override. Canonicalization
+absorbs platform-specific path forms (`/var → /private/var` on macOS,
+`\\?\C:\…` extended-length paths on Windows). The basename must be
+`settings.json` or `settings.local.json`. Any path outside the
+allowlist is refused with a clear `path injection refused` message;
+no writes happen.
+
+**Degraded-log refusal (#170).** `audit::read_all` reports a count
+of unreadable lines (corrupt JSON, schema drift the reader can't
+parse, truncated tails). Every undo / redo / restore path gates on
+that count: the GUI's `require_clean_audit_log` and the CLI's
+`read_audit_log` both refuse with a non-zero exit / blocked topbar
+button when `skipped > 0`. A partial log could leave the undo/redo
+state machine pointing at an op that was already undone, and
+confirming would emit a duplicate `restore` entry.
+
+**Tail-ID stalecheck (#165, #171).** Every restore re-reads the log
+immediately before applying and compares the trailing record's ULID
+against the value captured at preview time. A mismatch means the log
+changed under the user — refuse rather than apply a plan against a
+log the user didn't see. This catches concurrent GUI/CLI appends in
+the prompt window AND the (smaller) window between the initial read
+and `--yes` apply.
 
 ## Sandbox
 

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -137,3 +137,26 @@ For `undo` / `redo` / `restore`, `--json` emits the `RestorePreview`
 for a `--dry-run` and the resulting `restore` entry (as an
 `AuditRecordView`, the same shape `history --json` produces) once
 applied.
+
+### Refusals
+
+`undo` / `redo` / `restore` exit non-zero with a clear message and
+write nothing in these cases:
+
+- **`N audit-log entries are unreadable — refusing to compute
+  undo/redo against a partial log.`** The audit log has malformed
+  lines that the reader skipped. Acting against a partial log could
+  emit a duplicate restore entry; repair the log (copy aside, drop
+  the broken lines) and retry.
+- **`the audit log changed since the plan was built` /
+  `the audit log changed while waiting for confirmation`.** A
+  concurrent CLI or GUI session appended to the log between this
+  command's plan-build and apply (or during the confirm prompt). The
+  stale plan is rejected; re-run the command against the fresh log.
+- **`path injection refused`.** An entry's `file_path` points outside
+  the legitimate scope set for its `project_dir`. Indicates the log
+  has been hand-edited or corrupted by a third party; do not apply.
+  See the [security threat model](../security.md#threat-model).
+
+These refusals apply equally under `--yes` — there is no path that
+silently writes to the wrong file.

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -61,3 +61,44 @@ tomorrow with no code change on our end.
   documented at [Architecture → Audit log](./architecture/audit-log.md).
 - The docs site (this one) has **no analytics**. No tracking
   pixels, no third-party scripts.
+
+## Threat model
+
+ClaudeScope is a single-user desktop tool. The user running the app
+is the only legitimate operator. Within that frame, two threat
+surfaces are explicitly defended:
+
+**Hostile audit-log entries.** An attacker who can append a line to
+`~/.claude/claude-scope/audit.jsonl` (cloud-sync collision from a
+compromised peer, a previously-compromised tool with user-scope
+write, a malicious package postinstall, a shared workstation) should
+not be able to escalate that capability. The audit log drives
+`apply_restore_plan` to write to files at paths recorded in the log
+itself — without defenses, one well-formed line could direct
+ClaudeScope to write attacker-controlled JSON to any path the user
+can write to. The
+[Architecture → Audit log § Security invariants](./architecture/audit-log.md#security-invariants)
+section documents the three gates (path allowlist, degraded-log
+refusal, tail-ID stalecheck) that enforce containment. The path
+allowlist is the load-bearing control: every `Side.file_path` is
+validated against the four legitimate `ScopePaths` for its
+`project_dir` before any write happens.
+
+**Hand-edited settings files.** Users (or other tools) may edit
+`settings.json` outside ClaudeScope at any time. The atomic-write
+path captures a `FileStamp` at load time and refuses the save when
+the stamp differs at persist time — the user's external edit
+survives. See
+[Architecture → Atomic writes](./architecture/atomic-writes.md) for
+the contract.
+
+Out of scope:
+
+- Multi-user systems with adversarial co-users. The threat model
+  assumes a single trusted user; on shared workstations, OS-level
+  ACLs are the right layer.
+- Resource-exhaustion attacks. A user who can write large amounts
+  of data into `audit.jsonl` can fill the disk; that's a property
+  of any append-only log, not a ClaudeScope-specific issue.
+- Tampering with the bundled binary. Binary integrity is the
+  installer / OS package manager's responsibility.

--- a/docs/src/user-guide/undo-redo.md
+++ b/docs/src/user-guide/undo-redo.md
@@ -69,6 +69,28 @@ captured. If the file was hand-edited since (so its current contents
 differ from what the log expected), the confirm modal shows a warning
 band — you can still proceed, but you'll be overwriting that edit.
 
+**Disabled with a "log degraded" tooltip.** If
+`~/.claude/claude-scope/audit.jsonl` has unreadable lines (corrupt
+JSON, a crash mid-write, schema drift the build doesn't recognize),
+both Undo and Redo are withheld until the log is repaired. The
+tooltip names the count of unreadable entries. Acting against a
+partial log could emit a duplicate restore entry, so ClaudeScope
+refuses rather than guess. The CLI exits non-zero with the same
+message. Repair option: copy `audit.jsonl` aside, drop the broken
+lines, restart.
+
+**"Log changed since the preview."** If a concurrent CLI or GUI
+session writes to the audit log while the confirm modal is open,
+the apply is refused with that message — re-open the History view
+and retry against the fresh state. Same posture under
+`claude-scope-cli undo` and `--yes`.
+
+**"Path injection refused."** If an audit-log entry's `file_path`
+points outside the legitimate scope set for its project (e.g. an
+attacker hand-wrote a hostile line into `audit.jsonl`), the restore
+is refused before any I/O. See the
+[Security threat model](../security.md#threat-model) for context.
+
 ## Restore to before an entry
 
 Single-step undo walks back one operation at a time. To jump back

--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -546,39 +546,41 @@ fn audit_archives(home: Option<&Path>) -> io::Result<Vec<PathBuf>> {
     Ok(archives)
 }
 
-/// Sort key for an `audit-YYYY-MM[-N].jsonl` archive filename:
-/// `(YYYY-MM string, N as integer)`. The base archive (no suffix)
-/// sorts as `N=1` so it comes before any collision suffix
-/// (`audit-YYYY-MM-2.jsonl` and beyond). Names that don't match the
-/// pattern fall to the end with `N=u32::MAX`, which keeps them
-/// deterministic without claiming they were chronologically first.
-fn archive_sort_key(name: &str) -> (String, u32) {
+/// Sort key for an `audit-YYYY-MM[-N].jsonl` archive filename. Tuple
+/// shape is `(is_unrecognized, YYYY-MM, suffix)`:
+///
+/// - `is_unrecognized: bool` is `false` for parseable shapes and
+///   `true` for everything else. Putting it first means parseable
+///   archives sort before unknown ones regardless of name — fixing
+///   codex 3rd-pass [P2] where a stray `audit-0000.jsonl` would
+///   otherwise lex-sort ahead of valid `audit-2026-05.jsonl`.
+/// - `YYYY-MM` string for chronological grouping (lex == chrono on
+///   ISO-like dates).
+/// - `suffix: u32` — 1 for the base file, 2/3/… for the collision
+///   siblings.
+fn archive_sort_key(name: &str) -> (bool, String, u32) {
     // Strip the `audit-` prefix and `.jsonl` suffix; what's left is
     // either `YYYY-MM` or `YYYY-MM-N`.
     let stem = name
         .strip_prefix("audit-")
         .and_then(|s| s.strip_suffix(".jsonl"))
         .unwrap_or("");
+    let is_year_month = |s: &str| s.len() == 7 && s.as_bytes().get(4) == Some(&b'-');
     // Try `YYYY-MM-N` first: split on the LAST `-` and parse the tail.
     if let Some((head, tail)) = stem.rsplit_once('-') {
         if let Ok(n) = tail.parse::<u32>() {
-            // Tail parsed as a number — but only treat it as a
-            // collision suffix when the head still looks like
-            // `YYYY-MM` (7 chars, digits + one dash). Otherwise the
-            // whole stem is a bare year-month with a hyphen inside
-            // (e.g. `2026-05`).
-            if head.len() == 7 && head.as_bytes().get(4) == Some(&b'-') {
-                return (head.to_string(), n);
+            if is_year_month(head) {
+                return (false, head.to_string(), n);
             }
         }
     }
     // Bare `YYYY-MM` form — treat as collision index 1 so it sorts
     // before the `-2`, `-3`, … siblings.
-    if stem.len() == 7 && stem.as_bytes().get(4) == Some(&b'-') {
-        return (stem.to_string(), 1);
+    if is_year_month(stem) {
+        return (false, stem.to_string(), 1);
     }
-    // Unrecognized shape; park at the end deterministically.
-    (stem.to_string(), u32::MAX)
+    // Unrecognized shape; park after every parseable archive.
+    (true, stem.to_string(), 0)
 }
 
 /// Read records + skipped count from a single audit-log file. Factored
@@ -1511,12 +1513,28 @@ mod tests {
     }
 
     #[test]
-    fn archive_sort_key_parks_unknown_shapes_deterministically() {
-        // Unrecognized shapes still need a stable position. Park them
-        // at the end via u32::MAX rather than mixing with parseable
-        // archives.
-        let key = archive_sort_key("audit-garbage.jsonl");
-        assert_eq!(key.1, u32::MAX);
+    fn archive_sort_key_parks_unknown_shapes_after_valid() {
+        // Codex 3rd-pass [P2] fix: unknown shapes must sort AFTER
+        // every parseable archive, regardless of name. A stray
+        // `audit-0000.jsonl` would otherwise lex-sort ahead of valid
+        // dates. Test both directly via key + via the actual sort.
+        let valid = archive_sort_key("audit-2026-05.jsonl");
+        let unknown = archive_sort_key("audit-0000.jsonl");
+        assert!(
+            valid < unknown,
+            "valid archive {valid:?} should sort before unknown {unknown:?}"
+        );
+
+        let mut names = [
+            "audit-0000.jsonl",
+            "audit-2026-05.jsonl",
+            "audit-garbage.jsonl",
+        ];
+        names.sort_by_cached_key(|n| archive_sort_key(n));
+        assert_eq!(
+            names[0], "audit-2026-05.jsonl",
+            "parseable archive must come first"
+        );
     }
 
     #[test]

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -19,8 +19,8 @@ use claude_scope_lib::audit::{self, Record as AuditRecord};
 use claude_scope_lib::commands::{
     apply_move_leaf_impl, apply_restore_plan, audit_leaf_kind, audit_side, build_loaded,
     build_restore_plan, diff_move_leaf_impl, persist_audit_record, plan_restore_to,
-    preview_restore_plan, restore_record, AuditLogPage, AuditRecordView, MoveLeafPreview,
-    MoveLeafRequest, RestorePlan, RestorePreview,
+    preview_restore_plan, restore_record, validate_audit_records, AuditLogPage, AuditRecordView,
+    MoveLeafPreview, MoveLeafRequest, RestorePlan, RestorePreview,
 };
 use claude_scope_lib::io_atomic::{self, BackupTracker};
 use claude_scope_lib::model::{PathSeg, PermissionKind};
@@ -769,12 +769,15 @@ fn cmd_move(
 
     // Build and persist the audit record. CLI move is always
     // `Kind::Move` today — no change-kind path is exposed at the
-    // command line (#8 is GUI-only).
+    // command line (#8 is GUI-only). `project_dir` is required for
+    // the #183 path allowlist: without it, undo/redo/restore would
+    // refuse the record because they couldn't resolve the legitimate
+    // scope set. Closes #180 alongside the security fix.
     let record = audit::Record::new(
         audit::Kind::Move,
         audit_leaf_kind(&req.path),
         audit::Actor::Cli,
-        None,
+        Some(paths.project_dir.clone()),
         audit_side(
             req.from,
             from_file.as_deref(),
@@ -1029,6 +1032,11 @@ fn cmd_undo(
     let target = audit::undo_redo_state(&records)
         .undoable
         .ok_or("nothing to undo")?;
+    // Audit-log boundary check (#183). Refuse any record whose Side
+    // points outside the legitimate scope allowlist for its
+    // project_dir, so a hostile log line can't drive the apply path
+    // into writing attacker JSON to an attacker-chosen file.
+    validate_audit_records(std::slice::from_ref(&target), home)?;
     let plan = build_restore_plan(&target, audit::RestoreDirection::Undo)?;
     run_cli_restore(home, &plan, &target, expected_tail_id, dry_run, yes, json)
 }
@@ -1046,6 +1054,7 @@ fn cmd_redo(
         return Err("redo is unavailable: a change was made after the last undo".into());
     }
     let target = state.redoable.ok_or("nothing to redo")?;
+    validate_audit_records(std::slice::from_ref(&target), home)?;
     let plan = build_restore_plan(&target, audit::RestoreDirection::Redo)?;
     run_cli_restore(home, &plan, &target, expected_tail_id, dry_run, yes, json)
 }
@@ -1060,12 +1069,14 @@ fn cmd_restore(
     let records = read_audit_log(home)?;
     let expected_tail_id = records.last().map(|r| r.id);
     let target_id = resolve_entry_id(&records, id)?;
-    let plan = plan_restore_to(&records, target_id)?;
-    let target = records
+    let target_idx = records
         .iter()
-        .find(|r| r.id == target_id)
-        .expect("plan_restore_to verified the id is in the log")
-        .clone();
+        .position(|r| r.id == target_id)
+        .ok_or("target audit entry not found in the log")?;
+    // Validate the entire window (#183).
+    validate_audit_records(&records[target_idx..], home)?;
+    let plan = plan_restore_to(&records, target_id)?;
+    let target = records[target_idx].clone();
     run_cli_restore(home, &plan, &target, expected_tail_id, dry_run, yes, json)
 }
 
@@ -1820,9 +1831,14 @@ mod tests {
     }
 
     /// A logged move of `Bash(ls)` from `project` to `user`, with
-    /// before/after snapshots — the shape `cmd_undo` reads.
-    fn logged_move(project: &Path, user: &Path) -> Record {
+    /// before/after snapshots — the shape `cmd_undo` reads. The
+    /// `project_dir` argument scopes the record so the #183 path
+    /// allowlist accepts the `project` file_path; pre-validator the
+    /// helper left project_dir = None which now (correctly) fails
+    /// the security gate.
+    fn logged_move(project_dir: &Path, project: &Path, user: &Path) -> Record {
         let mut rec = make_audit_record(Kind::Move, LeafKind::PermissionRule);
+        rec.project_dir = Some(project_dir.to_path_buf());
         rec.path = vec![
             PathSeg::Key("permissions".into()),
             PathSeg::Key("allow".into()),
@@ -1854,7 +1870,11 @@ mod tests {
         // Files at their post-move state: the rule has moved Project → User.
         write_file(&project, r#"{"permissions":{"allow":[]}}"#);
         write_file(&user, r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
-        audit_lib::append(&logged_move(&project, &user), Some(home)).unwrap();
+        audit_lib::append(
+            &logged_move(&tmp.path().join("proj"), &project, &user),
+            Some(home),
+        )
+        .unwrap();
 
         // `--yes` skips the prompt; not a dry run.
         cmd_undo(Some(home), false, true, false).unwrap();
@@ -1881,7 +1901,11 @@ mod tests {
         let user = home.join(".claude/settings.json");
         write_file(&project, r#"{"permissions":{"allow":[]}}"#);
         write_file(&user, r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
-        audit_lib::append(&logged_move(&project, &user), Some(home)).unwrap();
+        audit_lib::append(
+            &logged_move(&tmp.path().join("proj"), &project, &user),
+            Some(home),
+        )
+        .unwrap();
 
         cmd_undo(Some(home), true, true, false).unwrap();
 
@@ -1911,7 +1935,7 @@ mod tests {
         write_file(&project, r#"{"permissions":{"allow":[]}}"#);
         write_file(&user, r#"{"permissions":{"allow":["Bash(ls)"]}}"#);
         // move → undo(move) → another move = a sequence break.
-        let m1 = logged_move(&project, &user);
+        let m1 = logged_move(&tmp.path().join("proj"), &project, &user);
         let undo = Record::new_restore(
             LeafKind::PermissionRule,
             Actor::Gui,
@@ -1923,7 +1947,7 @@ mod tests {
                 files: vec![],
             },
         );
-        let m2 = logged_move(&project, &user);
+        let m2 = logged_move(&tmp.path().join("proj"), &project, &user);
         for rec in [&m1, &undo, &m2] {
             audit_lib::append(rec, Some(home)).unwrap();
         }

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -424,18 +424,38 @@ fn resolve_paths(
     let Some(project_root) = project_dir else {
         return Ok(scope::resolve_with_home(None, home_dir)?);
     };
-    let home = home_dir
-        .map(std::path::Path::to_path_buf)
-        .or_else(dirs::home_dir);
+    // Absolutize the project root so audit-log entries persist absolute
+    // `file_path` values. Otherwise a CLI move with `--project-dir foo`
+    // logs `./foo/.claude/settings.json`, and a later `undo` run from a
+    // different cwd would resolve that against the new cwd — restoring
+    // (or creating) the wrong file. Same posture for `--home-dir`. See
+    // codex 4th-pass [P1].
+    let project_root_abs = absolutize(project_root)?;
+    let home = match home_dir {
+        Some(p) => Some(absolutize(p)?),
+        None => dirs::home_dir(),
+    };
     Ok(ScopePaths {
-        project_dir: project_root.to_path_buf(),
-        local: Some(project_root.join(".claude").join("settings.local.json")),
-        project: Some(project_root.join(".claude").join("settings.json")),
+        project_dir: project_root_abs.clone(),
+        local: Some(project_root_abs.join(".claude").join("settings.local.json")),
+        project: Some(project_root_abs.join(".claude").join("settings.json")),
         user_local: home
             .as_ref()
             .map(|h| h.join(".claude").join("settings.local.json")),
         user: home.map(|h| h.join(".claude").join("settings.json")),
     })
+}
+
+/// Resolve a possibly-relative path against the current working
+/// directory, without requiring the target to exist. Used to anchor CLI
+/// `--project-dir` / `--home-dir` flags so any audit-log entries built
+/// from them carry absolute paths — see `resolve_paths`.
+fn absolutize(p: &std::path::Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if p.is_absolute() {
+        Ok(p.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(p))
+    }
 }
 
 fn cmd_scopes(paths: &ScopePaths, json: bool) -> Result<(), Box<dyn std::error::Error>> {
@@ -1403,9 +1423,15 @@ mod tests {
         // ancestor (e.g. $HOME) happens to be a git working tree. Pin the
         // CLI-literal behavior so a future refactor can't quietly route
         // back through the walk-up.
-        let project = Path::new("/tmp/clitest-fixture/project");
-        let home = Path::new("/tmp/clitest-fixture/home");
-        let paths = resolve_paths(Some(project), Some(home)).unwrap();
+        //
+        // Use a tempdir so the paths are absolute on both Linux and
+        // Windows — bare `/tmp/...` strings look absolute on Linux but
+        // are relative on Windows, and `absolutize()` would resolve them
+        // against the test process's cwd. See codex 4th-pass [P1].
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("clitest-fixture").join("project");
+        let home = tmp.path().join("clitest-fixture").join("home");
+        let paths = resolve_paths(Some(&project), Some(&home)).unwrap();
         assert_eq!(paths.project_dir, project);
         assert_eq!(
             paths.local.as_deref().unwrap(),
@@ -1422,9 +1448,10 @@ mod tests {
         // Sandbox / dogfooding parity with the GUI's `--home` override.
         // Verify user + user-local both resolve under the supplied home,
         // not the real `dirs::home_dir()`.
-        let project = Path::new("/tmp/clitest-fixture/project");
-        let home = Path::new("/tmp/clitest-fixture/home");
-        let paths = resolve_paths(Some(project), Some(home)).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("clitest-fixture").join("project");
+        let home = tmp.path().join("clitest-fixture").join("home");
+        let paths = resolve_paths(Some(&project), Some(&home)).unwrap();
         assert_eq!(
             paths.user.as_deref().unwrap(),
             home.join(".claude").join("settings.json")
@@ -1433,6 +1460,23 @@ mod tests {
             paths.user_local.as_deref().unwrap(),
             home.join(".claude").join("settings.local.json")
         );
+    }
+
+    #[test]
+    fn resolve_paths_absolutizes_relative_project_dir() {
+        // Regression for codex 4th-pass [P1]: a relative `--project-dir`
+        // used to be stored verbatim in `ScopePaths` and propagated into
+        // the audit log's `file_path` values, so a later `undo` /
+        // `restore` run from a different cwd would resolve them against
+        // the new cwd and miss (or clobber) the original project.
+        let cwd = std::env::current_dir().unwrap();
+        let paths = resolve_paths(Some(Path::new("relative-foo")), None).unwrap();
+        assert!(
+            paths.project_dir.is_absolute(),
+            "project_dir must be absolute, got: {}",
+            paths.project_dir.display()
+        );
+        assert_eq!(paths.project_dir, cwd.join("relative-foo"));
     }
 
     #[test]

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -421,20 +421,21 @@ fn resolve_paths(
     project_dir: Option<&std::path::Path>,
     home_dir: Option<&std::path::Path>,
 ) -> Result<ScopePaths, Box<dyn std::error::Error>> {
-    let Some(project_root) = project_dir else {
-        return Ok(scope::resolve_with_home(None, home_dir)?);
-    };
-    // Absolutize the project root so audit-log entries persist absolute
-    // `file_path` values. Otherwise a CLI move with `--project-dir foo`
-    // logs `./foo/.claude/settings.json`, and a later `undo` run from a
-    // different cwd would resolve that against the new cwd — restoring
-    // (or creating) the wrong file. Same posture for `--home-dir`. See
-    // codex 4th-pass [P1].
-    let project_root_abs = absolutize(project_root)?;
-    let home = match home_dir {
+    // Absolutize `--home-dir` regardless of which branch we take — a
+    // relative `--home-dir` would otherwise persist relative
+    // `file_path`s into the audit log for the user / user-local scopes,
+    // and a later restore from a different cwd would resolve those
+    // against the new cwd. Codex 5th-pass [P1].
+    let home_abs = match home_dir {
         Some(p) => Some(absolutize(p)?),
-        None => dirs::home_dir(),
+        None => None,
     };
+    let Some(project_root) = project_dir else {
+        return Ok(scope::resolve_with_home(None, home_abs.as_deref())?);
+    };
+    // Same absolutize for `--project-dir` (codex 4th-pass [P1]).
+    let project_root_abs = absolutize(project_root)?;
+    let home = home_abs.or_else(dirs::home_dir);
     Ok(ScopePaths {
         project_dir: project_root_abs.clone(),
         local: Some(project_root_abs.join(".claude").join("settings.local.json")),
@@ -934,10 +935,10 @@ fn resolve_entry_id(
 /// confirm, apply, and log the resulting `restore` entry (actor `cli`).
 ///
 /// `expected_tail_id` is the ULID of the last audit-log record the caller
-/// saw when building the plan. After the confirm prompt — the only window
-/// where another process can append an entry — the log is re-read and the
-/// new tail compared against `expected_tail_id`. A mismatch means the
-/// plan is stale; abort instead of applying it (#165).
+/// saw when building the plan. Immediately before applying — whether the
+/// user just confirmed at a prompt or skipped the prompt via `--yes` —
+/// the log is re-read and compared. A mismatch means the plan is stale;
+/// abort instead of applying it (#165, codex 5th-pass extension).
 fn run_cli_restore(
     home: Option<&std::path::Path>,
     plan: &RestorePlan,
@@ -968,38 +969,34 @@ fn run_cli_restore(
             }
             return Ok(());
         }
-        // Re-read the log right after the prompt to catch a concurrent
-        // append from another GUI/CLI session that landed during the
-        // user's confirm window. The plan was computed against the
-        // pre-prompt log; applying it against a changed log can clobber
-        // the intervening op. Skipped only when `--yes` is set, since
-        // there's no prompt window then. See #165.
-        let (current_records, current_skipped) = audit::read_all(home)?;
-        // Mirror the GUI's `require_clean_audit_log` gate: a malformed
-        // tail line that landed during the prompt window would skip the
-        // tail-id check entirely (the corrupt entry doesn't shift the
-        // last record's id), and the restore would apply against a
-        // partial log. Refuse instead. Codex 3rd-pass [P1].
-        if current_skipped > 0 {
-            return Err(format!(
-                "the audit log became degraded while waiting for confirmation \
-                 ({current_skipped} unreadable {}). Re-run the command after \
-                 repairing the log.",
-                if current_skipped == 1 {
-                    "entry"
-                } else {
-                    "entries"
-                }
-            )
+    }
+    // Re-read the log immediately before applying — covers both the
+    // interactive prompt window and the smaller-but-real window between
+    // the caller's initial read and this point under `--yes`. A
+    // concurrent GUI/CLI append in either window would leave us
+    // applying a stale plan against a changed log. Refuse on any
+    // mismatch (tail shifted, or new malformed lines). Codex 3rd- and
+    // 5th-pass [P1]s.
+    let (current_records, current_skipped) = audit::read_all(home)?;
+    if current_skipped > 0 {
+        return Err(format!(
+            "the audit log became degraded since the plan was built \
+             ({current_skipped} unreadable {}). Re-run the command after \
+             repairing the log.",
+            if current_skipped == 1 {
+                "entry"
+            } else {
+                "entries"
+            }
+        )
+        .into());
+    }
+    let current_tail = current_records.last().map(|r| r.id);
+    if current_tail != expected_tail_id {
+        return Err("the audit log changed since the plan was built \
+                    (another session appended an entry). \
+                    Re-run the command."
             .into());
-        }
-        let current_tail = current_records.last().map(|r| r.id);
-        if current_tail != expected_tail_id {
-            return Err("the audit log changed while waiting for \
-                        confirmation (another session appended an entry). \
-                        Re-run the command."
-                .into());
-        }
     }
     let files = apply_restore_plan(plan, cli_backups_for_session(), &WatchState::default())?;
     let record = restore_record(plan, audit::Actor::Cli, files);

--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -954,7 +954,25 @@ fn run_cli_restore(
         // pre-prompt log; applying it against a changed log can clobber
         // the intervening op. Skipped only when `--yes` is set, since
         // there's no prompt window then. See #165.
-        let (current_records, _) = audit::read_all(home)?;
+        let (current_records, current_skipped) = audit::read_all(home)?;
+        // Mirror the GUI's `require_clean_audit_log` gate: a malformed
+        // tail line that landed during the prompt window would skip the
+        // tail-id check entirely (the corrupt entry doesn't shift the
+        // last record's id), and the restore would apply against a
+        // partial log. Refuse instead. Codex 3rd-pass [P1].
+        if current_skipped > 0 {
+            return Err(format!(
+                "the audit log became degraded while waiting for confirmation \
+                 ({current_skipped} unreadable {}). Re-run the command after \
+                 repairing the log.",
+                if current_skipped == 1 {
+                    "entry"
+                } else {
+                    "entries"
+                }
+            )
+            .into());
+        }
         let current_tail = current_records.last().map(|r| r.id);
         if current_tail != expected_tail_id {
             return Err("the audit log changed while waiting for \

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2186,55 +2186,79 @@ pub fn apply_restore_plan(
     backups: Option<&BackupTracker>,
     watch: &WatchState,
 ) -> Result<Vec<audit::Side>, Box<dyn std::error::Error>> {
-    /// Everything needed to write one file and, if a later file fails, to
-    /// roll this one back. `pending[i]` lines up with `plan.targets[i]`.
-    struct Pending {
+    /// One unique file's combined write. Multiple plan targets that
+    /// share `file_path` (different `top_level_key`s) coalesce into
+    /// the same `FileWrite` — its `new_doc` accumulates every key's
+    /// restored value, then a single save persists the combined
+    /// result. Without this coalescing, two targets on the same file
+    /// each issued their own save against the original stamp; the
+    /// second save would either hit `ConcurrentModification` (because
+    /// the first save changed the file) or, on coarse-mtime filesystems,
+    /// overwrite the first key's restoration with a stale doc. See
+    /// codex 4th-pass [P1].
+    struct FileWrite {
         path: PathBuf,
         existed: bool,
         original: SettingsDoc,
         stamp: FileStamp,
         new_doc: SettingsDoc,
-        before_key: Option<serde_json::Value>,
     }
 
-    // Phase 1 — load + compute. No disk writes here, so a failure to read
-    // any target aborts the whole batch with nothing on disk touched.
-    let mut pending: Vec<Pending> = Vec::with_capacity(plan.targets.len());
+    // Phase 1 — load + accumulate per-file mutations. The first time we
+    // see a file_path, load it; every subsequent target on the same
+    // file just mutates the in-progress new_doc. Preserves first-seen
+    // file order so phase 2 writes in plan order.
+    let mut writes: Vec<FileWrite> = Vec::new();
+    let mut file_idx: std::collections::HashMap<PathBuf, usize> = std::collections::HashMap::new();
     for t in &plan.targets {
-        let (loaded, stamp) = io_atomic::load_with_stamp(&t.file_path)?;
-        let existed = loaded.is_some();
-        let original = loaded.unwrap_or_else(SettingsDoc::empty);
-        let before_key = original.get_top_level(&t.top_level_key).cloned();
-        let mut new_doc = original.clone();
-        match &t.target_value {
-            Some(v) => new_doc.set_top_level(&t.top_level_key, v.clone()),
+        let idx = match file_idx.get(&t.file_path) {
+            Some(&i) => i,
             None => {
-                new_doc.remove_at_path(&[PathSeg::Key(t.top_level_key.clone())]);
+                let (loaded, stamp) = io_atomic::load_with_stamp(&t.file_path)?;
+                let existed = loaded.is_some();
+                let original = loaded.unwrap_or_else(SettingsDoc::empty);
+                let new_doc = original.clone();
+                let i = writes.len();
+                file_idx.insert(t.file_path.clone(), i);
+                writes.push(FileWrite {
+                    path: t.file_path.clone(),
+                    existed,
+                    original,
+                    stamp,
+                    new_doc,
+                });
+                i
+            }
+        };
+        let fw = &mut writes[idx];
+        match &t.target_value {
+            Some(v) => fw.new_doc.set_top_level(&t.top_level_key, v.clone()),
+            None => {
+                fw.new_doc
+                    .remove_at_path(&[PathSeg::Key(t.top_level_key.clone())]);
             }
         }
-        pending.push(Pending {
-            path: t.file_path.clone(),
-            existed,
-            original,
-            stamp,
-            new_doc,
-            before_key,
-        });
     }
 
-    // Phase 2 — write. Track which files landed so a mid-batch failure
-    // rolls them back: same posture as `apply_move_leaf_impl`'s two-file
-    // dance, generalized to N files.
+    // Phase 2 — write each unique file once. Skip a file whose
+    // accumulated new_doc matches its original on every key the plan
+    // touched (no key actually moved — e.g. every per-key target was
+    // a no-op against current disk).
     let mut written: Vec<usize> = Vec::new();
-    for (i, p) in pending.iter().enumerate() {
-        // Skip a file already at the target value — no point churning the
-        // watcher or dropping a `.bak` for a zero-delta write.
-        if p.before_key == plan.targets[i].target_value {
+    for (i, fw) in writes.iter().enumerate() {
+        let no_change = plan.targets.iter().all(|t| {
+            if t.file_path != fw.path {
+                return true;
+            }
+            let before = fw.original.get_top_level(&t.top_level_key).cloned();
+            before == t.target_value
+        });
+        if no_change {
             continue;
         }
-        if let Err(write_err) = io_atomic::save(&p.path, &p.new_doc, backups, Some(&p.stamp)) {
+        if let Err(write_err) = io_atomic::save(&fw.path, &fw.new_doc, backups, Some(&fw.stamp)) {
             for &w in written.iter().rev() {
-                let pw = &pending[w];
+                let pw = &writes[w];
                 let rollback: Result<(), Box<dyn std::error::Error>> = if pw.existed {
                     io_atomic::save(&pw.path, &pw.original, backups, None).map_err(Into::into)
                 } else {
@@ -2244,7 +2268,7 @@ pub fn apply_restore_plan(
                     return Err(format!(
                         "restore write of {} failed: {write_err}; \
                          rolling back {} also failed: {rollback_err}",
-                        p.path.display(),
+                        fw.path.display(),
                         pw.path.display()
                     )
                     .into());
@@ -2253,27 +2277,36 @@ pub fn apply_restore_plan(
             }
             return Err(format!(
                 "restore write of {} failed — all earlier files rolled back: {write_err}",
-                p.path.display()
+                fw.path.display()
             )
             .into());
         }
-        watch.note_self_write(&p.path);
+        watch.note_self_write(&fw.path);
         written.push(i);
     }
 
-    // The audit Sides describe what each file held before vs after. Built
-    // for every target, including no-op ones, so undoing this restore has
-    // a complete picture.
+    // Phase 3 — produce one audit Side per plan target, with per-key
+    // before/after values pulled from the matching FileWrite. The
+    // returned Sides line up 1:1 with `plan.targets`, even when two
+    // targets share a file_path — each Side reports its own
+    // top-level-key transition.
     Ok(plan
         .targets
         .iter()
-        .zip(&pending)
-        .map(|(t, p)| audit::Side {
-            scope: t.scope,
-            file_path: t.file_path.clone(),
-            top_level_key: t.top_level_key.clone(),
-            key_before: p.before_key.clone(),
-            key_after: t.target_value.clone(),
+        .map(|t| {
+            let idx = file_idx
+                .get(&t.file_path)
+                .expect("every target was inserted in phase 1");
+            let fw = &writes[*idx];
+            let key_before = fw.original.get_top_level(&t.top_level_key).cloned();
+            let key_after = fw.new_doc.get_top_level(&t.top_level_key).cloned();
+            audit::Side {
+                scope: t.scope,
+                file_path: t.file_path.clone(),
+                top_level_key: t.top_level_key.clone(),
+                key_before,
+                key_after,
+            }
         })
         .collect())
 }
@@ -3622,6 +3655,63 @@ mod tests {
             key_before: Some(before),
             key_after: Some(after),
         }
+    }
+
+    #[test]
+    fn apply_restore_plan_coalesces_two_targets_in_one_file() {
+        // Regression for codex 4th-pass [P1]. Two restore targets on
+        // the same file (different top-level keys) used to load the
+        // file twice from the same stamp and save twice; the second
+        // save tripped ConcurrentModification (or, worse, overwrote
+        // the first key's restore on coarse-mtime filesystems). The
+        // fix loads once per file and accumulates per-key mutations
+        // into a single new_doc + a single save.
+        let tmp = tempfile::tempdir().unwrap();
+        let project = paths_in(tmp.path()).project.clone().unwrap();
+        // Current on-disk state — both keys present in their
+        // post-change form.
+        write(
+            &project,
+            r#"{"env":{"X":"1","Y":"2"},"permissions":{"allow":["A"]}}"#,
+        );
+
+        let plan = RestorePlan {
+            direction: audit::RestoreDirection::ToPoint,
+            target_id: Ulid::new(),
+            leaf_kind: audit::LeafKind::PermissionRule,
+            project_dir: None,
+            path: vec![],
+            ops_spanned: 2,
+            targets: vec![
+                RestoreTarget {
+                    scope: Scope::Project,
+                    file_path: project.clone(),
+                    top_level_key: "env".to_string(),
+                    target_value: Some(serde_json::json!({"X": "1"})),
+                    expected_current: Some(serde_json::json!({"X": "1", "Y": "2"})),
+                },
+                RestoreTarget {
+                    scope: Scope::Project,
+                    file_path: project.clone(),
+                    top_level_key: "permissions".to_string(),
+                    target_value: Some(serde_json::json!({"allow": []})),
+                    expected_current: Some(serde_json::json!({"allow": ["A"]})),
+                },
+            ],
+        };
+
+        let sides = apply_restore_plan(&plan, None, &WatchState::default()).unwrap();
+        // Both Sides returned, in plan order, each carrying its own
+        // key's before/after.
+        assert_eq!(sides.len(), 2);
+        assert_eq!(sides[0].top_level_key, "env");
+        assert_eq!(sides[1].top_level_key, "permissions");
+
+        // The file holds BOTH restored keys, not just one of them.
+        let on_disk = std::fs::read_to_string(&project).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&on_disk).unwrap();
+        assert_eq!(v["env"], serde_json::json!({"X": "1"}));
+        assert_eq!(v["permissions"], serde_json::json!({"allow": []}));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -720,6 +720,12 @@ fn undo_redo_target(
     overrides: &RuntimeOverrides,
 ) -> Result<audit::Record, Box<dyn std::error::Error>> {
     let records = require_clean_audit_log(overrides)?;
+    // Audit log boundary check — refuse any record whose Side points
+    // at a path outside the legitimate scope-file allowlist for its
+    // project_dir (#183). A hostile log line can otherwise drive
+    // `apply_restore_plan` to write attacker JSON to any user-writable
+    // path.
+    validate_audit_records(&records, overrides.home())?;
     let state = audit::undo_redo_state(&records);
     let target = match direction {
         audit::RestoreDirection::Undo => state.undoable,
@@ -871,6 +877,14 @@ fn restore_to_point_preview(
 ) -> Result<RestorePreview, Box<dyn std::error::Error>> {
     let id = parse_audit_id(target_id)?;
     let records = require_clean_audit_log(overrides)?;
+    // Validate the entire window before building the plan (#183). Each
+    // record in `[target..]` could reference a different project_dir;
+    // the validator checks each against its own allowlist.
+    let target_idx = records
+        .iter()
+        .position(|r| r.id == id)
+        .ok_or("target audit entry not found in the log")?;
+    validate_audit_records(&records[target_idx..], overrides.home())?;
     let plan = plan_restore_to(&records, id)?;
     let target = records
         .iter()
@@ -903,6 +917,14 @@ fn apply_restore_to_point(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let id = parse_audit_id(target_id)?;
     let records = require_clean_audit_log(overrides)?;
+    // Allowlist gate on the window — see `restore_to_point_preview`.
+    // Mirrored at apply time so a malicious record appended between
+    // preview and apply also fails the security check (#183).
+    let target_idx_for_validate = records
+        .iter()
+        .position(|r| r.id == id)
+        .ok_or("target audit entry not found in the log")?;
+    validate_audit_records(&records[target_idx_for_validate..], overrides.home())?;
     // Identity check first: a concurrent rotate+append can leave the log
     // with a same-length-but-different-records window (codex #166 +
     // #171). Compare the trailing ULID against the preview's snapshot.
@@ -1985,6 +2007,103 @@ fn record_sides(rec: &audit::Record) -> Vec<&audit::Side> {
 fn record_view(rec: audit::Record) -> AuditRecordView {
     let ts_ms = rec.id.timestamp_ms();
     AuditRecordView { record: rec, ts_ms }
+}
+
+/// Validate every record in `records` against the legitimate scope-file
+/// allowlist (#183). Returns an error on the first record whose Side
+/// points outside the resolved [`ScopePaths`] for that record's own
+/// `project_dir`. Used at every audit-log boundary — GUI commands and
+/// CLI subcommands call this immediately after loading records and
+/// before building any [`RestorePlan`], so a hostile audit-log line
+/// can never reach `apply_restore_plan` with an attacker-controlled
+/// `file_path`.
+pub fn validate_audit_records(
+    records: &[audit::Record],
+    home_dir: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for entry in records {
+        for s in record_sides(entry) {
+            validate_audit_path(
+                &s.file_path,
+                &s.top_level_key,
+                entry.project_dir.as_deref(),
+                home_dir,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Verify that an audit-log-derived `file_path` belongs to the legitimate
+/// scope-file allowlist for `record_project_dir` under `home_dir`. Returns
+/// an error if the path is outside the resolved [`ScopePaths`] (local,
+/// project, user_local, user) for that project, or if the basename isn't
+/// a settings file.
+///
+/// Closes the path-injection primitive in #183: without this check, a
+/// hostile audit-log line carrying an arbitrary `file_path` would drive
+/// [`apply_restore_plan`] to write attacker-chosen JSON to any path the
+/// user can write to (including, on Windows, the Startup folder, and on
+/// Unix files like `~/.config/Code/User/settings.json` whose contents
+/// trigger code execution on the next app launch).
+///
+/// Both sides are canonicalized before comparison so a stamp-style path
+/// (`/private/var/...` on macOS, `\\?\C:\...` on Windows) doesn't slip
+/// past byte-equal checks. A canonicalize failure (target file doesn't
+/// exist yet — legitimate for create-on-restore) falls back to lexical
+/// equality, which is safe: the audit log stores the same path string
+/// the resolver produces, so they match without canonicalization too.
+fn validate_audit_path(
+    target_path: &Path,
+    _target_top_level_key: &str,
+    record_project_dir: Option<&Path>,
+    home_dir: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let basename = target_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    if !matches!(basename, "settings.json" | "settings.local.json") {
+        return Err(format!(
+            "audit-log path injection refused: file_path `{}` does not look \
+             like a Claude Code settings file (basename `{}`).",
+            target_path.display(),
+            basename
+        )
+        .into());
+    }
+    let paths = scope::resolve_with_home(record_project_dir, home_dir)?;
+    let allowed: [Option<&Path>; 4] = [
+        paths.local.as_deref(),
+        paths.project.as_deref(),
+        paths.user_local.as_deref(),
+        paths.user.as_deref(),
+    ];
+    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    let target_canon = canon(target_path);
+    if !allowed
+        .iter()
+        .filter_map(|opt| *opt)
+        .any(|allowed_path| canon(allowed_path) == target_canon || allowed_path == target_path)
+    {
+        return Err(format!(
+            "audit-log path injection refused: file_path `{}` is not a \
+             legitimate scope file for project_dir `{}`. \
+             Refusing to restore to a path outside the resolved scope set.",
+            target_path.display(),
+            record_project_dir
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "<user-only>".to_string()),
+        )
+        .into());
+    }
+    // Top-level key allowlist is intentionally left for follow-up — the
+    // load-bearing security control is the path allowlist above. A
+    // hostile `top_level_key` on a *legitimate* settings.json file
+    // expands attacker control to the user's own Claude config keys,
+    // which is a much narrower blast radius than the original
+    // arbitrary-file-write primitive.
+    Ok(())
 }
 
 /// Build the plan to undo or redo a single op record.
@@ -3712,6 +3831,116 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&on_disk).unwrap();
         assert_eq!(v["env"], serde_json::json!({"X": "1"}));
         assert_eq!(v["permissions"], serde_json::json!({"allow": []}));
+    }
+
+    #[test]
+    fn validate_audit_records_refuses_path_outside_scope_allowlist() {
+        // Regression for #183 (security). A hostile audit-log line
+        // carrying a `file_path` outside the resolved ScopePaths for
+        // its `project_dir` must be rejected before any restore plan
+        // is built. Otherwise the apply path would write attacker-
+        // controlled JSON to an attacker-chosen file.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+
+        // Hostile record claims its project is the test's project, but
+        // its Side's file_path points at a totally different file.
+        let hostile = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            Some(paths.project_dir.clone()),
+            None,
+            Some(audit::Side {
+                scope: Scope::User,
+                file_path: tmp.path().join("malicious-target.json"),
+                top_level_key: "permissions".to_string(),
+                key_before: Some(serde_json::json!({})),
+                key_after: Some(serde_json::json!({"allow": ["pwn"]})),
+            }),
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+
+        let home = tmp.path().join("home");
+        let err = validate_audit_records(std::slice::from_ref(&hostile), Some(&home))
+            .expect_err("must refuse path outside scope allowlist");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("path injection refused"),
+            "expected path-injection refusal, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_audit_records_refuses_non_settings_basename() {
+        // Defense-in-depth: even a path the resolver might somehow
+        // produce must end in `settings.json` or `settings.local.json`.
+        // Catches hostile records that try to use the home dir
+        // structure to claim a non-settings basename.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+
+        let hostile = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            Some(paths.project_dir.clone()),
+            None,
+            Some(audit::Side {
+                scope: Scope::Project,
+                file_path: paths.project_dir.join(".claude").join("config.json"), // wrong basename
+                top_level_key: "permissions".to_string(),
+                key_before: None,
+                key_after: Some(serde_json::json!({"allow": ["x"]})),
+            }),
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+
+        let err = validate_audit_records(std::slice::from_ref(&hostile), None)
+            .expect_err("must refuse non-settings basename");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does not look like a Claude Code settings file"),
+            "expected basename refusal, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_audit_records_accepts_legitimate_record() {
+        // Sanity: a record produced for a legitimate scope file under
+        // the resolved project must pass.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+
+        let legit = audit::Record::new(
+            audit::Kind::Move,
+            audit::LeafKind::PermissionRule,
+            audit::Actor::Gui,
+            Some(paths.project_dir.clone()),
+            Some(audit::Side {
+                scope: Scope::Project,
+                file_path: paths.project.clone().unwrap(),
+                top_level_key: "permissions".to_string(),
+                key_before: Some(serde_json::json!({"allow": ["A"]})),
+                key_after: Some(serde_json::json!({"allow": []})),
+            }),
+            Some(audit::Side {
+                scope: Scope::User,
+                file_path: paths.user.clone().unwrap(),
+                top_level_key: "permissions".to_string(),
+                key_before: Some(serde_json::json!({"allow": []})),
+                key_after: Some(serde_json::json!({"allow": ["A"]})),
+            }),
+            vec![key("permissions"), key("allow"), idx(0)],
+            None,
+        );
+
+        // home_dir matches what paths_in used for user_home.
+        let home = tmp.path().join("home");
+        validate_audit_records(std::slice::from_ref(&legit), Some(&home))
+            .expect("legitimate record must pass");
     }
 
     #[test]

--- a/src-tauri/src/preferences.rs
+++ b/src-tauri/src/preferences.rs
@@ -292,10 +292,17 @@ where
 /// give us a config directory (no `$HOME` set, say) — we treat that the same
 /// as "no config yet" and fall back to defaults.
 ///
-/// `CLAUDE_SCOPE_CONFIG_DIR` overrides the default OS location. Used by the
-/// CLI integration tests to point at a sandbox config; also a useful escape
-/// hatch for users who want to relocate preferences (XDG-style on platforms
-/// where `dirs` doesn't honor it natively).
+/// `CLAUDE_SCOPE_CONFIG_DIR` overrides the default OS location. **This is a
+/// developer/test hook, not a user-facing feature.** The CLI integration
+/// tests under `src-tauri/tests/cli.rs` set it on each subprocess to give
+/// every test an isolated sandbox config (the alternative — touching the
+/// developer's real `~/.config/claude-scope/` — would be unsafe and
+/// non-parallel). A power user who knowingly sets this env var to relocate
+/// their config will get the relocation, but there is no UI affordance for
+/// it: the Settings dialog will silently read/write at the override path
+/// with no banner the way `--home`'s sandbox mode shows. If we ever want
+/// to expose config relocation as a real feature, plumb it through
+/// `RuntimeOverrides` instead so the sandbox banner picks it up.
 pub fn config_path() -> Option<PathBuf> {
     if let Some(override_dir) = std::env::var_os("CLAUDE_SCOPE_CONFIG_DIR") {
         return Some(PathBuf::from(override_dir).join("config.json"));

--- a/src-tauri/tests/cli.rs
+++ b/src-tauri/tests/cli.rs
@@ -601,6 +601,69 @@ fn cli_undo_aborts_when_audit_log_changes_during_confirm_prompt() {
     );
 }
 
+/// #183 (security): a hostile audit-log line carrying a `file_path`
+/// outside the legitimate scope set must be refused by the CLI restore
+/// pipeline. Without the allowlist gate, `claude-scope-cli undo --yes`
+/// would write attacker-controlled JSON to the attacker-chosen path.
+#[test]
+fn cli_undo_refuses_audit_record_pointing_outside_scope_allowlist() {
+    use claude_scope_lib::audit;
+    use claude_scope_lib::model::{PathSeg, PermissionKind};
+    use claude_scope_lib::scope::Scope as ScopeEnum;
+
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":[]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":[]}}"#);
+
+    let malicious_target_path = sb._tmp.path().join("attacker-chosen.json");
+
+    // Construct a hostile record via the real audit:: API so the
+    // serde shape is guaranteed correct (the threat model is "attacker
+    // gets one well-formed line into audit.jsonl"). project_dir
+    // claims the legitimate sandbox project; the Side's file_path
+    // points outside the resolved ScopePaths.
+    let hostile = audit::Record::new(
+        audit::Kind::Move,
+        audit::LeafKind::PermissionRule,
+        audit::Actor::Gui,
+        Some(sb.project.clone()),
+        None,
+        Some(audit::Side {
+            scope: ScopeEnum::User,
+            file_path: malicious_target_path.clone(),
+            top_level_key: "permissions".to_string(),
+            key_before: Some(serde_json::json!({"allow": []})),
+            key_after: Some(serde_json::json!({"allow": ["pwn"]})),
+        }),
+        vec![
+            PathSeg::Key("permissions".to_string()),
+            PathSeg::Key("allow".to_string()),
+            PathSeg::Index(0),
+        ],
+        None::<PermissionKind>,
+    );
+    audit::append(&hostile, Some(sb.home.as_path())).expect("write hostile line");
+
+    let out = sb.run(&["undo", "--yes"]);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on hostile audit record, got success. stderr: {}",
+        stderr(&out)
+    );
+    let err = stderr(&out);
+    assert!(
+        err.contains("path injection refused"),
+        "expected path-injection refusal on stderr, got: {err}"
+    );
+
+    // The attacker's target file must NOT exist — the hostile write
+    // was prevented BEFORE any I/O happened.
+    assert!(
+        !malicious_target_path.exists(),
+        "hostile target file must not have been written"
+    );
+}
+
 /// Codex 3rd-pass [P1] — even the post-confirm re-read in
 /// `run_cli_restore` must refuse a degraded log. A malformed line
 /// appended during the prompt window doesn't change the trailing

--- a/src-tauri/tests/cli.rs
+++ b/src-tauri/tests/cli.rs
@@ -601,6 +601,82 @@ fn cli_undo_aborts_when_audit_log_changes_during_confirm_prompt() {
     );
 }
 
+/// Codex 3rd-pass [P1] — even the post-confirm re-read in
+/// `run_cli_restore` must refuse a degraded log. A malformed line
+/// appended during the prompt window doesn't change the trailing
+/// ULID (it's just `skipped`), so the existing tail-id check sails
+/// past it. The new `skipped > 0` guard catches it.
+#[test]
+fn cli_undo_refuses_when_audit_log_degrades_during_confirm_prompt() {
+    use std::io::Write as _;
+    use std::process::Stdio;
+    use std::time::Duration;
+
+    let sb = Sandbox::new();
+    sb.write_project(r#"{"permissions":{"allow":["Bash(git status)"]}}"#);
+    sb.write_user(r#"{"permissions":{"allow":[]}}"#);
+
+    // Seed one valid CLI move so undo has something to act on.
+    let mv = sb.run(&[
+        "move",
+        "Bash(git status)",
+        "--kind",
+        "allow",
+        "--from",
+        "project",
+        "--to",
+        "user",
+    ]);
+    assert!(mv.status.success(), "seed move failed: {}", stderr(&mv));
+
+    let mut child = Command::new(BIN)
+        .env("CLAUDE_SCOPE_CONFIG_DIR", &sb.config_dir)
+        .args([
+            "--project-dir",
+            sb.project.to_str().unwrap(),
+            "--home-dir",
+            sb.home.to_str().unwrap(),
+        ])
+        .arg("undo")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn claude-scope-cli undo");
+
+    std::thread::sleep(Duration::from_millis(400));
+
+    // Append a malformed line directly to the audit log — the post-
+    // confirm re-read will see this as `skipped > 0`.
+    let audit_path = sb
+        .home
+        .join(".claude")
+        .join("claude-scope")
+        .join("audit.jsonl");
+    let mut existing = std::fs::read_to_string(&audit_path).expect("read audit log");
+    existing.push_str("{ this is not valid json }\n");
+    std::fs::write(&audit_path, existing).expect("inject corrupt line");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("piped stdin")
+        .write_all(b"y\n")
+        .expect("write y to child stdin");
+
+    let out = child.wait_with_output().expect("wait for child");
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit on degraded log, got success. stderr: {}",
+        stderr(&out)
+    );
+    let err = stderr(&out);
+    assert!(
+        err.contains("degraded") && err.contains("unreadable"),
+        "expected degraded-log message on stderr, got: {err}"
+    );
+}
+
 /// #170 — CLI undo / redo / restore must refuse against a log with
 /// unreadable lines. A corrupt restore line could leave the state
 /// machine pointing at an op that's already undone; running undo

--- a/src/main.ts
+++ b/src/main.ts
@@ -215,7 +215,11 @@ async function moveLeaf(
   if (moveInFlight) return;
   moveInFlight = true;
   try {
-    const projectDir = state.projectDir;
+    // `opts.projectDir` lets the Move-to submenu redirect a write into
+    // a different known project's `local` / `project` scope (#111).
+    // Without honoring it we'd silently target the currently-open
+    // project regardless of which entry the user clicked.
+    const projectDir = opts?.projectDir ?? state.projectDir;
     // Drag-and-drop drops set `skipConfirm`: the user already expressed
     // intent by dragging onto a target column, so the diff/confirm modal
     // becomes friction (#70). Click-to-move stays gated on the modal as

--- a/src/main.ts
+++ b/src/main.ts
@@ -250,7 +250,18 @@ async function moveLeaf(
       await invoke("apply_move_leaf", { req, project_dir: projectDir });
       // load() owns busy cleanup + final render on success — don't
       // duplicate that work in a finally block.
-      await load(projectDir);
+      //
+      // Reload the CURRENTLY VIEWED project, not the projectDir used
+      // for the move. Cross-project Move-to (#111) uses
+      // opts.projectDir to redirect the write into a different
+      // project, but the user is still looking at state.projectDir —
+      // reloading the override would silently context-switch the UI
+      // to the other project (scopes panel, watcher, recent-projects
+      // LRU). The source side of the move still belonged to
+      // state.projectDir (or User scope, which is project-independent),
+      // so reloading state.projectDir is the right refresh for what
+      // the user sees. Codex/code-review post-fix finding.
+      await load(state.projectDir);
     } catch (err) {
       alert(`Move failed: ${err}`);
       state.busy = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,15 @@ export interface AddLeafRequest {
  */
 export interface MoveOptions {
   skipConfirm?: boolean;
+  /**
+   * Override the active project root for this single move. The Move-to
+   * submenu (#111) lets a user redirect a rule into a *different*
+   * project's `local` or `project` scope; without this override the
+   * dispatch would silently use `state.projectDir` and land the write
+   * in the currently-open project's settings instead of the chosen
+   * one. See codex 6th-pass [P1].
+   */
+  projectDir?: string;
 }
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -3421,7 +3421,7 @@ export function _resetMoveToProjectFilterForTesting(): void {
 function buildMoveToSubmenu(
   props: AppProps,
   from: Scope,
-  onPick: (target: Scope) => void,
+  onPick: (target: Scope, projectRoot?: string) => void,
 ): MenuItem[] {
   const items: MenuItem[] = [];
   // Machine-global scopes first.
@@ -3455,7 +3455,14 @@ function buildMoveToSubmenu(
     for (const target of ["local", "project"] as Scope[]) {
       if (target === from) continue;
       if (!isScopeVisible(target)) continue;
-      inner.push({ label: SCOPE_LABELS[target], onClick: () => onPick(target) });
+      // Pass `project.root` so the outer onPick wires it through to
+      // `onMoveLeaf` as a project override (#111 + codex 6th-pass [P1]).
+      // Without this, choosing `OtherProject > Project` silently
+      // landed the rule in the CURRENT project's settings file.
+      inner.push({
+        label: SCOPE_LABELS[target],
+        onClick: () => onPick(target, project.root),
+      });
     }
     if (inner.length === 0) continue;
     items.push({
@@ -3755,8 +3762,12 @@ function leafContextMenuItems(
     items.push({ label: "Change kind", submenu: sub });
   }
 
-  const moveItems = buildMoveToSubmenu(props, scope, (target) => {
-    props.onMoveLeaf({ path, from: scope, to: target });
+  const moveItems = buildMoveToSubmenu(props, scope, (target, projectRoot) => {
+    props.onMoveLeaf(
+      { path, from: scope, to: target },
+      undefined,
+      projectRoot ? { projectDir: projectRoot } : undefined,
+    );
   });
   items.push({
     label: "Move to",
@@ -3785,8 +3796,12 @@ function combinedChipContextMenuItems(
   if (sourceScope) {
     const sourcePath = findPermissionPath(props, rule, sourceScope);
     if (sourcePath) {
-      const moveItems = buildMoveToSubmenu(props, sourceScope, (target) => {
-        props.onMoveLeaf({ path: sourcePath, from: sourceScope, to: target });
+      const moveItems = buildMoveToSubmenu(props, sourceScope, (target, projectRoot) => {
+        props.onMoveLeaf(
+          { path: sourcePath, from: sourceScope, to: target },
+          undefined,
+          projectRoot ? { projectDir: projectRoot } : undefined,
+        );
       });
       items.push({
         label: `Move to (from ${SCOPE_LABELS[sourceScope]})`,


### PR DESCRIPTION
## Summary

PR #178 landed only its first 5 cluster commits on \`dev\`. PR #184 then merged into \`fix/v0.6-release-blockers\` (the feature branch), not into \`dev\`. Net result: **7 v0.6 release-blocker commits never reached \`dev\`** — including the audit-log path-injection fix (#183) and several codex-pass correctness fixes.

This PR cherry-picks those 7 commits onto a fresh branch off \`dev\`:

| Commit | What it fixes |
|---|---|
| \`884f1c8\` → \`884f1c8\` | Cover post-confirm degraded log; park unknown archives after valid (codex pass 3) |
| \`6da4de0\` → \`d68a89d\` | Absolutize CLI project paths; coalesce restore writes per file (codex pass 4) |
| \`e4b2734\` → \`1c32d1b\` | Absolutize \`--home-dir\` always; recheck audit log even under \`--yes\` (codex pass 5) |
| \`920219e\` → \`6acec8f\` | Route Move-to project-submenu picks to the selected project (codex pass 6, #111) |
| \`973ce76\` → \`00b0999\` | Reload current project after cross-project Move-to; doc the config-dir env hook (/code-review) |
| \`e901b51\` → \`81012ba\` | **Audit-log path allowlist (#183 security) + CLI project_dir (#180)** |
| \`f31dd55\` → \`6fd3073\` | Post-v0.6 docs sync — audit-log security invariants, refusal UX, threat model |

Cherry-picks were clean — no manual conflict resolution. Each commit's original message and authorship preserved.

## Why this is its own PR

GitHub merged PR #184 into \`fix/v0.6-release-blockers\`, not into \`dev\`, because that was its base. The \`Closes #N\` keywords on \`e901b51\` / \`81012ba\` therefore never fired, leaving #183 + #180 open. This PR's merge to \`dev\` will close them.

## Test plan

- [x] All 7 commits passed CI on PR #178 / #184 before merge
- [x] Cherry-pick reapplied cleanly with no conflicts
- [ ] CI re-validates on \`dev\` base

## v0.6 release-gate impact

Once this lands, the v0.6 release-gate (#143) clears its final code-side checkbox. Then **Actions → Release Please → Run workflow** to cut the tag.

Closes #183, closes #180, closes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)