### PR TITLE
chore(release-please): pin next release as 0.6.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,7 @@
       "release-type": "node",
       "package-name": "claude-scope",
       "bootstrap-sha": "57893438aecf3b293ded4aca25876eb3fee2db67",
+      "release-as": "0.6.0",
       "skip-changelog": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Summary

The empty \`Release-As: 0.6.0\` commit in PR #186 was squashed into a no-op (squash-merge collapses zero-diff commits), so release-please still sees the conventional-commits computation (\`0.3.1 → 0.4.0\` from the 31 \`feat:\` commits). Pin the version in \`release-please-config.json\` instead — a real one-line file change that can't be dropped.

## After this lands

Trigger **Actions → Release Please → Run workflow**. Release-please reads the \`release-as: 0.6.0\` override and opens its PR targeting \`v0.6.0\`. Merging that PR cuts the tag and triggers \`release.yml\` to build installers + \`SHA256SUMS.txt\`.

## Post-release cleanup

After the \`v0.6.0\` tag lands, remove the \`release-as\` entry (PR or commit) so the next release cycle bumps normally via conventional-commits (anticipated \`0.7.0\` for the v0.7 milestone work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)