### PR TITLE
fix(ci): pre-lipo claude-scope-cli for macOS universal bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,32 @@ jobs:
 
       - run: npm ci
 
+      # macOS-only: pre-build claude-scope-cli for BOTH Apple architectures
+      # and lipo them into a universal binary at the path Tauri's bundler
+      # looks for. `tauri build --target universal-apple-darwin` does the
+      # universal-build dance for the default binary (`claude-scope`) only,
+      # but the bundler then walks every `[[bin]]` declared in Cargo.toml
+      # and tries to copy each from `target/universal-apple-darwin/release/`
+      # into the .app. Without this step the `claude-scope-cli` bin gets
+      # built for the host arch only, in the wrong target dir, and the
+      # bundler fails with "binary does not exist". Linux + Windows are
+      # single-arch so this step is a no-op there.
+      - name: Pre-build claude-scope-cli as macOS universal binary
+        if: matrix.platform.os == 'macos-latest'
+        working-directory: src-tauri
+        run: |
+          cargo build --release --bin claude-scope-cli --target aarch64-apple-darwin
+          cargo build --release --bin claude-scope-cli --target x86_64-apple-darwin
+          mkdir -p target/universal-apple-darwin/release
+          lipo -create \
+            target/aarch64-apple-darwin/release/claude-scope-cli \
+            target/x86_64-apple-darwin/release/claude-scope-cli \
+            -output target/universal-apple-darwin/release/claude-scope-cli
+          # Sanity-check the result reports both arches so a future
+          # toolchain change can't silently regress to a single-arch
+          # binary while still putting *a* file in the expected path.
+          lipo -info target/universal-apple-darwin/release/claude-scope-cli
+
       # tauri-action runs `beforeBuildCommand` (which is `npm run build`)
       # before invoking `tauri build`, so the frontend dist/ is produced
       # as part of the same step. Pinned to a specific version rather than


### PR DESCRIPTION
## Summary

v0.6.0 \`release.yml\` dispatch failed on the macOS leg during bundling:

\`\`\`
failed to bundle project Failed to copy binary from
"target/universal-apple-darwin/release/claude-scope-cli": does not exist
\`\`\`

\`tauri build --target universal-apple-darwin\` does the universal-build dance for the **default** binary (\`claude-scope\`) only. The bundler then walks every \`[[bin]]\` declared in Cargo.toml and tries to copy each from \`target/universal-apple-darwin/release/\` into the .app. Without intervention, \`claude-scope-cli\` gets built for the host arch in \`target/<host-arch>-apple-darwin/release/\` — the wrong path — so the bundler exits non-zero before any \`.dmg\` is produced.

## Fix

Add a macOS-only pre-build step that:

1. Builds \`claude-scope-cli\` for \`aarch64-apple-darwin\`
2. Builds it for \`x86_64-apple-darwin\`
3. \`lipo\`s the two into \`target/universal-apple-darwin/release/claude-scope-cli\`
4. Runs \`lipo -info\` to verify both arches are present (so a future toolchain shift can't silently regress to single-arch)

No-op on Linux and Windows (single-arch).

## Test plan

- [x] Linux + Windows builds aren't affected (the new step is \`matrix.platform.os == 'macos-latest'\`-gated)
- [ ] Re-dispatch \`release.yml\` against \`v0.6.0\` after this lands — the failing macOS leg should now succeed
- [ ] Resulting \`ClaudeScope.app\` ships a universal \`claude-scope-cli\` binary (verifiable via \`lipo -info\`)

## Post-merge action

Maintainer re-runs **Actions → Release → Run workflow** with \`tag_name: v0.6.0\`. The existing v0.6.0 draft release will be updated in place with the corrected macOS artifacts. Linux installers are already uploaded from the previous run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)