### PR TITLE
chore(release-please): drop release-as pin now that v0.6.0 is shipped

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,6 @@
       "release-type": "node",
       "package-name": "claude-scope",
       "bootstrap-sha": "57893438aecf3b293ded4aca25876eb3fee2db67",
-      "release-as": "0.6.0",
       "skip-changelog": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Summary

\`v0.6.0\` is shipped (published release with installers + SHA256SUMS). Drop the \`"release-as": "0.6.0"\` override from \`release-please-config.json\` so the next release cycle bumps normally from conventional commits.

Leaving the pin in would force every subsequent release to also be \`0.6.0\`, which would clash with the just-shipped tag.

## What to expect next cycle

Without the override, release-please walks \`dev\` since \`v0.6.0\` and computes:

- Patch (\`0.6.1\`) if only \`fix:\` / \`perf:\` commits have landed
- Minor (\`0.7.0\`) once any \`feat:\` lands — anticipated for v0.7 milestone work
- Major (\`1.0.0\`) only on an explicit \`feat!:\` / \`BREAKING CHANGE\` footer

## Test plan

- [x] One-line config delete, no behavior change for the current shipped tag
- [ ] Next \`Release Please\` workflow_dispatch opens a PR targeting the conventional-commits-computed version, not \`0.6.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)