### PR TITLE
feat(ui): combined permissions panel as a column in the scope grid (#154)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -320,9 +320,15 @@ button:disabled {
 }
 
 .combined {
-  padding: 12px 16px;
+  /* `.combined` now renders as the trailing column inside `.grid`
+     alongside `.col` (#154). Match `.col`'s card chrome so the row
+     reads as a uniform set of panels rather than a special one. */
   background: var(--panel);
-  border-bottom: 1px solid var(--border);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
 }
 
 .combined h2 {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -609,7 +609,9 @@ export function renderApp(root: HTMLElement, props: AppProps): void {
   // Lowercase the query once per render instead of per rule; scopeGrid/
   // combinedPanel push this down into every filter call.
   const lowerQuery = props.query.toLowerCase();
-  root.appendChild(combinedPanel(props.scopes, props, lowerQuery));
+  // The combined panel renders inside scopeGrid as the trailing
+  // column (#154) — peers with Local / Project / User-Local / User
+  // so the whole "what's where" view sits in one row.
   root.appendChild(scopeGrid(props, lowerQuery));
   restoreSearchFocus(preserveSearchFocus, caret);
   // Re-apply the cross-pane highlight (#49) once the new chips are
@@ -2259,6 +2261,11 @@ function scopeGrid(props: AppProps, lowerQuery: string): HTMLElement {
     if (!view) continue;
     grid.appendChild(scopeColumn(view, props, lowerQuery));
   }
+  // Combined panel as the trailing column (#154). It's a peer of the
+  // per-scope columns rather than a separate band so the user reads
+  // the row as "Local / Project / User-Local / User → Combined" — the
+  // effective view sits where the precedence flow naturally lands.
+  grid.appendChild(combinedPanel(loaded, props, lowerQuery));
   return grid;
 }
 

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -118,6 +118,25 @@ describe("renderApp", () => {
     expect(empty?.textContent).toBe("No settings loaded.");
   });
 
+  it("places the combined panel as the trailing column inside the scope grid", () => {
+    // Regression for #154. Combined panel used to be a separate band
+    // above the per-scope grid; now it's the trailing column inside
+    // the same grid, peer to Local / Project / User-Local / User.
+    // Two assertions: parent-child relationship, and trailing position
+    // among the grid's children.
+    const scopes = buildLoadedScopes({
+      scopes: [{ scope: "project", permissions: { allow: ["Bash(ls)"] } }],
+    });
+    renderApp(root, makeProps({ scopes }));
+    const grid = root.querySelector(".grid");
+    const combined = root.querySelector(".combined");
+    expect(grid).not.toBeNull();
+    expect(combined).not.toBeNull();
+    expect(combined!.parentElement).toBe(grid);
+    // Combined panel is the LAST child of the grid — peers come first.
+    expect(grid!.lastElementChild).toBe(combined);
+  });
+
   it("renders the combined permissions panel with allow/deny/ask counts", () => {
     const scopes = buildLoadedScopes({
       scopes: [


### PR DESCRIPTION
## Summary

Combined / effective permissions panel becomes the **trailing column inside the scope grid**, peer to Local / Project / User-Local / User. Row reads left-to-right as the precedence flow: \`Local → Project → User-Local → User → Combined\`, with the effective view landing where the flow naturally ends.

Three changes:

- \`src/ui.ts\`: \`renderApp\` no longer appends \`combinedPanel\` directly to the app root. \`scopeGrid\` appends it as the trailing column after the per-scope columns.
- \`src/styles.css\`: \`.combined\` gets \`.col\`'s card chrome — border, radius, panel background, flex column. Padding matches the per-scope columns exactly.
- \`.combo-groups\` (allow/deny/ask) inner grid unchanged — its \`auto-fit + minmax(220px, 1fr)\` rule lets the three groups stack vertically when the combined column is narrow (one of five in the row) and tile horizontally as the column widens.

## Test plan

- [x] \`places the combined panel as the trailing column inside the scope grid\` — \`combined.parentElement === grid\` and \`grid.lastElementChild === combined\`.
- [x] All 121 JS tests pass.
- [ ] CI confirms.

Closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)