### PR TITLE
chore: add tsc --noEmit to just check via js-lint

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,8 +25,16 @@ build:
 
 # --- lint / fmt / test ---------------------------------------------------
 
+# Read-only JS/TS static analysis: biome (lint) + tsc --noEmit
+# (typecheck). Both must pass for `just check` to clear. tsc catches
+# strict-type regressions that biome's syntactic lint doesn't — e.g.
+# missing fields on `PropsOverrides`, return-type drift, unhandled
+# null branches. Vite's build runs tsc too, but kicking it in via the
+# lint pipeline closes the gap where vitest (which doesn't strict-
+# typecheck) passes locally and CI's `npm run build` fails late.
 js-lint:
     npm run lint
+    npm run typecheck
 
 rs-lint:
     cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "tauri": "tauri",
     "lint": "biome check",
     "format": "biome format --write",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.0",


### PR DESCRIPTION
## Summary

CI's \`npm run build\` (vite) runs \`tsc\` strictly; vitest doesn't. Type errors that slip past biome and unit tests therefore only show up on PR CI — recent example: PR #193 had a missing field on \`PropsOverrides\` that vitest happily ignored locally, and the CI build failed on all three platforms with \`TS2339\` / \`TS2353\`.

Wire tsc into the \`just check\` pipeline so the same failure catches before push:

- New \`typecheck\` script in \`package.json\` runs \`tsc --noEmit\`.
- \`js-lint\` recipe now chains \`npm run lint\` (biome) + \`npm run typecheck\`. Both are read-only — \`fmt\` still owns all mutation per the recipe convention.
- \`just check\` (= \`lint test\`) therefore strict-typechecks now too.

## Test plan

- [x] \`just check\` passes locally on dev base
- [x] No behavior change for biome's lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)