### PR TITLE
feat(ui): reframe combined panel + drop inline move buttons (#158, #152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Claude Code reads settings from JSON files at several scopes. Moving a permissio
 
 ### Features
 
-- **Four-column scope view** — User / User-Local / Project / Local, laid out broadest-on-the-left, with a "Combined permissions" panel above them. That panel is a union across scopes; it is not a full precedence-aware evaluation of what Claude Code resolves at runtime, and the subtitle says so.
+- **Four-column scope view** — User / User-Local / Project / Local, laid out broadest-on-the-left, with an **Effective settings** panel as a trailing column summarizing what applies in the active directory. Default-collapsed with inline counts; expand to see the full union across scopes. (Not a full precedence-aware evaluation — the subtitle says so.)
 - **Atomic writes with revalidation** — serialize → re-parse the produced JSON → tempfile + rename, with one-shot `.bak` backup per file per session. See [Write strategy](#write-strategy) for the fine print.
 - **Diff preview modal** — shows before/after for both sides of a move with a proper diff, Esc/Enter/Tab-trap keyboard handling, focus restored to the triggering button on close
 - **Rule search / filter** — press `/` anywhere to focus, case-insensitive substring, `m/n` match counts per group

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -63,9 +63,11 @@ reviewer.
 ## Golden path
 
 - [ ] **All four scope columns render.** User / User-Local / Project / Local
-      appear left-to-right; the "Combined permissions" panel shows the union
-      across scopes on top, with the precedence-aware-evaluation caveat in
-      its subtitle.
+      appear left-to-right; the **Effective settings** panel is the trailing
+      column. It's collapsed by default with an inline `N allow · N deny ·
+      N ask` summary, naming the project directory in its subtitle. Expanding
+      shows the union across scopes with the precedence-aware-evaluation
+      caveat.
 - [ ] **Click-to-move a permission rule.** From any populated scope, click a
       `→ <Scope>` button on a rule → diff modal opens with before/after for
       both sides → click **Apply** → modal closes, rule disappears from

--- a/docs/src/user-guide/scopes.md
+++ b/docs/src/user-guide/scopes.md
@@ -34,10 +34,11 @@ narrowest-on-the-right**:
 
 That's the opposite of precedence order. ClaudeScope's column order is
 about *audience* — User-scope rules affect every project, Local-scope
-rules affect one. The "Combined permissions" panel above the columns is
-a simple union across scopes; it's **not** a full precedence-aware
-evaluation of what Claude Code resolves at runtime, and the subtitle in
-the app says so.
+rules affect one. The **Effective settings** panel is the trailing column
+in the same row, summarizing what applies in the active directory.
+Default-collapsed with inline counts; expand to see the full union
+across scopes. It's **not** a full precedence-aware evaluation of what
+Claude Code resolves at runtime — the subtitle in the app says so.
 
 ## Per-scope file presence
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -649,15 +649,10 @@ button:disabled {
   white-space: nowrap;
 }
 
-.rule-moves {
-  display: flex;
-  gap: 4px;
-}
-
-.move-btn {
-  font-size: 11px;
-  padding: 2px 6px;
-}
+/* `.rule-moves` / `.move-btn` / `.tree-key-moves` removed in #152 —
+   inline arrow buttons were redundant with the right-click context
+   menu (#111 Move-to submenu). Right-click and keyboard drag (#41)
+   are the canonical move affordances. */
 
 /* Tree view for non-permission top-level keys (env, hooks, theme, …).
    Uses native <details>/<summary> so expand/collapse and keyboard
@@ -751,14 +746,6 @@ button:disabled {
 .tree-value-null {
   color: var(--muted);
   font-style: italic;
-}
-
-/* Move-target buttons for top-level tree keys. Live on the summary row
-   (branches) or the leaf row (scalars). Push to the right so the
-   key/peek/value stays readable and button clicks are intentional. */
-.tree-key-moves {
-  margin-left: auto;
-  gap: 4px;
 }
 
 /* ------- Diff confirm modal ------- */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1898,7 +1898,11 @@ function treeBranch(
   peek.textContent = treeBranchPeek(path, value, lowerQuery);
   summary.appendChild(peek);
   if (props && offerMoveAffordance) {
-    summary.appendChild(leafMoveButtons(scope, path, props));
+    // Move affordance is now right-click only (#152). The inline
+    // arrow buttons were redundant once the Move-to submenu (#111)
+    // surfaced every legitimate target including cross-project
+    // entries — keyboard drag (#41) and the context menu cover the
+    // remaining gestures.
     attachContextMenu(summary, () => leafContextMenuItems(scope, path, value, props));
   }
   details.appendChild(summary);
@@ -2143,10 +2147,9 @@ function treeLeaf(
     const badge = lintBadge(rule);
     if (badge) row.appendChild(badge);
     if (props) {
-      // Pass the rule string as the move-button label so the screen
-      // reader announces "Move Bash(git status) from …" instead of
-      // the meaningless path "permissions.allow[0]".
-      row.appendChild(leafMoveButtons(scope, path, props, rule));
+      // Inline arrow buttons dropped in #152 — right-click context
+      // menu (with the full Move-to submenu, including cross-project
+      // targets) is now the canonical click affordance.
       attachContextMenu(row, () => leafContextMenuItems(scope, path, value, props));
     }
     return row;
@@ -2182,49 +2185,12 @@ function treeLeaf(
   val.textContent = formatLeaf(value);
   row.appendChild(val);
   if (props && offerMoveAffordance) {
-    row.appendChild(leafMoveButtons(scope, path, props));
+    // Inline arrow buttons dropped in #152 — right-click context menu
+    // is the canonical click affordance; keyboard drag (#41) was wired
+    // by `setupLeafDragSource` above.
     attachContextMenu(row, () => leafContextMenuItems(scope, path, value, props));
   }
   return row;
-}
-
-function leafMoveButtons(
-  scope: Scope,
-  path: PathSeg[],
-  props: AppProps,
-  // Optional override for the screen-reader label. Permission rule rows
-  // pass the rule string so the button announces something meaningful;
-  // top-level key and rule-list rows fall back to the path's
-  // dotted-bracket form, which is informative at that level.
-  ariaSubject?: string,
-): HTMLElement {
-  const moveBtns = document.createElement("div");
-  moveBtns.className = "rule-moves tree-key-moves";
-  const subject = ariaSubject ?? describePath(path);
-  for (const target of SCOPES) {
-    if (target === scope) continue;
-    // Mirror scopeGrid: don't offer moves into columns the user hid — the
-    // result would land in a column they can't see without re-enabling it.
-    if (!isScopeVisible(target)) continue;
-    const btn = document.createElement("button");
-    btn.className = "move-btn";
-    btn.type = "button";
-    btn.textContent = `→ ${SCOPE_LABELS[target]}`;
-    btn.setAttribute(
-      "aria-label",
-      `Move ${subject} from ${SCOPE_LABELS[scope]} to ${SCOPE_LABELS[target]}`,
-    );
-    btn.disabled = props.busy;
-    btn.addEventListener("click", (e) => {
-      // Clicks on the summary element would otherwise toggle the <details>;
-      // the move action is a distinct intent, so swallow propagation.
-      e.preventDefault();
-      e.stopPropagation();
-      props.onMoveLeaf({ path, from: scope, to: target }, e.currentTarget as HTMLElement);
-    });
-    moveBtns.appendChild(btn);
-  }
-  return moveBtns;
 }
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -956,7 +956,12 @@ function combinedPanel(loaded: LoadedScopes, props: AppProps, lowerQuery: string
   summary.className = "combined-summary";
   const title = document.createElement("span");
   title.className = "combined-title";
-  title.textContent = "Combined permissions";
+  // Reframe from "Combined permissions" (a merge view) to "Effective
+  // settings" (the source-of-truth view for what Claude Code applies
+  // in this directory). The data itself is unchanged — same union
+  // across scopes — but the label now matches the question the user
+  // is actually asking when they look here. See #158.
+  title.textContent = "Effective settings";
   summary.appendChild(title);
   // Inline kind-count summary so the collapsed state still tells the
   // user what's in the combined view at a glance. Reads "5 allow ·
@@ -979,9 +984,24 @@ function combinedPanel(loaded: LoadedScopes, props: AppProps, lowerQuery: string
     props.onToggleCombinedPanelCollapsed(!panel.open);
   });
 
+  // Subtitle: name the directory this panel is summarizing, with the
+  // honest "union, not precedence-aware" caveat right after. Putting
+  // the project dir in the panel itself (#158) makes the section
+  // self-contained — a user who scrolls down to the effective view
+  // doesn't have to look back up at the topbar to confirm which
+  // directory's settings they're reading.
   const subtitle = document.createElement("p");
   subtitle.className = "combined-subtitle";
-  subtitle.textContent = "Union across scopes — not a precedence-aware evaluation.";
+  if (loaded.project_dir) {
+    const forDir = document.createElement("span");
+    forDir.className = "combined-subtitle-dir";
+    forDir.textContent = `for ${loaded.project_dir}`;
+    subtitle.appendChild(forDir);
+    subtitle.appendChild(document.createTextNode(" · "));
+  }
+  subtitle.appendChild(
+    document.createTextNode("union across scopes — not a precedence-aware evaluation"),
+  );
   panel.appendChild(subtitle);
 
   // Three side-by-side group columns instead of stacked rows. The grid

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -201,6 +201,23 @@ describe("renderApp", () => {
     expect(grid!.lastElementChild).toBe(combined);
   });
 
+  it("labels the combined panel as 'Effective settings' with the project dir in the subtitle (#158)", () => {
+    // Reframes the panel from "Combined permissions" (a merge view)
+    // to "Effective settings" (the source-of-truth view for what
+    // applies in this directory). The project dir lands in the
+    // subtitle so the section is self-contained.
+    const scopes = buildLoadedScopes({
+      project_dir: "/work/explicit-project",
+      scopes: [{ scope: "project", permissions: { allow: ["Bash(ls)"] } }],
+    });
+    renderApp(root, makeProps({ scopes }));
+    const title = root.querySelector(".combined-title");
+    expect(title?.textContent).toBe("Effective settings");
+    const subtitle = root.querySelector(".combined-subtitle");
+    expect(subtitle?.textContent).toContain("/work/explicit-project");
+    expect(subtitle?.textContent).toContain("union across scopes");
+  });
+
   it("renders the combined permissions panel with allow/deny/ask counts", () => {
     const scopes = buildLoadedScopes({
       scopes: [

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -273,28 +273,19 @@ describe("renderApp", () => {
     expect(after?.selectionEnd).toBe(2);
   });
 
-  it("invokes onMoveLeaf with a path-based request when a per-scope move button is clicked", () => {
-    // Permission rules now live as tree leaves under `permissions.allow[*]`,
-    // so the move button rides on the leaf's `.rule .rule-moves .move-btn`
-    // and the request payload carries a JSON path instead of {rule, kind}.
-    const onMoveLeaf = vi.fn();
+  it("no longer renders inline →Scope move buttons on rule rows (#152)", () => {
+    // Regression for #152. The inline arrow buttons were dropped in
+    // favor of the right-click context menu's Move-to submenu (#111).
+    // Asserts the DOM has no `.move-btn` / `.rule-moves` markers
+    // anywhere — keyboard drag (#41) and right-click are the
+    // canonical move affordances now.
     const scopes = buildLoadedScopes({
       scopes: [{ scope: "project", permissions: { allow: ["Bash(git status)"] } }],
     });
-    renderApp(root, makeProps({ scopes, onMoveLeaf }));
-    const buttons = Array.from(
-      root.querySelectorAll<HTMLButtonElement>(".rule.rule-allow .rule-moves .move-btn"),
-    );
-    const toUser = buttons.find((b) => b.textContent === "→ User");
-    expect(toUser).toBeDefined();
-    toUser?.click();
-    expect(onMoveLeaf).toHaveBeenCalledTimes(1);
-    const [req] = onMoveLeaf.mock.calls[0];
-    expect(req).toEqual({
-      path: ["permissions", "allow", 0],
-      from: "project",
-      to: "user",
-    });
+    renderApp(root, makeProps({ scopes }));
+    expect(root.querySelector(".move-btn")).toBeNull();
+    expect(root.querySelector(".rule-moves")).toBeNull();
+    expect(root.querySelector(".tree-key-moves")).toBeNull();
   });
 
   it("renders a lint warning badge for a malformed rule", () => {
@@ -1229,7 +1220,12 @@ describe("tool-prefix grouping in the scope tree (#68)", () => {
     expect(visibleRules[0].querySelector(".rule-text")?.textContent).toBe("handoff(copilot *)");
   });
 
-  it("group members keep leaf-level paths so move buttons still address the rule directly", () => {
+  it("group members keep leaf-level paths so context-menu moves address the rule directly", () => {
+    // #152 dropped the inline arrow buttons in favor of the right-click
+    // Move-to submenu (#111). This test now exercises that path: inside
+    // a tool-group, right-click the second member and assert the
+    // dispatched path is `permissions.allow[1]` (not anything
+    // group-relative).
     const onMoveLeaf = vi.fn();
     const scopes = buildLoadedScopes({
       project_dir: "/fake/grouping-move",
@@ -1241,27 +1237,28 @@ describe("tool-prefix grouping in the scope tree (#68)", () => {
       ],
     });
     renderApp(root, makeProps({ scopes, onMoveLeaf }));
-    // Inside the Bash group: click the second member's "→ User" button and
-    // assert the dispatched path is `permissions.allow[1]`, not anything
-    // group-relative.
     const group = root.querySelector<HTMLDetailsElement>(".tree-tool-group");
     if (!group) throw new Error("expected tool group");
     const memberRows = group.querySelectorAll<HTMLElement>(".rule.rule-allow");
     expect(memberRows.length).toBe(2);
-    const toUser = memberRows[1].querySelector<HTMLButtonElement>(".rule-moves .move-btn");
-    if (!toUser || toUser.textContent !== "→ User") {
-      // The first matching scope target may differ depending on default
-      // visibility; fall back to searching by label across all buttons in
-      // the row.
-      const buttons = Array.from(
-        memberRows[1].querySelectorAll<HTMLButtonElement>(".rule-moves .move-btn"),
-      );
-      const fallback = buttons.find((b) => b.textContent === "→ User");
-      if (!fallback) throw new Error("expected → User button");
-      fallback.click();
-    } else {
-      toUser.click();
-    }
+    // Right-click the second member to open its context menu, then
+    // navigate into Move-to → User. `findMenuItem` is defined in the
+    // context-menu describe block; reuse the local helper here too.
+    memberRows[1].dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 50, clientY: 50 }),
+    );
+    const items = document.querySelectorAll<HTMLButtonElement>(".context-menu-item");
+    const moveTo = Array.from(items).find((b) =>
+      b.textContent?.replace(/\s+/g, " ").trim().startsWith("Move to"),
+    );
+    expect(moveTo).toBeDefined();
+    moveTo?.click();
+    const submenus = document.querySelectorAll<HTMLElement>(".context-menu");
+    const user = Array.from(
+      submenus[submenus.length - 1].querySelectorAll<HTMLButtonElement>(".context-menu-item"),
+    ).find((b) => b.textContent?.replace(/\s*▸$/, "").trim() === "User");
+    expect(user).toBeDefined();
+    user?.click();
     expect(onMoveLeaf).toHaveBeenCalledTimes(1);
     const [req] = onMoveLeaf.mock.calls[0];
     expect(req).toEqual({
@@ -1269,6 +1266,9 @@ describe("tool-prefix grouping in the scope tree (#68)", () => {
       from: "project",
       to: "user",
     });
+    // Clean up the lingering context menus from this test so the next
+    // test doesn't inherit them.
+    for (const m of Array.from(document.querySelectorAll(".context-menu"))) m.remove();
   });
 });
 


### PR DESCRIPTION
## Summary

Two small v0.7 UI commits, both targeting the rule-row + combined-panel surface, both pure UI.

### #158 — Reframe combined panel as "Effective settings"

- \`combinedPanel\` title \`Combined permissions\` → \`Effective settings\`
- Subtitle now leads with \`for <project_dir>\` (panel is self-contained — no need to look back at the topbar) then the existing union/precedence caveat
- README, SMOKE_TEST.md, docs/src/user-guide/scopes.md updated to match
- Internal identifiers (\`combined_permissions\`, \`.combo-*\` CSS classes, \`combined_panel_collapsed\` preference) stay — they're not user-facing

### #152 — Drop inline →Scope buttons

- \`leafMoveButtons\` function and its 3 call sites removed; each row keeps its \`attachContextMenu\`
- \`setupLeafDragSource\` (#41 keyboard drag) untouched — independent code path
- CSS \`.rule-moves\` / \`.move-btn\` / \`.tree-key-moves\` deleted
- Net: -36 lines of UI clutter; right-click Move-to submenu (#111/#139) covers every previous target plus cross-project ones

## Test plan

- [x] New test \`labels the combined panel as 'Effective settings' with the project dir in the subtitle\`
- [x] New test \`no longer renders inline →Scope move buttons on rule rows\` (regression)
- [x] Existing button-click test rewritten as right-click context-menu test (same path-correctness assertion)
- [x] All 126 JS + 254 lib + 21 CLI integration tests pass
- [ ] CI confirms

Closes #158, closes #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)