### PR TITLE
feat(scopes): warn on path collisions and kind disagreements (#153, #156)

### DIFF
--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -129,6 +129,22 @@ reviewer.
 - [ ] **Last-column guard.** In the Settings dialog, uncheck scopes one by
       one. The final remaining checkbox refuses to uncheck (the grid would
       otherwise render empty with no recovery from inside the dialog).
+- [ ] **Path-collision banner (#153).** Open ClaudeScope against your real
+      `$HOME` (e.g. `Open project…` → pick your home directory). A yellow
+      banner appears directly under the toolbar: **Scopes share files**,
+      listing "Project and User both resolve to `~/.claude/settings.json`"
+      and the same for Local + User-Local. Try clicking a `→` move target
+      between two scopes that share a file: the apply should fail with a
+      typed error naming both scopes and the shared path. Close and
+      re-open against a normal project root; the banner disappears.
+- [ ] **Kind-disagreement badge (#156).** Hand-edit a rule into two
+      scopes under different kinds — e.g. `Bash(git push)` as `allow` in
+      User and `deny` in Project. Reload. A red ⚠ badge appears next to
+      the rule row in **both** affected scope columns AND on the matching
+      chips in the Effective settings panel. Hover (or focus + Enter) the
+      badge: a popover lists every (scope, kind) pairing of the rule with
+      the highest-precedence one marked **wins by precedence**. Click the
+      badge to pin the popover; Esc or outside-click dismisses it.
 
 ## Audit log: History, undo, redo (non-sandbox runs only)
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -68,6 +68,50 @@ pub struct LoadedScopes {
     /// precedence order (highest first). Drives the front-end's
     /// scope-origin tooltip on combined rule rows.
     pub combined_origins: PermissionRuleOrigins,
+    /// Pairs (or larger groups) of scopes whose resolved file paths point at
+    /// the same file on disk — the common case is launching ClaudeScope
+    /// from `$HOME` itself, which makes Project and User collapse onto the
+    /// same `~/.claude/settings.json`. Surfacing this as a warning banner
+    /// stops the user from believing "move from User to Project" is doing
+    /// anything other than overwriting the file with its own contents. See
+    /// #153.
+    pub path_collisions: Vec<PathCollision>,
+    /// Rules that appear in multiple scopes under *different* kinds — e.g.
+    /// `Bash(git *)` is `allow` in User scope but `deny` in Project. The
+    /// effective union picks one by precedence; the UI surfaces the
+    /// disagreement so the user can spot a likely typo or stale rule
+    /// without scanning every column. See #156.
+    pub kind_conflicts: Vec<KindConflict>,
+}
+
+/// Two-or-more scopes whose resolved file paths point at the same on-disk
+/// file. Surfaced by [`detect_path_collisions`] and rendered as a top-of-app
+/// warning banner. See #153.
+#[derive(Debug, Clone, Serialize)]
+pub struct PathCollision {
+    /// Scopes that share the path, in [`Scope::ALL`] order so the rendered
+    /// banner reads in the same broad→narrow order as the scope columns.
+    pub scopes: Vec<Scope>,
+    /// The shared file path, as resolved by [`scope::resolve_with_home`].
+    pub path: String,
+}
+
+/// One rule string that appears in 2+ scopes with disagreeing kinds. See
+/// #156.
+#[derive(Debug, Clone, Serialize)]
+pub struct KindConflict {
+    pub rule: String,
+    /// Every (scope, kind) pairing of this rule across all four scopes, in
+    /// precedence order (highest first — matches `combined_origins`). The
+    /// frontend picks the highest-precedence entry as the "winner" for
+    /// effective-evaluation rendering.
+    pub occurrences: Vec<KindOccurrence>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct KindOccurrence {
+    pub scope: Scope,
+    pub kind: PermissionKind,
 }
 
 /// Per-rule provenance for the combined permissions view: for each rule in
@@ -1015,13 +1059,118 @@ pub fn build_loaded(paths: &ScopePaths) -> Result<LoadedScopes, Box<dyn std::err
     }
 
     let (combined, origins) = combined_permissions(&views);
+    let path_collisions = detect_path_collisions(paths);
+    let kind_conflicts = detect_kind_conflicts(&views);
 
     Ok(LoadedScopes {
         project_dir: paths.project_dir.display().to_string(),
         scopes: views,
         combined_permissions: combined,
         combined_origins: origins,
+        path_collisions,
+        kind_conflicts,
     })
+}
+
+/// Detect scopes whose resolved file paths point at the same on-disk file
+/// (#153). The common case is launching ClaudeScope with the project root
+/// equal to `$HOME` — Project and User then both resolve to
+/// `~/.claude/settings.json`, and so do Local and UserLocal. The two
+/// columns are still rendered, but every move between them is a no-op
+/// against the same file; surfacing the collision lets the user notice
+/// before relying on the columns as if they were independent.
+///
+/// Comparison is byte-equal on the `PathBuf`s `resolve_with_home` produced.
+/// That's enough for the only collision shape this catches: project_dir
+/// landing on home, which generates the same lexical path string from both
+/// sides of the resolver. Canonicalize-if-exists would defend against an
+/// exotic case (one scope's symlink resolving differently from another's
+/// non-symlink view), but that case isn't observed in the wild and the
+/// existing `dirs::home_dir()` / `find_project_root` pipeline never emits
+/// such a pair anyway.
+pub fn detect_path_collisions(paths: &ScopePaths) -> Vec<PathCollision> {
+    let mut groups: std::collections::BTreeMap<PathBuf, Vec<Scope>> =
+        std::collections::BTreeMap::new();
+    for scope in Scope::ALL {
+        if let Some(p) = paths.path_for(scope) {
+            groups.entry(p.to_path_buf()).or_default().push(scope);
+        }
+    }
+    let mut out = Vec::new();
+    for (path, mut scopes) in groups {
+        if scopes.len() < 2 {
+            continue;
+        }
+        // Sort by Scope::ALL order so the banner reads broad→narrow,
+        // matching the column layout. BTreeMap gave us path-key sort, not
+        // scope sort, so this is the meaningful ordering step.
+        scopes.sort_by_key(|s| Scope::ALL.iter().position(|x| x == s).unwrap_or(usize::MAX));
+        out.push(PathCollision {
+            scopes,
+            path: path.display().to_string(),
+        });
+    }
+    out
+}
+
+/// Detect rules that appear in 2+ scopes with disagreeing kinds (#156). A
+/// rule string is in conflict iff it lands in at least one `allow` list AND
+/// at least one `deny` or `ask` list across the four scopes (any pair of
+/// different kinds suffices; the case shape is two `allow`s and one `deny`
+/// of the same rule, etc.).
+///
+/// Returns one [`KindConflict`] per conflicting rule, with occurrences
+/// listed in [`Scope::ALL`] precedence order (highest first) so the
+/// frontend can render "X wins by precedence" against the head entry
+/// without re-sorting. A rule that appears multiple times in the same
+/// (scope, kind) bucket — possible from a hand-edited duplicate —
+/// collapses to a single occurrence; the duplicate-detection issue (#17)
+/// is the right surface for "you've got two copies of the same rule
+/// here", not this one.
+fn detect_kind_conflicts(views: &[ScopeView]) -> Vec<KindConflict> {
+    // Preserve first-seen rule order so the rendered list stays stable
+    // across loads. `views` is in `Scope::ALL` (precedence) order, so the
+    // first scope to mention a rule sets its slot here, and subsequent
+    // scopes append to that slot.
+    let mut order: Vec<String> = Vec::new();
+    let mut by_rule: std::collections::HashMap<String, Vec<KindOccurrence>> =
+        std::collections::HashMap::new();
+    for view in views {
+        let perms = permissions_from_values(&view.values);
+        for (kind, rules) in [
+            (PermissionKind::Allow, &perms.allow),
+            (PermissionKind::Deny, &perms.deny),
+            (PermissionKind::Ask, &perms.ask),
+        ] {
+            for rule in rules {
+                let entry = by_rule.entry(rule.clone()).or_insert_with(|| {
+                    order.push(rule.clone());
+                    Vec::new()
+                });
+                // Collapse duplicates within the same (scope, kind) bucket;
+                // see fn-level rationale.
+                if !entry
+                    .iter()
+                    .any(|o| o.scope == view.scope && o.kind == kind)
+                {
+                    entry.push(KindOccurrence {
+                        scope: view.scope,
+                        kind,
+                    });
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    for rule in order {
+        let occurrences = by_rule.remove(&rule).expect("seeded above");
+        let distinct_kinds: std::collections::HashSet<PermissionKind> =
+            occurrences.iter().map(|o| o.kind).collect();
+        if distinct_kinds.len() >= 2 {
+            out.push(KindConflict { rule, occurrences });
+        }
+    }
+    out
 }
 
 fn load_scope_view(scope: Scope, path: Option<&Path>) -> ScopeView {
@@ -1251,7 +1400,33 @@ fn dest_path_for(req: &MoveLeafRequest) -> Vec<PathSeg> {
 fn validate_move_request(
     req: &MoveLeafRequest,
     movable: &MovablePath<'_>,
+    paths: &ScopePaths,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Cross-scope moves between two scopes whose resolved file paths point
+    // at the same on-disk file are no-ops at best and silently destructive
+    // at worst — the rule lands in the same file under the same key,
+    // overwriting itself. Refuse with a typed error rather than letting
+    // the apply path waste a write or, worse, succeed and leave the
+    // user thinking the move took effect (#153). Same-scope change-kind
+    // (req.from == req.to) is unaffected because the *operation* still
+    // mutates the file's permissions object meaningfully.
+    if req.from != req.to {
+        let from_path = paths.path_for(req.from);
+        let to_path = paths.path_for(req.to);
+        if let (Some(fp), Some(tp)) = (from_path, to_path) {
+            if fp == tp {
+                return Err(format!(
+                    "{} and {} both resolve to {} — these scopes share the same file on disk, \
+                     so a move between them would be a no-op. Open a different project root \
+                     to give the scopes distinct files.",
+                    req.from.label(),
+                    req.to.label(),
+                    fp.display(),
+                )
+                .into());
+            }
+        }
+    }
     match (req.to_kind, movable) {
         (Some(new_kind), MovablePath::PermissionRule(current_kind, _)) => {
             if req.from == req.to && *current_kind == new_kind {
@@ -1281,7 +1456,7 @@ pub fn diff_move_leaf_impl(
     req: &MoveLeafRequest,
 ) -> Result<MoveLeafPreview, Box<dyn std::error::Error>> {
     let movable = validate_movable_path(&req.path)?;
-    validate_move_request(req, &movable)?;
+    validate_move_request(req, &movable, paths)?;
 
     if req.from == req.to {
         // Same-scope change-kind: load the file once, simulate add+remove on
@@ -1469,7 +1644,7 @@ pub fn apply_move_leaf_impl(
     watch: &WatchState,
 ) -> Result<LeafApplyOutcome, Box<dyn std::error::Error>> {
     let movable = validate_movable_path(&req.path)?;
-    validate_move_request(req, &movable)?;
+    validate_move_request(req, &movable, paths)?;
 
     if req.from == req.to {
         // Same-scope change-kind: one file, one write. Apply add+remove to
@@ -2655,6 +2830,178 @@ mod tests {
         assert_eq!(origins.allow[2], vec![Scope::User]);
         assert!(origins.deny.is_empty());
         assert!(origins.ask.is_empty());
+    }
+
+    #[test]
+    fn detect_path_collisions_groups_scopes_sharing_one_file() {
+        // #153 — Launching ClaudeScope with project_dir == $HOME makes
+        // User and Project resolve to the same `~/.claude/settings.json`,
+        // and Local/UserLocal to the same `settings.local.json`. The
+        // detector groups those collisions with the scopes sorted in
+        // Scope::ALL (broad→narrow) order so the rendered banner reads
+        // in the same order the columns are laid out.
+        let tmp = tempfile::tempdir().unwrap();
+        let claude = tmp.path().join(".claude");
+        std::fs::create_dir_all(&claude).unwrap();
+        let shared_settings = claude.join("settings.json");
+        let shared_local = claude.join("settings.local.json");
+        let paths = ScopePaths {
+            project_dir: tmp.path().to_path_buf(),
+            local: Some(shared_local.clone()),
+            project: Some(shared_settings.clone()),
+            user_local: Some(shared_local.clone()),
+            user: Some(shared_settings.clone()),
+        };
+
+        let collisions = detect_path_collisions(&paths);
+        assert_eq!(collisions.len(), 2, "two distinct shared files");
+
+        // Scope::ALL ordering is [Local, Project, UserLocal, User], so
+        // the broader (User, UserLocal) pair lists first in each group.
+        let local_collision = collisions
+            .iter()
+            .find(|c| c.path == shared_local.display().to_string())
+            .expect("local collision present");
+        assert_eq!(local_collision.scopes, vec![Scope::Local, Scope::UserLocal]);
+        let project_collision = collisions
+            .iter()
+            .find(|c| c.path == shared_settings.display().to_string())
+            .expect("project collision present");
+        assert_eq!(project_collision.scopes, vec![Scope::Project, Scope::User]);
+    }
+
+    #[test]
+    fn detect_path_collisions_returns_empty_when_paths_are_distinct() {
+        // Sanity: the common case (project_dir != home) produces zero
+        // collisions even though Local/Project share a parent and
+        // UserLocal/User share theirs.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = paths_in(tmp.path());
+        assert!(detect_path_collisions(&paths).is_empty());
+    }
+
+    #[test]
+    fn detect_kind_conflicts_surfaces_allow_vs_deny_across_scopes() {
+        // #156 — `Bash(git push)` is allowed in User but denied in
+        // Project. The conflict surfaces with both occurrences in
+        // precedence order (highest first = Project before User), so
+        // the frontend can label "Project's deny wins by precedence".
+        let views = vec![
+            make_view(Scope::Local, true, &[], &[], &[]),
+            make_view(Scope::Project, true, &[], &["Bash(git push)"], &[]),
+            make_view(Scope::UserLocal, true, &[], &[], &[]),
+            make_view(Scope::User, true, &["Bash(git push)"], &[], &[]),
+        ];
+        let conflicts = detect_kind_conflicts(&views);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].rule, "Bash(git push)");
+        // Scope::ALL is [Local, Project, UserLocal, User] (precedence,
+        // highest first); the conflict's occurrences inherit that.
+        assert_eq!(
+            conflicts[0]
+                .occurrences
+                .iter()
+                .map(|o| (o.scope, o.kind))
+                .collect::<Vec<_>>(),
+            vec![
+                (Scope::Project, PermissionKind::Deny),
+                (Scope::User, PermissionKind::Allow),
+            ]
+        );
+    }
+
+    #[test]
+    fn detect_kind_conflicts_ignores_matching_kinds_in_multiple_scopes() {
+        // The same rule in `allow` across two scopes is *not* a conflict;
+        // it just means both scopes agree. Without filtering on distinct
+        // kinds, the detector would emit a spurious entry every time a
+        // user-scope allow was reaffirmed at project scope.
+        let views = vec![
+            make_view(Scope::Local, true, &["Bash(git status)"], &[], &[]),
+            make_view(Scope::User, true, &["Bash(git status)"], &[], &[]),
+        ];
+        assert!(detect_kind_conflicts(&views).is_empty());
+    }
+
+    #[test]
+    fn detect_kind_conflicts_collapses_duplicates_in_one_scope_kind() {
+        // A hand-edited duplicate in the same (scope, kind) bucket
+        // shouldn't produce a phantom conflict against itself, and
+        // shouldn't appear twice in `occurrences`. Duplicate-detection
+        // is #17's surface, not this one.
+        let views = vec![make_view(
+            Scope::Local,
+            true,
+            &["Bash(rm)", "Bash(rm)"],
+            &["Bash(rm)"],
+            &[],
+        )];
+        let conflicts = detect_kind_conflicts(&views);
+        assert_eq!(conflicts.len(), 1);
+        // Two unique (scope, kind) pairs, not three.
+        assert_eq!(conflicts[0].occurrences.len(), 2);
+    }
+
+    #[test]
+    fn validate_move_request_refuses_cross_scope_move_into_a_colliding_pair() {
+        // #153 — Even with the path-collision banner up, the user could
+        // still try to drag a rule from User to Project when both
+        // resolve to the same file. Such a move would either be a no-op
+        // or corrupt the file (rewrite-with-self while the source
+        // and destination IPCs race for the same FileStamp). Refuse at
+        // validation rather than asking the apply layer to deal with
+        // it: a typed error keeps the modal close path clean and gives
+        // the UI a stable string to surface.
+        let tmp = tempfile::tempdir().unwrap();
+        let claude = tmp.path().join(".claude");
+        std::fs::create_dir_all(&claude).unwrap();
+        let shared = claude.join("settings.json");
+        let paths = ScopePaths {
+            project_dir: tmp.path().to_path_buf(),
+            local: Some(claude.join("settings.local.json")),
+            project: Some(shared.clone()),
+            user_local: None,
+            user: Some(shared.clone()),
+        };
+        std::fs::write(&shared, r#"{"permissions":{"allow":["X"]}}"#).unwrap();
+        let req = MoveLeafRequest {
+            path: vec![key("permissions"), key("allow"), idx(0)],
+            from: Scope::Project,
+            to: Scope::User,
+            to_kind: None,
+        };
+        let err = apply_move_leaf_impl(&paths, &req, None, &WatchState::default()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("share the same file"),
+            "expected collision-message error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn detect_kind_conflicts_handles_three_way_disagreement() {
+        // Allow / deny / ask across three scopes — all three should
+        // appear in `occurrences`, still in precedence order.
+        let views = vec![
+            make_view(Scope::Local, true, &["X"], &[], &[]),
+            make_view(Scope::Project, true, &[], &["X"], &[]),
+            make_view(Scope::UserLocal, true, &[], &[], &[]),
+            make_view(Scope::User, true, &[], &[], &["X"]),
+        ];
+        let conflicts = detect_kind_conflicts(&views);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(
+            conflicts[0]
+                .occurrences
+                .iter()
+                .map(|o| (o.scope, o.kind))
+                .collect::<Vec<_>>(),
+            vec![
+                (Scope::Local, PermissionKind::Allow),
+                (Scope::Project, PermissionKind::Deny),
+                (Scope::User, PermissionKind::Ask),
+            ]
+        );
     }
 
     #[test]

--- a/src/styles.css
+++ b/src/styles.css
@@ -145,6 +145,44 @@ body {
   color: var(--sandbox-text-strong);
 }
 
+/* Path-collision banner (#153). Reuses the sandbox color palette — both
+   are persistent warnings that live directly under the toolbar. The
+   list+explain stack distinguishes it from the single-line sandbox
+   banner so the user can tell them apart at a glance when both happen
+   to be up. */
+.collision-banner {
+  background: var(--sandbox-bg);
+  color: var(--sandbox-text);
+  border-bottom: 1px solid var(--sandbox-border);
+  padding: 10px 16px;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.collision-banner strong {
+  color: var(--sandbox-text-strong);
+}
+
+.collision-list {
+  margin: 4px 0;
+  padding-left: 20px;
+}
+
+.collision-list li {
+  margin: 2px 0;
+}
+
+.collision-list code {
+  background: var(--panel-2);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.collision-explain {
+  margin: 4px 0 0;
+  opacity: 0.85;
+}
+
 .search {
   position: relative;
   flex: 0 1 320px;
@@ -1021,6 +1059,36 @@ button:disabled {
   transition:
     opacity 120ms ease,
     visibility 120ms ease;
+}
+
+/* Kind-disagreement badge (#156). Reuses the lint-warn shape but
+   recolors to --deny so a user can tell at a glance which of the two
+   warnings is on a row when both happen to fire. --deny is the
+   "structural problem" color in the rest of the UI; conflict between
+   allow/deny/ask is exactly that, vs. lint's heuristic shape check. */
+.kind-conflict-warn {
+  color: var(--deny);
+}
+.kind-conflict-warn:hover,
+.kind-conflict-wrap.is-open > .kind-conflict-warn {
+  color: var(--deny);
+  border-color: var(--deny);
+}
+.kind-conflict-warn:focus-visible {
+  color: var(--deny);
+  border-color: var(--deny);
+}
+
+.kind-conflict-list {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  list-style: disc;
+}
+.kind-conflict-list li {
+  margin: 2px 0;
+}
+.kind-conflict-winner {
+  font-weight: 600;
 }
 
 /* Reason on top, then a muted heuristic disclaimer separated by a hairline.

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,43 @@ export interface LoadedScopes {
   scopes: ScopeView[];
   combined_permissions: PermissionRules;
   combined_origins: PermissionRuleOrigins;
+  /**
+   * Pairs (or larger groups) of scopes whose resolved file paths point at
+   * the same file on disk — the common case is launching ClaudeScope from
+   * `$HOME` itself, which collapses Project onto User (and Local onto
+   * UserLocal). Rendered as a top-of-app warning banner so the user can't
+   * miss it before treating the columns as if they were independent
+   * (#153).
+   */
+  path_collisions: PathCollision[];
+  /**
+   * Rule strings that appear in multiple scopes under disagreeing kinds —
+   * e.g. `Bash(git *)` is `allow` in User but `deny` in Project. Rendered
+   * as a warning chip next to the affected rule rows; the chip's tooltip
+   * explains which kind wins by precedence (#156).
+   */
+  kind_conflicts: KindConflict[];
+}
+
+/** One group of scopes whose resolved file paths point at the same on-disk
+ *  file (#153). Mirrors Rust's `PathCollision`. Scopes are in `SCOPES`
+ *  display order so the banner reads broad→narrow, same as the columns. */
+export interface PathCollision {
+  scopes: Scope[];
+  path: string;
+}
+
+/** One rule with disagreeing kinds across scopes (#156). Mirrors Rust's
+ *  `KindConflict`. Occurrences are in precedence order (highest first); the
+ *  frontend treats `occurrences[0]` as the winner. */
+export interface KindConflict {
+  rule: string;
+  occurrences: KindOccurrence[];
+}
+
+export interface KindOccurrence {
+  scope: Scope;
+  kind: PermissionKind;
 }
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -10,6 +10,7 @@ import type {
   DeleteLeafPreview,
   DeleteLeafRequest,
   JsonValue,
+  KindConflict,
   KnownProject,
   LoadedScopes,
   MoveLeafKind,
@@ -587,6 +588,12 @@ export function renderApp(root: HTMLElement, props: AppProps): void {
   root.appendChild(header(props));
   const banner = sandboxBanner(props.runtime);
   if (banner) root.appendChild(banner);
+  // Path-collision banner (#153) — only renders when the resolved scope
+  // paths overlap (the common case: launching from $HOME itself). Goes
+  // under the sandbox banner so the most contextual / surprising
+  // warnings stack near the topbar.
+  const collisionBanner = pathCollisionsBanner(props.scopes);
+  if (collisionBanner) root.appendChild(collisionBanner);
 
   if (!props.scopes) {
     const empty = document.createElement("div");
@@ -654,6 +661,51 @@ function restoreSearchFocus(
  * is "the user can't forget they're in scratch mode," so we deliberately
  * don't make this dismissible.
  */
+/**
+ * Warning banner shown when two or more scopes resolved to the same file
+ * on disk (#153). The common case: launching ClaudeScope with the
+ * project root equal to `$HOME` — Project and User then collapse onto the
+ * same `~/.claude/settings.json` and Local/UserLocal onto the same
+ * `settings.local.json`. The columns still render, but every cross-scope
+ * move between a colliding pair is rejected by the backend; this banner
+ * names the affected scopes + shared path so the user notices before
+ * trying.
+ */
+function pathCollisionsBanner(scopes: LoadedScopes | null): HTMLElement | null {
+  if (!scopes || scopes.path_collisions.length === 0) return null;
+  const banner = document.createElement("div");
+  banner.className = "collision-banner";
+  banner.setAttribute("role", "note");
+
+  const label = document.createElement("strong");
+  label.textContent = "Scopes share files";
+  banner.appendChild(label);
+
+  const list = document.createElement("ul");
+  list.className = "collision-list";
+  for (const c of scopes.path_collisions) {
+    const item = document.createElement("li");
+    const labels = c.scopes.map((s) => SCOPE_LABELS[s]).join(" and ");
+    const intro = document.createElement("span");
+    intro.textContent = `${labels} both resolve to `;
+    const path = document.createElement("code");
+    path.textContent = c.path;
+    item.appendChild(intro);
+    item.appendChild(path);
+    list.appendChild(item);
+  }
+  banner.appendChild(list);
+
+  const explain = document.createElement("p");
+  explain.className = "collision-explain";
+  explain.textContent =
+    "Moves between these scopes are disabled — they'd be no-ops or overwrite the file with itself. " +
+    "Open a different project root to give the scopes distinct files.";
+  banner.appendChild(explain);
+
+  return banner;
+}
+
 function sandboxBanner(runtime: RuntimeInfo): HTMLElement | null {
   if (!runtime.home_override && !runtime.project_override) return null;
   const banner = document.createElement("div");
@@ -1058,6 +1110,18 @@ function combinedPanel(loaded: LoadedScopes, props: AppProps, lowerQuery: string
       chipWrap.appendChild(originWrap);
       const badge = lintBadge(rule);
       if (badge) chipWrap.appendChild(badge);
+      // Kind-disagreement badge (#156). The combined panel deduplicates
+      // each kind separately, so the *same* rule string can appear in
+      // both `combined.allow` and `combined.deny`. The badge anchors on
+      // the highest-precedence (scope, kind) for this row — the first
+      // entry of `combined_origins[kind][i]` — so it sits exactly where
+      // the rule "lives" in this kind's column.
+      const conflictAnchorScope = (allOrigins[i] ?? [])[0];
+      if (conflictAnchorScope) {
+        const conflict = findKindConflict(rule, conflictAnchorScope, kind, loaded.kind_conflicts);
+        const cBadge = kindConflictBadge(conflict);
+        if (cBadge) chipWrap.appendChild(cBadge);
+      }
       attachContextMenu(chipWrap, () =>
         combinedChipContextMenuItems(rule, allOrigins[i] ?? [], props),
       );
@@ -1067,6 +1131,98 @@ function combinedPanel(loaded: LoadedScopes, props: AppProps, lowerQuery: string
   }
   panel.appendChild(groupsWrap);
   return panel;
+}
+
+/**
+ * Look up a rule's cross-scope kind disagreement (#156). Returns the
+ * matching `KindConflict` only when the *current* row's (scope, kind) is
+ * one of the occurrences — a rule that disagrees across two *other*
+ * scopes shouldn't render a badge on a row that's not part of the
+ * conflict. For the combined panel, callers pass the panel's "winning"
+ * scope (first entry of the rule's `combined_origins`) so the badge
+ * only sits on rule rows that are themselves part of the disagreement.
+ */
+function findKindConflict(
+  rule: string,
+  scope: Scope,
+  kind: PermissionKind,
+  conflicts: KindConflict[],
+): KindConflict | null {
+  for (const c of conflicts) {
+    if (c.rule !== rule) continue;
+    if (c.occurrences.some((o) => o.scope === scope && o.kind === kind)) return c;
+  }
+  return null;
+}
+
+/**
+ * Warning badge for a permission rule whose kind disagrees across scopes
+ * (#156). Shape mirrors `lintBadge`: a focusable ⚠ button paired with a
+ * popover so the explanation surfaces consistently on hover, focus, and
+ * click. The popover names every (scope, kind) the rule appears under,
+ * with the highest-precedence entry labeled as the winner.
+ *
+ * Returns null when `conflict` is null so callers can write
+ * `chip.append(kindConflictBadge(...) ?? document.createTextNode(""))`-
+ * style code without branching.
+ */
+function kindConflictBadge(conflict: KindConflict | null): HTMLElement | null {
+  if (conflict === null) return null;
+
+  const wrap = document.createElement("span");
+  wrap.className = "lint-warn-wrap kind-conflict-wrap";
+  const popoverId = `kind-conflict-popover-${++lintPopoverSeq}`;
+
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "lint-warn kind-conflict-warn";
+  btn.textContent = "⚠";
+  btn.setAttribute("aria-label", "Rule kind disagrees across scopes");
+  btn.setAttribute("aria-describedby", popoverId);
+
+  const pop = document.createElement("span");
+  pop.id = popoverId;
+  pop.className = "lint-warn-popover kind-conflict-popover";
+  pop.setAttribute("role", "tooltip");
+
+  const intro = document.createElement("span");
+  intro.className = "lint-warn-popover-reason";
+  intro.textContent = `Rule appears in multiple scopes with different kinds:`;
+  pop.appendChild(intro);
+
+  const list = document.createElement("ul");
+  list.className = "kind-conflict-list";
+  for (let i = 0; i < conflict.occurrences.length; i++) {
+    const o = conflict.occurrences[i];
+    const item = document.createElement("li");
+    const isWinner = i === 0;
+    item.textContent = `${SCOPE_LABELS[o.scope]}: ${KIND_LABELS[o.kind]}${
+      isWinner ? "  (wins by precedence)" : ""
+    }`;
+    if (isWinner) item.className = "kind-conflict-winner";
+    list.appendChild(item);
+  }
+  pop.appendChild(list);
+
+  const note = document.createElement("span");
+  note.className = "lint-warn-popover-note";
+  note.textContent =
+    "Highest-precedence scope wins for the effective union, but Claude Code's runtime " +
+    "resolution may apply additional rules.";
+  pop.appendChild(note);
+
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (openPinnedPopover === wrap) {
+      closePinnedPopover();
+    } else {
+      pinPopover(wrap);
+    }
+  });
+
+  wrap.appendChild(btn);
+  wrap.appendChild(pop);
+  return wrap;
 }
 
 /**
@@ -2146,6 +2302,15 @@ function treeLeaf(
     row.appendChild(wrapWithOriginTooltip(code, [scope]));
     const badge = lintBadge(rule);
     if (badge) row.appendChild(badge);
+    // Kind-disagreement badge (#156). Surfaces when the same rule string
+    // exists in another scope under a different kind (allow vs deny vs
+    // ask). The popover lists every (scope, kind) so the user can spot
+    // a likely typo or stale rule without scanning every column.
+    if (props?.scopes) {
+      const conflict = findKindConflict(rule, scope, permKind, props.scopes.kind_conflicts);
+      const cBadge = kindConflictBadge(conflict);
+      if (cBadge) row.appendChild(cBadge);
+    }
     if (props) {
       // Inline arrow buttons dropped in #152 — right-click context
       // menu (with the full Move-to submenu, including cross-project

--- a/test/fixtures/loadedScopes.ts
+++ b/test/fixtures/loadedScopes.ts
@@ -1,6 +1,8 @@
 import type {
   JsonValue,
+  KindConflict,
   LoadedScopes,
+  PathCollision,
   PermissionKind,
   PermissionRuleOrigins,
   PermissionRules,
@@ -96,6 +98,8 @@ interface LoadedScopesOverrides {
   scopes?: ScopeViewOverrides[];
   combined_permissions?: Partial<PermissionRules>;
   combined_origins?: Partial<PermissionRuleOrigins>;
+  path_collisions?: PathCollision[];
+  kind_conflicts?: KindConflict[];
 }
 
 /**
@@ -147,6 +151,8 @@ export function buildLoadedScopes(overrides: LoadedScopesOverrides = {}): Loaded
     scopes,
     combined_permissions: { ...combined, ...(overrides.combined_permissions ?? {}) },
     combined_origins: { ...origins, ...(overrides.combined_origins ?? {}) },
+    path_collisions: overrides.path_collisions ?? [],
+    kind_conflicts: overrides.kind_conflicts ?? [],
   };
 }
 

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -120,6 +120,133 @@ describe("renderApp", () => {
     expect(empty?.textContent).toBe("No settings loaded.");
   });
 
+  it("does not render the path-collisions banner when no scopes share files (#153)", () => {
+    // Sanity: the common case has no collisions, so the banner must
+    // not exist by default — otherwise it would be a noisy permanent
+    // fixture for every user.
+    const scopes = buildLoadedScopes({
+      scopes: [{ scope: "project", permissions: { allow: ["Bash(ls)"] } }],
+    });
+    renderApp(root, makeProps({ scopes }));
+    expect(root.querySelector(".collision-banner")).toBeNull();
+  });
+
+  it("renders the path-collisions banner with scope labels + shared path (#153)", () => {
+    // Mirrors the headline case: launching from $HOME makes Project and
+    // User resolve to the same `~/.claude/settings.json`. The banner
+    // names both scopes by their display labels (broad→narrow) and the
+    // shared path so the user can spot the collision before relying on
+    // the columns as if they were independent.
+    const scopes = buildLoadedScopes({
+      path_collisions: [
+        {
+          scopes: ["project", "user"],
+          path: "/home/u/.claude/settings.json",
+        },
+        {
+          scopes: ["local", "user_local"],
+          path: "/home/u/.claude/settings.local.json",
+        },
+      ],
+    });
+    renderApp(root, makeProps({ scopes }));
+    const banner = root.querySelector(".collision-banner");
+    expect(banner).not.toBeNull();
+    expect(banner!.textContent).toContain("Scopes share files");
+    const items = banner!.querySelectorAll(".collision-list li");
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toContain("Project and User");
+    expect(items[0].textContent).toContain("/home/u/.claude/settings.json");
+    expect(items[1].textContent).toContain("Local and User-Local");
+    expect(items[1].textContent).toContain("/home/u/.claude/settings.local.json");
+  });
+
+  it("renders a kind-conflict badge on the per-scope rule row (#156)", () => {
+    // `Bash(git push)` is allowed in User but denied in Project — the
+    // detector picks this up and surfaces a `kind_conflicts` entry; the
+    // renderer must put a ⚠ badge on the rule row in each scope it
+    // appears in, with the popover naming both occurrences.
+    //
+    // Unique project_dir so `seedDefaultOpenPermissions` actually runs
+    // for this test (the seeder no-ops when `lastSeededProjectDir`
+    // already matches the incoming projectDir — module-level state
+    // shared across tests in this file).
+    const scopes = buildLoadedScopes({
+      project_dir: "/fake/project-kind-conflict-per-scope",
+      scopes: [
+        { scope: "project", permissions: { deny: ["Bash(git push)"] } },
+        { scope: "user", permissions: { allow: ["Bash(git push)"] } },
+      ],
+      kind_conflicts: [
+        {
+          rule: "Bash(git push)",
+          occurrences: [
+            { scope: "project", kind: "deny" },
+            { scope: "user", kind: "allow" },
+          ],
+        },
+      ],
+    });
+    renderApp(root, makeProps({ scopes }));
+    const projectRule = Array.from(root.querySelectorAll(".rule")).find(
+      (r) => r.textContent?.includes("Bash(git push)") && r.classList.contains("rule-deny"),
+    );
+    expect(projectRule).toBeDefined();
+    expect(projectRule!.querySelector(".kind-conflict-wrap")).not.toBeNull();
+    // Popover lists both occurrences with Project first (precedence).
+    const pop = projectRule!.querySelector(".kind-conflict-popover");
+    expect(pop?.textContent).toContain("Project: deny");
+    expect(pop?.textContent).toContain("User: allow");
+    expect(pop?.textContent).toContain("wins by precedence");
+  });
+
+  it("does not render the kind-conflict badge when scopes agree (#156)", () => {
+    // Same rule under the same kind in two scopes — agreement, not
+    // conflict. No badge.
+    const scopes = buildLoadedScopes({
+      scopes: [
+        { scope: "project", permissions: { allow: ["Bash(git status)"] } },
+        { scope: "user", permissions: { allow: ["Bash(git status)"] } },
+      ],
+      // Detector returns empty for matching kinds; the fixture mirrors that.
+      kind_conflicts: [],
+    });
+    renderApp(root, makeProps({ scopes }));
+    expect(root.querySelector(".kind-conflict-wrap")).toBeNull();
+  });
+
+  it("renders the kind-conflict badge on the combined panel chip (#156)", () => {
+    const scopes = buildLoadedScopes({
+      project_dir: "/fake/project-kind-conflict-combined",
+      scopes: [
+        { scope: "project", permissions: { deny: ["Bash(git push)"] } },
+        { scope: "user", permissions: { allow: ["Bash(git push)"] } },
+      ],
+      kind_conflicts: [
+        {
+          rule: "Bash(git push)",
+          occurrences: [
+            { scope: "project", kind: "deny" },
+            { scope: "user", kind: "allow" },
+          ],
+        },
+      ],
+    });
+    renderApp(
+      root,
+      makeProps({ scopes, preferences: buildPreferences({ combined_panel_collapsed: false }) }),
+    );
+    // The combined panel renders the rule under each kind it appears in
+    // (allow and deny in this case). Each chip should carry the badge.
+    const chips = Array.from(root.querySelectorAll(".combo-group .chip-wrap")).filter((w) =>
+      w.textContent?.includes("Bash(git push)"),
+    );
+    expect(chips.length).toBeGreaterThanOrEqual(1);
+    for (const chip of chips) {
+      expect(chip.querySelector(".kind-conflict-wrap")).not.toBeNull();
+    }
+  });
+
   it("defaults the combined panel to collapsed via preferences (#155)", () => {
     // Default `combined_panel_collapsed: true` from buildPreferences
     // mirrors the Rust default — the panel renders closed on first


### PR DESCRIPTION
## Summary

Two warning surfaces, both detected at scope load, surfaced through `LoadedScopes`. Bundled because they're peer "things the user couldn't otherwise notice" warnings and share the LoadedScopes payload + fixture plumbing.

### #153 — Path collisions

Detects scopes whose resolved file paths collapse onto the same on-disk file. Common case: opening ClaudeScope from \`\$HOME\` makes Project and User both resolve to \`~/.claude/settings.json\` (and Local/UserLocal to \`settings.local.json\`).

- Banner under the sandbox banner: "Scopes share files" + bulleted list naming each pair + the shared path
- \`validate_move_request\` refuses cross-scope moves between colliding scopes with a typed error
- Same-scope change-kind unaffected (operation still meaningful)

### #156 — Kind disagreements

Detects rule strings that appear in multiple scopes under different kinds (e.g. \`Bash(git push)\` is \`allow\` in User but \`deny\` in Project).

- ⚠ badge on every per-scope rule row in each affected (scope, kind) bucket
- Same badge on the matching combined-panel chips
- Popover lists every (scope, kind) with the highest-precedence one labeled "wins by precedence"
- Badge styled with \`--deny\` so a row with both lint + conflict shows two visually distinct cues

## Test plan

- [x] 281 Rust lib tests (was 274 — +7 for the two detectors + move-refusal)
- [x] 137 JS unit tests (was 132 — +5 for banner + badge rendering)
- [x] 21 CLI integration tests
- [x] \`just check\` clean (typecheck, biome, clippy, all suites)
- [x] SMOKE_TEST.md: two new bullets covering banner + badge flows
- [ ] CI confirms

## Reviewer notes

- Both detectors live in \`build_loaded\` so every \`load_scopes\` IPC carries the data; no opt-in needed.
- Path-collision comparison is byte-equal on the \`PathBuf\` the resolver produced — sufficient because both sides come from the same \`dirs::home_dir()\` / \`find_project_root\` pipeline. Canonicalize-if-exists is a defensive nicety we don't need today; if symlink edge cases bite later, the helper is one file to update.
- Kind-conflict badge reuses \`lintBadge\`'s shape (focusable ⚠ + popover). Recoloring is the only visual differentiator from the lint badge; the popover content disambiguates verbally.
- \`combined_origins[kind][i][0]\` is the anchor scope for the combined-panel badge — the rule's highest-precedence (scope, kind) in *this* kind's column. The lookup helper checks every occurrence so the badge fires on any chip the rule is part of, not just where it "wins."

Closes #153, closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)