### PR TITLE
feat(redundancy): detect duplicate and subsumed permission rules (#17)

### DIFF
--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -137,6 +137,17 @@ reviewer.
       between two scopes that share a file: the apply should fail with a
       typed error naming both scopes and the shared path. Close and
       re-open against a normal project root; the banner disappears.
+- [ ] **Redundancy badge (#17).** Set up a sandbox project whose
+      User-scope settings contain `"Bash(git *)"` in `allow` and whose
+      Project-scope settings duplicate it AND add `"Bash(git status)"`.
+      Reload. The Project's `Bash(git *)` row shows a gray ⚠ badge
+      ("Exact duplicate of another rule" / covered by User). The
+      Project's `Bash(git status)` row shows a gray ⚠ badge ("Already
+      covered by a broader rule" / `Bash(git *)` in User). The User's
+      `Bash(git *)` row stays clean. Hover (or focus + Enter) each
+      badge: the popover names the covering rule + scope and points at
+      right-click → Delete. Right-click the redundant chip → **Delete**
+      → confirm: the rule disappears and the badge clears.
 - [ ] **Cross-project Move-to: same-scope unlock (#179, #181).** Set up
       two project sandboxes (e.g. `/tmp/cs-smoke-a` and `/tmp/cs-smoke-b`,
       each with a `.claude/settings.local.json` containing a different

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -82,6 +82,12 @@ pub struct LoadedScopes {
     /// disagreement so the user can spot a likely typo or stale rule
     /// without scanning every column. See #156.
     pub kind_conflicts: Vec<KindConflict>,
+    /// Permission rules that are either exact duplicates or fully
+    /// covered by a broader rule of the same kind (#17). The UI renders
+    /// a ⚠ badge on every redundant chip with a popover naming the
+    /// covering rule. Cross-kind shadowing (allow vs deny) is out of
+    /// scope here — that's the kind-conflict warning's territory.
+    pub redundancies: Vec<crate::redundancy::Redundancy>,
 }
 
 /// Two-or-more scopes whose resolved file paths point at the same on-disk
@@ -1129,6 +1135,7 @@ pub fn build_loaded(paths: &ScopePaths) -> Result<LoadedScopes, Box<dyn std::err
     let (combined, origins) = combined_permissions(&views);
     let path_collisions = detect_path_collisions(paths);
     let kind_conflicts = detect_kind_conflicts(&views);
+    let redundancies = crate::redundancy::detect_redundancies(&views);
 
     Ok(LoadedScopes {
         project_dir: paths.project_dir.display().to_string(),
@@ -1137,6 +1144,7 @@ pub fn build_loaded(paths: &ScopePaths) -> Result<LoadedScopes, Box<dyn std::err
         combined_origins: origins,
         path_collisions,
         kind_conflicts,
+        redundancies,
     })
 }
 
@@ -1305,7 +1313,9 @@ fn combined_permissions(views: &[ScopeView]) -> (PermissionRules, PermissionRule
 /// disk load. Missing or malformed shapes degrade to empty lists rather
 /// than panic, matching the "partial corruption shouldn't break the UI"
 /// stance everywhere else.
-fn permissions_from_values(values: &serde_json::Map<String, serde_json::Value>) -> PermissionRules {
+pub fn permissions_from_values(
+    values: &serde_json::Map<String, serde_json::Value>,
+) -> PermissionRules {
     let mut out = PermissionRules::default();
     let Some(perms) = values
         .get("permissions")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod io_atomic;
 pub mod model;
 pub mod preferences;
 pub mod projects;
+pub mod redundancy;
 mod runtime;
 pub mod scope;
 pub mod watcher;

--- a/src-tauri/src/redundancy.rs
+++ b/src-tauri/src/redundancy.rs
@@ -1,0 +1,695 @@
+//! Detect redundant permission rules across the loaded scopes (#17).
+//!
+//! Two redundancy shapes are reported:
+//!
+//!   - **Duplicate** — the exact same rule string appears in more than one
+//!     `(scope, kind, index)` position within the same `PermissionKind`.
+//!     Trivial; any of the copies can be removed.
+//!   - **Subsumed** — a narrower rule pattern is fully covered by a broader
+//!     rule of the same kind (`Bash(git status)` ⊂ `Bash(git *)`). The
+//!     narrower copy adds nothing because the broader rule already
+//!     grants / denies it.
+//!
+//! Both cases are scoped to one [`PermissionKind`] at a time. Cross-kind
+//! shadowing (`allow Bash(git *)` vs `deny Bash(git push)`) is a different
+//! UX surface — the user might *want* a carve-out — and is left to the
+//! kind-conflict warning (#156) for v0.7.
+//!
+//! ## Subsumption philosophy
+//!
+//! Conservative-by-design. The detector reports **only** the cases it can
+//! decide with certainty by string matching; everything else falls through
+//! as "not redundant." Claude Code's real argument grammars per tool aren't
+//! publicly documented in full, so a wrong "remove this, it's covered"
+//! claim would actively erase user intent — far worse than a false
+//! negative.
+//!
+//! The recognized subsumption shapes are:
+//!
+//!   - **Bare tool name** covers `Tool(<anything>)`. `Bash` (equivalent to
+//!     `Bash(*)`) covers `Bash(git status)` and every other `Bash(...)`.
+//!   - **Tool with universal arg** `Tool(*)` covers `Tool(<anything>)`.
+//!   - **Tool with glob suffix** `Tool(prefix*)` covers
+//!     `Tool(prefixXYZ)` where the broader rule's literal prefix is a
+//!     byte-prefix of the narrower rule's full arg. The `*` is treated as
+//!     "any tail" — Claude Code's matcher is shell-glob-ish but we don't
+//!     assume per-character semantics.
+//!   - **WebFetch domain wildcards** — `WebFetch(domain:*)` covers any
+//!     `WebFetch(domain:<host>)`. `WebFetch(domain:*.suffix)` covers any
+//!     `WebFetch(domain:<sub>.suffix)`.
+//!   - **MCP server wildcards** — `mcp__<server>__*` covers
+//!     `mcp__<server>__<tool>` for the same server.
+//!
+//! Everything else returns `false`. Notably: nested glob patterns
+//! (`Bash(git **)`), path globs with intermediate wildcards
+//! (`Read(/foo/*/bar)`), and any rule whose argument the lint rejects
+//! all fall through unmatched.
+
+use serde::Serialize;
+
+use crate::commands::ScopeView;
+use crate::model::PermissionKind;
+use crate::scope::Scope;
+
+/// One detected redundancy: a `redundant` rule that's fully covered by
+/// `covered_by`. The frontend renders a ⚠ badge on every chip whose
+/// `(scope, kind, index)` matches `redundant`, with a popover that names
+/// the covering rule by string + scope.
+///
+/// Position fields (`scope` / `kind` / `index`) carry enough context to
+/// dispatch an `apply_delete_leaf` IPC against the redundant rule
+/// directly — wiring that delete path into a "Remove redundant" action
+/// is a follow-up.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Redundancy {
+    pub redundant: RuleLoc,
+    pub covered_by: RuleLoc,
+    pub kind: RedundancyKind,
+}
+
+/// Position of one rule inside a `LoadedScopes` view. `index` is the
+/// position within `permissions.<kind>` at the redundant rule's scope.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RuleLoc {
+    pub rule: String,
+    pub scope: Scope,
+    pub kind: PermissionKind,
+    pub index: usize,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RedundancyKind {
+    /// Exact string duplicate.
+    Duplicate,
+    /// Pattern subsumption: `redundant`'s pattern is a strict subset of
+    /// `covered_by`'s pattern.
+    Subsumed,
+}
+
+/// Walk every (scope, kind, rule) triple across `views` and report the
+/// minimal set of redundancies a user could safely remove.
+///
+/// Detection direction: for each rule, find the **broadest** other rule
+/// of the same kind that covers it. A rule covered by itself (its own
+/// position in the iteration) doesn't count.
+///
+/// The returned list is deduplicated on `redundant.{scope, kind, index}`
+/// so each redundant chip surfaces at most one badge — the badge picks
+/// the broadest coverer to display.
+pub fn detect_redundancies(views: &[ScopeView]) -> Vec<Redundancy> {
+    // Flatten to a Vec of (loc, view-index) so the cross-pair scan can
+    // skip-self by index. `views` is in `Scope::ALL` (precedence) order,
+    // so a deterministic scan inherits that order — handy for tests
+    // that pin the chosen coverer.
+    let mut rules: Vec<RuleLoc> = Vec::new();
+    for view in views {
+        let perms = crate::commands::permissions_from_values(&view.values);
+        for (kind, list) in [
+            (PermissionKind::Allow, &perms.allow),
+            (PermissionKind::Deny, &perms.deny),
+            (PermissionKind::Ask, &perms.ask),
+        ] {
+            for (idx, rule) in list.iter().enumerate() {
+                rules.push(RuleLoc {
+                    rule: rule.clone(),
+                    scope: view.scope,
+                    kind,
+                    index: idx,
+                });
+            }
+        }
+    }
+
+    let mut out: Vec<Redundancy> = Vec::new();
+    for (i, candidate) in rules.iter().enumerate() {
+        // Find the broadest other rule of the same kind that covers
+        // `candidate`. "Broadest" is determined by `rule_breadth`: a
+        // bare tool name > `Tool(*)` > `Tool(prefix*)` > exact. Ties
+        // resolve by scan order (which matches `Scope::ALL`
+        // precedence) so the chosen coverer is deterministic.
+        let mut best: Option<(&RuleLoc, RedundancyKind, u32)> = None;
+        for (j, other) in rules.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            if other.kind != candidate.kind {
+                continue;
+            }
+            let Some(kind_of_redundancy) = subsumes(&other.rule, &candidate.rule) else {
+                continue;
+            };
+            let breadth = rule_breadth(&other.rule);
+            let take = match best {
+                None => true,
+                Some((_, _, b)) => breadth > b,
+            };
+            if take {
+                best = Some((other, kind_of_redundancy, breadth));
+            }
+        }
+        if let Some((other, kind, _)) = best {
+            // For an exact duplicate, only emit the badge on ONE of the
+            // two copies — otherwise both copies show "this is redundant
+            // because of the other one" which is circular. Keep the
+            // later-scanned copy as the redundant one; the earlier one
+            // (which appears first in precedence + index order) is the
+            // canonical keeper.
+            if kind == RedundancyKind::Duplicate {
+                let other_idx = rules.iter().position(|r| r == other).unwrap_or(usize::MAX);
+                if other_idx < i {
+                    out.push(Redundancy {
+                        redundant: candidate.clone(),
+                        covered_by: other.clone(),
+                        kind,
+                    });
+                }
+            } else {
+                out.push(Redundancy {
+                    redundant: candidate.clone(),
+                    covered_by: other.clone(),
+                    kind,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Returns `Some(kind)` iff `broader` is recognized to cover `narrower`
+/// for the same `PermissionKind`. Returns `None` for any case the
+/// detector can't decide with certainty.
+///
+/// The kind axis is the caller's responsibility — this function compares
+/// rule *strings* only.
+fn subsumes(broader: &str, narrower: &str) -> Option<RedundancyKind> {
+    // Reject obviously unparseable inputs up front so the identity branch
+    // can't fire on garbage strings (e.g. `subsumes("", "")` had been
+    // falsely reporting an empty pair as a duplicate).
+    if parse_rule(broader).is_none() || parse_rule(narrower).is_none() {
+        return None;
+    }
+    if broader == narrower {
+        return Some(RedundancyKind::Duplicate);
+    }
+    if covers_strictly(broader, narrower) {
+        return Some(RedundancyKind::Subsumed);
+    }
+    None
+}
+
+/// True iff `broader`'s pattern covers `narrower`'s pattern AND they are
+/// not byte-equal. Identity is handled separately by [`subsumes`] so the
+/// duplicate / subsumed distinction stays in the caller.
+fn covers_strictly(broader: &str, narrower: &str) -> bool {
+    let Some(b) = parse_rule(broader) else {
+        return false;
+    };
+    let Some(n) = parse_rule(narrower) else {
+        return false;
+    };
+
+    // MCP: server-level wildcard covers every tool under that server.
+    if let (ParsedRule::Mcp(b_server, b_tool), ParsedRule::Mcp(n_server, _)) = (&b, &n) {
+        if b_server == n_server && b_tool == "*" {
+            return true;
+        }
+    }
+
+    // Tool name must match for non-MCP. Bare tool name is treated as
+    // `Tool(*)` for coverage purposes.
+    let (broader_tool, broader_args) = match b {
+        ParsedRule::BareTool(name) => (name, "*".to_string()),
+        ParsedRule::Tool(name, args) => (name, args),
+        ParsedRule::Mcp(_, _) => return false,
+    };
+    let (narrower_tool, narrower_args) = match n {
+        ParsedRule::BareTool(name) => (name, "*".to_string()),
+        ParsedRule::Tool(name, args) => (name, args),
+        ParsedRule::Mcp(_, _) => return false,
+    };
+    if broader_tool != narrower_tool {
+        return false;
+    }
+
+    args_cover(&broader_tool, &broader_args, &narrower_args)
+}
+
+/// Tool-specific argument-pattern coverage. Conservative by design —
+/// `false` is always a safe answer.
+fn args_cover(tool: &str, broader: &str, narrower: &str) -> bool {
+    if broader == narrower {
+        return false; // identity handled upstream
+    }
+    // Universal arg: `Tool(*)` covers any non-empty arg.
+    if broader == "*" {
+        return !narrower.is_empty();
+    }
+    // WebFetch domain wildcards: handle `domain:*` and `domain:*.suffix`.
+    if tool == "WebFetch" {
+        if let (Some(b_host), Some(n_host)) = (
+            broader.strip_prefix("domain:"),
+            narrower.strip_prefix("domain:"),
+        ) {
+            return domain_covers(b_host, n_host);
+        }
+        return false;
+    }
+    // Generic glob suffix: `prefix*` covers `prefix<anything>` (where
+    // `<anything>` is non-empty and the literal prefix is a byte-prefix
+    // of the narrower arg). Reserved for the case where the broader rule
+    // ends in exactly one `*` and the narrower has no `*` at all — the
+    // moment either side gets fancier (intermediate `*`, `**`, character
+    // classes) we bail.
+    if let Some(prefix) = broader.strip_suffix('*') {
+        if !prefix.contains('*') && !narrower.contains('*') && narrower.starts_with(prefix) {
+            // Require the narrower arg to actually extend the prefix —
+            // otherwise `Bash(*)` would be claimed to cover itself, and
+            // empty-extension cases collapse into the duplicate branch.
+            return narrower.len() > prefix.len();
+        }
+    }
+    false
+}
+
+/// Domain-glob coverage for WebFetch. `*` covers anything; `*.suffix`
+/// covers `<sub>.suffix` (single label or further nested). Conservative:
+/// no support for mid-string wildcards.
+fn domain_covers(broader: &str, narrower: &str) -> bool {
+    if broader == "*" {
+        return !narrower.is_empty();
+    }
+    if let Some(suffix) = broader.strip_prefix("*.") {
+        if narrower.contains('*') {
+            return false;
+        }
+        // `*.github.com` covers `api.github.com` (one label prefix) and
+        // `nested.api.github.com` (multi-label) — match the wildcard's
+        // shell-style semantics.
+        if let Some(stripped) = narrower.strip_suffix(suffix) {
+            return stripped.ends_with('.') && stripped.len() > 1;
+        }
+    }
+    false
+}
+
+/// Rank a rule's "breadth" — how many other rules it could plausibly
+/// cover. Used to pick the broadest coverer when multiple rules cover
+/// the same candidate. Higher number = broader.
+///
+/// The ranking is heuristic but stable enough that tests can pin a
+/// specific coverer choice. Exact values don't matter; only their
+/// relative order does.
+fn rule_breadth(rule: &str) -> u32 {
+    let Some(parsed) = parse_rule(rule) else {
+        return 0;
+    };
+    match parsed {
+        // Bare tool name and `Tool(*)` are equivalent — both rank as
+        // "universal". MCP server-level wildcard sits at the same tier
+        // since it covers all tools under the server.
+        ParsedRule::BareTool(_) => 100,
+        ParsedRule::Tool(_, args) if args == "*" => 100,
+        ParsedRule::Mcp(_, tool) if tool == "*" => 100,
+        // Tool with a glob suffix: more specific than universal but
+        // broader than an exact rule. Shorter literal prefix = broader.
+        ParsedRule::Tool(_, args)
+            if args.ends_with('*') && !args[..args.len() - 1].contains('*') =>
+        {
+            50 + (32_u32.saturating_sub(args.len() as u32))
+        }
+        // WebFetch domain wildcards: same tier as glob suffix, scored
+        // by how much of the domain is wild.
+        ParsedRule::Tool(tool, args) if tool == "WebFetch" && args.starts_with("domain:*") => 60,
+        _ => 10,
+    }
+}
+
+#[derive(Debug, Clone)]
+enum ParsedRule {
+    /// Bare tool name (no parens). `Bash` is equivalent to `Bash(*)`.
+    BareTool(String),
+    /// Tool with arguments: `Tool(<args>)`.
+    Tool(String, String),
+    /// MCP rule: `mcp__<server>__<tool>` or `mcp__<server>__*`.
+    Mcp(String, String),
+}
+
+fn parse_rule(raw: &str) -> Option<ParsedRule> {
+    let rule = raw.trim();
+    if rule.is_empty() {
+        return None;
+    }
+    if let Some(rest) = rule.strip_prefix("mcp__") {
+        let parts: Vec<&str> = rest.split("__").collect();
+        if parts.len() < 2 {
+            return None;
+        }
+        let server = parts[0].to_string();
+        let tool = parts[parts.len() - 1].to_string();
+        if server.is_empty() || tool.is_empty() {
+            return None;
+        }
+        return Some(ParsedRule::Mcp(server, tool));
+    }
+    if let Some(paren_start) = rule.find('(') {
+        if !rule.ends_with(')') {
+            return None;
+        }
+        let name = rule[..paren_start].to_string();
+        let args = rule[paren_start + 1..rule.len() - 1].to_string();
+        if name.is_empty() {
+            return None;
+        }
+        return Some(ParsedRule::Tool(name, args));
+    }
+    // Bare tool name — alphanumeric only (the lint accepts an explicit
+    // small set, but for coverage purposes any identifier is fine).
+    if rule.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return Some(ParsedRule::BareTool(rule.to_string()));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::ScopeView;
+
+    fn view(scope: Scope, allow: &[&str], deny: &[&str], ask: &[&str]) -> ScopeView {
+        let mut values = serde_json::Map::new();
+        if !allow.is_empty() || !deny.is_empty() || !ask.is_empty() {
+            values.insert(
+                "permissions".into(),
+                serde_json::json!({
+                    "allow": allow,
+                    "deny": deny,
+                    "ask": ask,
+                }),
+            );
+        }
+        ScopeView {
+            scope,
+            path: None,
+            exists: true,
+            values,
+            parse_error: None,
+        }
+    }
+
+    // ---- subsumes() -----------------------------------------------------
+
+    #[test]
+    fn subsumes_identity_is_duplicate() {
+        assert_eq!(
+            subsumes("Bash(git status)", "Bash(git status)"),
+            Some(RedundancyKind::Duplicate)
+        );
+    }
+
+    #[test]
+    fn subsumes_universal_arg_covers_any_arg_for_same_tool() {
+        assert_eq!(
+            subsumes("Bash(*)", "Bash(git status)"),
+            Some(RedundancyKind::Subsumed)
+        );
+        assert_eq!(
+            subsumes("Bash(*)", "Bash(echo hi)"),
+            Some(RedundancyKind::Subsumed)
+        );
+    }
+
+    #[test]
+    fn subsumes_bare_tool_equivalent_to_universal() {
+        // `Bash` is shorthand for `Bash(*)` per the lint module.
+        assert_eq!(
+            subsumes("Bash", "Bash(git status)"),
+            Some(RedundancyKind::Subsumed)
+        );
+    }
+
+    #[test]
+    fn subsumes_glob_suffix_covers_prefixed_args() {
+        assert_eq!(
+            subsumes("Bash(git *)", "Bash(git status)"),
+            Some(RedundancyKind::Subsumed)
+        );
+        assert_eq!(
+            subsumes("Read(/home/u/foo/*)", "Read(/home/u/foo/bar.txt)"),
+            Some(RedundancyKind::Subsumed)
+        );
+    }
+
+    #[test]
+    fn subsumes_glob_suffix_does_not_cover_unrelated_prefix() {
+        // Different prefix — the broader rule does not in fact cover.
+        assert_eq!(subsumes("Bash(git *)", "Bash(rm -rf /)"), None);
+    }
+
+    #[test]
+    fn subsumes_does_not_claim_when_narrower_also_has_glob() {
+        // `Bash(git *)` vs `Bash(git st*)` — both have wildcards;
+        // deciding whether the latter's match set is a subset of the
+        // former's requires real glob semantics we don't have. Bail.
+        assert_eq!(subsumes("Bash(git *)", "Bash(git st*)"), None);
+    }
+
+    #[test]
+    fn subsumes_does_not_claim_across_different_tools() {
+        assert_eq!(subsumes("Bash(*)", "Read(/etc/passwd)"), None);
+    }
+
+    #[test]
+    fn subsumes_webfetch_universal_domain_covers_specific_host() {
+        assert_eq!(
+            subsumes("WebFetch(domain:*)", "WebFetch(domain:api.github.com)"),
+            Some(RedundancyKind::Subsumed)
+        );
+    }
+
+    #[test]
+    fn subsumes_webfetch_wildcard_suffix_covers_subdomain() {
+        assert_eq!(
+            subsumes(
+                "WebFetch(domain:*.github.com)",
+                "WebFetch(domain:api.github.com)"
+            ),
+            Some(RedundancyKind::Subsumed)
+        );
+        // Multi-level subdomains also count: `*.github.com` covers
+        // `nested.api.github.com` because shell-glob semantics make
+        // `*` greedy across `.`.
+        assert_eq!(
+            subsumes(
+                "WebFetch(domain:*.github.com)",
+                "WebFetch(domain:nested.api.github.com)"
+            ),
+            Some(RedundancyKind::Subsumed)
+        );
+    }
+
+    #[test]
+    fn subsumes_webfetch_wildcard_does_not_cover_unrelated_domain() {
+        assert_eq!(
+            subsumes(
+                "WebFetch(domain:*.github.com)",
+                "WebFetch(domain:gitlab.com)"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn subsumes_mcp_server_wildcard_covers_specific_tool() {
+        assert_eq!(
+            subsumes("mcp__github__*", "mcp__github__list_issues"),
+            Some(RedundancyKind::Subsumed)
+        );
+    }
+
+    #[test]
+    fn subsumes_mcp_server_wildcard_does_not_cover_different_server() {
+        assert_eq!(subsumes("mcp__github__*", "mcp__gitlab__list_issues"), None);
+    }
+
+    #[test]
+    fn subsumes_bails_on_unparseable_inputs() {
+        assert_eq!(subsumes("not a rule", "Bash(rm)"), None);
+        assert_eq!(subsumes("Bash(rm", "Bash(rm)"), None);
+        assert_eq!(subsumes("", ""), None);
+    }
+
+    // ---- detect_redundancies() ------------------------------------------
+
+    #[test]
+    fn detects_exact_duplicate_within_one_scope_and_kind() {
+        // Hand-edited duplicate in one file. Emits ONE redundancy
+        // (later copy is the redundant one; earlier is the keeper) —
+        // not two cross-referencing each other.
+        let views = vec![view(Scope::Local, &["Bash(rm)", "Bash(rm)"], &[], &[])];
+        let red = detect_redundancies(&views);
+        assert_eq!(red.len(), 1);
+        assert_eq!(red[0].redundant.index, 1);
+        assert_eq!(red[0].covered_by.index, 0);
+        assert_eq!(red[0].kind, RedundancyKind::Duplicate);
+    }
+
+    #[test]
+    fn detects_exact_duplicate_across_scopes() {
+        // `Bash(rm)` in both User and Project — same kind. Scan order
+        // is callsite-supplied (`view` calls go in test order), so
+        // whichever scope appears first is the keeper. The detector's
+        // job is to emit exactly one redundancy in either case.
+        let views = vec![
+            view(Scope::Project, &["Bash(rm)"], &[], &[]),
+            view(Scope::User, &["Bash(rm)"], &[], &[]),
+        ];
+        let red = detect_redundancies(&views);
+        assert_eq!(red.len(), 1);
+        // First-scanned scope (Project here) is the keeper.
+        assert_eq!(red[0].covered_by.scope, Scope::Project);
+        assert_eq!(red[0].redundant.scope, Scope::User);
+    }
+
+    #[test]
+    fn detects_subsumption_within_one_scope() {
+        // `Bash(git *)` covers `Bash(git status)`.
+        let views = vec![view(
+            Scope::Local,
+            &["Bash(git *)", "Bash(git status)"],
+            &[],
+            &[],
+        )];
+        let red = detect_redundancies(&views);
+        assert_eq!(red.len(), 1);
+        assert_eq!(red[0].redundant.rule, "Bash(git status)");
+        assert_eq!(red[0].covered_by.rule, "Bash(git *)");
+        assert_eq!(red[0].kind, RedundancyKind::Subsumed);
+    }
+
+    #[test]
+    fn detects_subsumption_across_scopes() {
+        // User has the broad rule; Project has the specific one. The
+        // Project specific is redundant.
+        let views = vec![
+            view(Scope::Project, &["Bash(git status)"], &[], &[]),
+            view(Scope::User, &["Bash(git *)"], &[], &[]),
+        ];
+        let red = detect_redundancies(&views);
+        assert_eq!(red.len(), 1);
+        assert_eq!(red[0].redundant.scope, Scope::Project);
+        assert_eq!(red[0].covered_by.scope, Scope::User);
+    }
+
+    #[test]
+    fn does_not_detect_subsumption_across_kinds() {
+        // Same rule string, but allow vs deny. That's the
+        // kind-conflict warning (#156), not a redundancy.
+        let views = vec![view(
+            Scope::Project,
+            &["Bash(git *)"],
+            &["Bash(git push)"],
+            &[],
+        )];
+        let red = detect_redundancies(&views);
+        assert!(
+            red.is_empty(),
+            "cross-kind shadowing is out of scope: {red:?}"
+        );
+    }
+
+    #[test]
+    fn picks_the_broadest_coverer_when_multiple_apply() {
+        // `Bash(git status)` is covered by both `Bash(*)` (universal)
+        // and `Bash(git *)` (prefix). The broader rule (`Bash(*)`)
+        // should be reported as the coverer.
+        let views = vec![view(
+            Scope::Local,
+            &["Bash(git status)", "Bash(git *)", "Bash(*)"],
+            &[],
+            &[],
+        )];
+        let red = detect_redundancies(&views);
+        // Three rules; two should be flagged as redundant (everything
+        // except `Bash(*)`).
+        let redundant_rules: Vec<&str> = red.iter().map(|r| r.redundant.rule.as_str()).collect();
+        assert!(redundant_rules.contains(&"Bash(git status)"));
+        assert!(redundant_rules.contains(&"Bash(git *)"));
+        // The flagged `Bash(git status)` should point at the broadest
+        // coverer, not the intermediate `Bash(git *)`.
+        let git_status_red = red
+            .iter()
+            .find(|r| r.redundant.rule == "Bash(git status)")
+            .unwrap();
+        assert_eq!(git_status_red.covered_by.rule, "Bash(*)");
+    }
+
+    #[test]
+    fn returns_empty_when_no_redundancies() {
+        let views = vec![view(
+            Scope::Local,
+            &[
+                "Bash(git status)",
+                "Read(**)",
+                "WebFetch(domain:github.com)",
+            ],
+            &[],
+            &[],
+        )];
+        assert!(detect_redundancies(&views).is_empty());
+    }
+
+    #[test]
+    fn detects_mcp_server_wildcard_subsumption() {
+        let views = vec![view(
+            Scope::Local,
+            &["mcp__github__*", "mcp__github__list_issues"],
+            &[],
+            &[],
+        )];
+        let red = detect_redundancies(&views);
+        assert_eq!(red.len(), 1);
+        assert_eq!(red[0].redundant.rule, "mcp__github__list_issues");
+        assert_eq!(red[0].covered_by.rule, "mcp__github__*");
+    }
+
+    #[test]
+    fn webfetch_subdomain_wildcard_subsumption_end_to_end() {
+        let views = vec![view(
+            Scope::Local,
+            &[
+                "WebFetch(domain:*.github.com)",
+                "WebFetch(domain:api.github.com)",
+            ],
+            &[],
+            &[],
+        )];
+        let red = detect_redundancies(&views);
+        assert_eq!(red.len(), 1);
+        assert_eq!(red[0].redundant.rule, "WebFetch(domain:api.github.com)");
+    }
+
+    #[test]
+    fn three_copies_in_two_scopes_emit_one_keeper_two_redundants() {
+        // Hand-edited duplicate in Project + a copy in User. The
+        // first-scanned copy (Project's first slot) becomes the
+        // keeper; the other two are redundant. Three rules → two
+        // redundancies, regardless of which is the keeper.
+        let views = vec![
+            view(Scope::Project, &["Bash(rm)", "Bash(rm)"], &[], &[]),
+            view(Scope::User, &["Bash(rm)"], &[], &[]),
+        ];
+        let red = detect_redundancies(&views);
+        assert_eq!(red.len(), 2);
+        // All redundants point at the same keeper.
+        let keepers: std::collections::HashSet<_> = red
+            .iter()
+            .map(|r| (r.covered_by.scope, r.covered_by.index))
+            .collect();
+        assert_eq!(
+            keepers.len(),
+            1,
+            "all redundants should share one keeper: {red:?}"
+        );
+    }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1091,6 +1091,41 @@ button:disabled {
   font-weight: 600;
 }
 
+/* Redundancy badge (#17). Recolored to --muted so the user can tell at
+   a glance it's the lowest-severity of the three warnings — lint's --ask
+   amber flags a shape problem, --deny red flags a kind disagreement,
+   --muted gray suggests "this could be tidied up." The popover's
+   `redundancy-covering` code block names the covering rule verbatim so
+   the user can compare without leaving the chip. */
+.redundancy-warn {
+  color: var(--muted);
+}
+.redundancy-warn:hover,
+.redundancy-wrap.is-open > .redundancy-warn {
+  color: var(--text);
+  border-color: var(--muted);
+}
+.redundancy-warn:focus-visible {
+  color: var(--text);
+  border-color: var(--muted);
+}
+
+.redundancy-covering {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 2px 5px;
+  background: var(--panel-2);
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.redundancy-scope {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
 /* Reason on top, then a muted heuristic disclaimer separated by a hairline.
    The yellow ⚠ reads as authoritative on its own, so the popover spells out
    that it's a best-effort shape check rather than a verdict from Claude

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,30 @@ export interface LoadedScopes {
    * explains which kind wins by precedence (#156).
    */
   kind_conflicts: KindConflict[];
+  /**
+   * Permission rules that are either exact duplicates or fully covered
+   * by a broader rule of the same kind (#17). Each entry is one
+   * redundant rule with the rule that covers it; rendering puts a ⚠
+   * badge on the redundant chip and the popover explains which rule
+   * (and which scope) covers it.
+   */
+  redundancies: Redundancy[];
+}
+
+export type RedundancyKind = "duplicate" | "subsumed";
+
+/** One detected redundancy (#17). Mirrors Rust's `redundancy::Redundancy`. */
+export interface Redundancy {
+  redundant: RuleLoc;
+  covered_by: RuleLoc;
+  kind: RedundancyKind;
+}
+
+export interface RuleLoc {
+  rule: string;
+  scope: Scope;
+  kind: PermissionKind;
+  index: number;
 }
 
 /** One group of scopes whose resolved file paths point at the same on-disk

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -21,6 +21,7 @@ import type {
   PathSeg,
   PermissionKind,
   Preferences,
+  Redundancy,
   RestorePreview,
   RestoreSidePreview,
   RuntimeInfo,
@@ -1122,6 +1123,16 @@ function combinedPanel(loaded: LoadedScopes, props: AppProps, lowerQuery: string
         const cBadge = kindConflictBadge(conflict);
         if (cBadge) chipWrap.appendChild(cBadge);
       }
+      // Redundancy badge (#17). The combined panel collapses by rule
+      // string, so the badge surfaces when ANY per-scope occurrence of
+      // this rule under this kind is flagged. Match on rule + kind
+      // since we don't know which per-scope index the chip "is" —
+      // there can be multiple contributors.
+      const redundancyForChip = loaded.redundancies.find(
+        (r) => r.redundant.rule === rule && r.redundant.kind === kind,
+      );
+      const rBadge = redundancyBadge(redundancyForChip ?? null);
+      if (rBadge) chipWrap.appendChild(rBadge);
       attachContextMenu(chipWrap, () =>
         combinedChipContextMenuItems(rule, allOrigins[i] ?? [], props),
       );
@@ -1209,6 +1220,107 @@ function kindConflictBadge(conflict: KindConflict | null): HTMLElement | null {
   note.textContent =
     "Highest-precedence scope wins for the effective union, but Claude Code's runtime " +
     "resolution may apply additional rules.";
+  pop.appendChild(note);
+
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (openPinnedPopover === wrap) {
+      closePinnedPopover();
+    } else {
+      pinPopover(wrap);
+    }
+  });
+
+  wrap.appendChild(btn);
+  wrap.appendChild(pop);
+  return wrap;
+}
+
+/**
+ * Find the redundancy entry whose `redundant.{scope, kind, index}`
+ * matches a rule's position (#17). Returns null when the rule isn't
+ * flagged as redundant — the caller skips the badge entirely.
+ *
+ * Linear scan is fine: realistic settings have <100 rules total and
+ * usually far fewer redundancies; building a Map per render would buy
+ * nothing.
+ */
+function findRedundancy(
+  scope: Scope,
+  kind: PermissionKind,
+  index: number,
+  redundancies: Redundancy[],
+): Redundancy | null {
+  for (const r of redundancies) {
+    if (r.redundant.scope === scope && r.redundant.kind === kind && r.redundant.index === index) {
+      return r;
+    }
+  }
+  return null;
+}
+
+/**
+ * Warning badge for a rule that's been flagged as redundant (#17).
+ * Same shape as `lintBadge` / `kindConflictBadge`: a focusable ⚠ button
+ * paired with a popover. The popover names the rule that covers this
+ * one (with scope) and labels the redundancy as either an exact
+ * duplicate or a pattern subsumption so the user can decide whether to
+ * remove the chip.
+ *
+ * Recolored with the `muted-warn` palette — redundancies are
+ * informational ("this could be tidied up"), not the same severity as
+ * a kind disagreement or a structural shape error. Distinguishing the
+ * three palettes lets a rule with two badges (lint + redundancy, or
+ * conflict + redundancy) read as three separate cues.
+ */
+function redundancyBadge(redundancy: Redundancy | null): HTMLElement | null {
+  if (redundancy === null) return null;
+
+  const wrap = document.createElement("span");
+  wrap.className = "lint-warn-wrap redundancy-wrap";
+  const popoverId = `redundancy-popover-${++lintPopoverSeq}`;
+
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "lint-warn redundancy-warn";
+  btn.textContent = "⚠";
+  const label =
+    redundancy.kind === "duplicate"
+      ? "Duplicate rule — already present in another scope"
+      : "Redundant rule — covered by a broader rule";
+  btn.setAttribute("aria-label", label);
+  btn.setAttribute("aria-describedby", popoverId);
+
+  const pop = document.createElement("span");
+  pop.id = popoverId;
+  pop.className = "lint-warn-popover redundancy-popover";
+  pop.setAttribute("role", "tooltip");
+
+  const reasonLine = document.createElement("span");
+  reasonLine.className = "lint-warn-popover-reason";
+  reasonLine.textContent =
+    redundancy.kind === "duplicate"
+      ? "Exact duplicate of another rule:"
+      : "Already covered by a broader rule:";
+  pop.appendChild(reasonLine);
+
+  const covering = document.createElement("code");
+  covering.className = "redundancy-covering";
+  covering.textContent = redundancy.covered_by.rule;
+  pop.appendChild(covering);
+
+  const scopeLine = document.createElement("span");
+  scopeLine.className = "redundancy-scope";
+  scopeLine.textContent = ` in ${SCOPE_LABELS[redundancy.covered_by.scope]} (${
+    KIND_LABELS[redundancy.covered_by.kind]
+  })`;
+  pop.appendChild(scopeLine);
+
+  const note = document.createElement("span");
+  note.className = "lint-warn-popover-note";
+  note.textContent =
+    "Safe to remove — the covering rule grants/denies the same behavior. " +
+    "Right-click this chip to delete.";
   pop.appendChild(note);
 
   btn.addEventListener("click", (e) => {
@@ -2310,6 +2422,16 @@ function treeLeaf(
       const conflict = findKindConflict(rule, scope, permKind, props.scopes.kind_conflicts);
       const cBadge = kindConflictBadge(conflict);
       if (cBadge) row.appendChild(cBadge);
+      // Redundancy badge (#17). The rule's position in this kind's
+      // array is `path[2]` for a permission-rule leaf. Lookup keys on
+      // (scope, kind, index) so two chips with the same text but
+      // different indices each get their own badge (or none).
+      const rulePathIdx = typeof path[2] === "number" ? path[2] : -1;
+      if (rulePathIdx >= 0) {
+        const redundancy = findRedundancy(scope, permKind, rulePathIdx, props.scopes.redundancies);
+        const rBadge = redundancyBadge(redundancy);
+        if (rBadge) row.appendChild(rBadge);
+      }
     }
     if (props) {
       // Inline arrow buttons dropped in #152 — right-click context

--- a/test/fixtures/loadedScopes.ts
+++ b/test/fixtures/loadedScopes.ts
@@ -7,6 +7,7 @@ import type {
   PermissionRuleOrigins,
   PermissionRules,
   Preferences,
+  Redundancy,
   RuntimeInfo,
   Scope,
   ScopeView,
@@ -100,6 +101,7 @@ interface LoadedScopesOverrides {
   combined_origins?: Partial<PermissionRuleOrigins>;
   path_collisions?: PathCollision[];
   kind_conflicts?: KindConflict[];
+  redundancies?: Redundancy[];
 }
 
 /**
@@ -153,6 +155,7 @@ export function buildLoadedScopes(overrides: LoadedScopesOverrides = {}): Loaded
     combined_origins: { ...origins, ...(overrides.combined_origins ?? {}) },
     path_collisions: overrides.path_collisions ?? [],
     kind_conflicts: overrides.kind_conflicts ?? [],
+    redundancies: overrides.redundancies ?? [],
   };
 }
 

--- a/test/ui/renderApp.test.ts
+++ b/test/ui/renderApp.test.ts
@@ -247,6 +247,79 @@ describe("renderApp", () => {
     }
   });
 
+  it("renders a redundancy badge on the redundant rule's per-scope row (#17)", () => {
+    // The detector backend produces redundancy entries with
+    // (redundant, covered_by) pairs. The renderer keys per-scope
+    // badges on (scope, kind, index), so the badge lands on the
+    // narrower-rule chip at its exact slot.
+    const scopes = buildLoadedScopes({
+      project_dir: "/fake/project-redundancy-perscope",
+      scopes: [
+        { scope: "user", permissions: { allow: ["Bash(git *)"] } },
+        { scope: "project", permissions: { allow: ["Bash(git status)"] } },
+      ],
+      redundancies: [
+        {
+          redundant: { rule: "Bash(git status)", scope: "project", kind: "allow", index: 0 },
+          covered_by: { rule: "Bash(git *)", scope: "user", kind: "allow", index: 0 },
+          kind: "subsumed",
+        },
+      ],
+    });
+    renderApp(root, makeProps({ scopes }));
+    const projectRule = Array.from(root.querySelectorAll(".rule")).find((r) =>
+      r.textContent?.includes("Bash(git status)"),
+    );
+    expect(projectRule).toBeDefined();
+    expect(projectRule!.querySelector(".redundancy-wrap")).not.toBeNull();
+    const pop = projectRule!.querySelector(".redundancy-popover");
+    expect(pop?.textContent).toContain("Already covered by a broader rule");
+    expect(pop?.textContent).toContain("Bash(git *)");
+    expect(pop?.textContent).toContain("User");
+    // The covering rule's own row should NOT carry a badge.
+    const userRule = Array.from(root.querySelectorAll(".rule")).find((r) =>
+      r.textContent?.includes("Bash(git *)"),
+    );
+    expect(userRule?.querySelector(".redundancy-wrap")).toBeNull();
+  });
+
+  it("labels exact duplicates differently in the redundancy popover (#17)", () => {
+    // Duplicate kind gets "Exact duplicate of another rule"; subsumed
+    // gets "Already covered by a broader rule." Pin the wording so a
+    // refactor doesn't silently change the user-facing strings.
+    const scopes = buildLoadedScopes({
+      project_dir: "/fake/project-redundancy-duplicate",
+      scopes: [
+        { scope: "user", permissions: { allow: ["Bash(rm)"] } },
+        { scope: "project", permissions: { allow: ["Bash(rm)"] } },
+      ],
+      redundancies: [
+        {
+          redundant: { rule: "Bash(rm)", scope: "project", kind: "allow", index: 0 },
+          covered_by: { rule: "Bash(rm)", scope: "user", kind: "allow", index: 0 },
+          kind: "duplicate",
+        },
+      ],
+    });
+    renderApp(root, makeProps({ scopes }));
+    const flagged = Array.from(root.querySelectorAll(".rule")).find((r) =>
+      r.querySelector(".redundancy-wrap"),
+    );
+    expect(flagged).toBeDefined();
+    const pop = flagged!.querySelector(".redundancy-popover");
+    expect(pop?.textContent).toContain("Exact duplicate of another rule");
+  });
+
+  it("does not render the redundancy badge when no redundancies are present (#17)", () => {
+    const scopes = buildLoadedScopes({
+      project_dir: "/fake/project-redundancy-none",
+      scopes: [{ scope: "project", permissions: { allow: ["Bash(git status)"] } }],
+      redundancies: [],
+    });
+    renderApp(root, makeProps({ scopes }));
+    expect(root.querySelector(".redundancy-wrap")).toBeNull();
+  });
+
   it("defaults the combined panel to collapsed via preferences (#155)", () => {
     // Default `combined_panel_collapsed: true` from buildPreferences
     // mirrors the Rust default — the panel renders closed on first


### PR DESCRIPTION
## Summary

New \`redundancy\` module detects two patterns of cruft in permission rules and surfaces them via a gray ⚠ badge with explanatory popover. Rounds out the warning-surface trio (lint shape / kind conflict / redundancy) — same UI shell, three palettes.

### Detected shapes

- **Exact duplicates** — same rule string in two slots (within one file, or across scopes), same kind.
- **Pattern subsumption** — a narrower rule fully covered by a broader one of the same kind:
  - \`Bash(git status)\` ⊂ \`Bash(git *)\`
  - \`Bash(*)\` and bare \`Bash\` cover any \`Bash(...)\`
  - \`WebFetch(domain:*.github.com)\` covers any subdomain
  - \`mcp__server__*\` covers any tool on that server

### Conservative by design

The detector reports only the cases it can decide with certainty by string matching. Anything fancier (nested globs, path globs with intermediate wildcards, unparseable inputs) returns \`None\`. False negatives are fine; false positives erase user intent.

Cross-kind shadowing (allow vs deny) is intentionally out of scope — that's the kind-conflict warning (#156). The user might want a carve-out, so auto-flagging would obscure intent.

### UI

- ⚠ badge on every per-scope rule row whose \`(scope, kind, index)\` matches a redundancy.
- Combined panel chip badges any rule with at least one redundant per-scope occurrence (panel collapses by rule string, so the match keys on \`(rule, kind)\` rather than slot).
- Popover labels duplicate vs subsumed with different wording, names the covering rule + scope, and points at right-click → Delete.
- Recolored \`--muted\` so a chip with two badges (lint + redundancy, or conflict + redundancy) reads as three visually distinct cues.

A dedicated "Redundancies" panel with bulk-remove is a follow-up — keeping this PR to the detect + flag surface; removal goes through the existing right-click → Delete path.

## Test plan

- [x] 303 Rust lib tests (was 280 — +23 detector tests covering identity, universal, bare-tool, glob-suffix, WebFetch domain wildcards, MCP server wildcards, and the cross-scope / multi-coverer / no-redundancy / three-copies cases)
- [x] 27 binary, 21 CLI integration tests
- [x] 143 JS unit tests (was 140 — +3 for badge rendering + wording + empty)
- [x] \`just check\` clean
- [x] SMOKE_TEST.md: new bullet for the badge + popover + delete flow
- [ ] CI confirms

## Reviewer notes

- The detector picks the BROADEST coverer when multiple rules cover the same candidate (\`Bash(*)\` over \`Bash(git *)\` when both could flag \`Bash(git status)\`). Breadth ranking is heuristic but stable enough that tests can pin specific picks.
- Exact-duplicate pairs emit ONE redundancy (later-scanned copy is the redundant one) — not two cross-referencing chips, which would read as circular.
- The \`Redundancy\` struct carries enough context to dispatch \`apply_delete_leaf\` directly, so a future "Remove redundant" panel can be a thin wrapper over the existing delete pipeline.

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)